### PR TITLE
Adding ExprLength's property expression

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
@@ -30,7 +30,7 @@ public class ExprLength extends PropertyExpression<Number, String> {
 
     @Override
     public Function<String[], Number[]> getPropertyFunction() {
-        return strings -> new Number[] {strings[0].length()};
+        return strings -> strings.length == 0 ? new Number[0] : new Number[]{strings[0].length()};
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
@@ -3,6 +3,7 @@ package io.github.syst3ms.skriptparser.expressions;
 import io.github.syst3ms.skriptparser.Main;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.lang.base.PropertyExpression;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import org.jetbrains.annotations.Nullable;
 
@@ -15,7 +16,7 @@ import org.jetbrains.annotations.Nullable;
  * @since ALPHA
  * @author Romitou
  */
-public class ExprLength implements Expression<Number> {
+public class ExprLength extends PropertyExpression<Number, String> {
 
     private Expression<String> strValue;
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @name Length
  * @pattern length of %string%
+ * @pattern %string%'s length
  * @since ALPHA
  * @author Romitou
  */

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
@@ -1,0 +1,50 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Length of a string.
+ *
+ * @name Length
+ * @pattern length of %string%
+ * @since ALPHA
+ * @author Romitou
+ */
+public class ExprLength implements Expression<Number> {
+
+    private Expression<String> strValue;
+
+    static {
+        Main.getMainRegistration().addPropertyExpression(
+                ExprLength.class,
+                Number.class,
+                true,
+                "string",
+                "length"
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        strValue = (Expression<String>) expressions[0];
+        return true;
+    }
+
+    @Override
+    public Number[] getValues(TriggerContext ctx) {
+        String str = strValue.getSingle(ctx);
+        if (str == null) return new Number[]{0};
+        return new Number[]{str.length()};
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return "length of " + strValue.toString(ctx, debug);
+    }
+
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
@@ -1,11 +1,11 @@
 package io.github.syst3ms.skriptparser.expressions;
 
 import io.github.syst3ms.skriptparser.Main;
-import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.lang.base.PropertyExpression;
-import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Function;
 
 /**
  * Length of a string.
@@ -18,8 +18,6 @@ import org.jetbrains.annotations.Nullable;
  */
 public class ExprLength extends PropertyExpression<Number, String> {
 
-    private Expression<String> strValue;
-
     static {
         Main.getMainRegistration().addPropertyExpression(
                 ExprLength.class,
@@ -30,23 +28,13 @@ public class ExprLength extends PropertyExpression<Number, String> {
         );
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
-        strValue = (Expression<String>) expressions[0];
-        return true;
-    }
-
-    @Override
-    public Number[] getValues(TriggerContext ctx) {
-        String str = strValue.getSingle(ctx);
-        if (str == null) return new Number[]{0};
-        return new Number[]{str.length()};
+    public Function<String[], Number[]> getPropertyFunction() {
+        return strings -> new Number[] {strings[0].length()};
     }
 
     @Override
     public String toString(@Nullable TriggerContext ctx, boolean debug) {
-        return "length of " + strValue.toString(ctx, debug);
+        return "length of " + getOwner().toString(ctx, debug);
     }
-
 }


### PR DESCRIPTION
This Pull Request adds the expression property of the length of a string.
Example of script:
```applescript
on script load:
	set {_length} to "Hello."'s length
	print "%{_length}%" # Output: 6
```

If the `strValue.getSingle(ctx)` is null, I'd rather return 0 instead of empty array causing error.
I almost forgot, thanks to Olyno for his help!