### PR TITLE
Update ExprTernary.java

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprTernary.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprTernary.java
@@ -42,19 +42,14 @@ public class ExprTernary implements Expression<Object> {
     @Override
     public Object[] getValues(TriggerContext ctx) {
         Boolean check = valueToCheck.getSingle(ctx);
-        Object first = firstValue.getSingle(ctx);
-        Object second = secondValue.getSingle(ctx);
+        Object[] first = firstValue.getValues(ctx);
+        Object[] second = secondValue.getValues(ctx);
         if (check == null)
             return new Object[0];
-        Object result = check ? first : second;
+        Object[] result = check ? first : second;
         if (result == null)
             return new Object[0];
-        return new Object[]{result};
-    }
-
-    @Override
-    public Class<?> getReturnType() {
-        return Object.class;
+        return result;
     }
 
     @Override


### PR DESCRIPTION
- Removed an unnecessary override.
- Used #getValues() instead of #getSingle() as the lather may produce wrong results when using multiple values (which is possible since the author used `objects`)