### PR TITLE
[enhancement] Change java io to java nio

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/Main.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/Main.java
@@ -77,8 +77,6 @@ public class Main {
                     .getCodeSource()
                     .getLocation()
                     .toURI()
-                    .getPath()
-                    .substring(1) // Remove first char due to Windows path
                 );
                 Path addonFolderPath = Paths.get(parserPath.getParent().toString(), "addons");
                 if (Files.isDirectory(addonFolderPath)) {

--- a/src/main/java/io/github/syst3ms/skriptparser/Main.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/Main.java
@@ -85,13 +85,13 @@ public class Main {
                     Files.walk(addonFolderPath)
                         .filter(Files::isRegularFile)
                         .filter((filePath) -> filePath.toString().endsWith(".jar"))
-                        .forEach((Path filePath) -> {
+                        .forEach((Path addonPath) -> {
                             try {
                                 URLClassLoader child = new URLClassLoader(
-                                    new URL[]{filePath.toUri().toURL()},
+                                    new URL[]{addonPath.toUri().toURL()},
                                     Main.class.getClassLoader()
                                 );
-                                JarFile jar = new JarFile(filePath.toString());
+                                JarFile jar = new JarFile(addonPath.toString());
                                 Manifest manifest = jar.getManifest();
                                 String main = manifest.getMainAttributes().getValue("Main-Class");
                                 if (main != null) {

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/ScriptLoader.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/ScriptLoader.java
@@ -18,8 +18,8 @@ import io.github.syst3ms.skriptparser.registration.SkriptAddon;
 import io.github.syst3ms.skriptparser.util.FileUtils;
 import io.github.syst3ms.skriptparser.util.MultiMap;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -35,14 +35,14 @@ public class ScriptLoader {
      * @param script the script file to load
      * @param debug
      */
-    public static List<LogEntry> loadScript(File script, boolean debug) {
+    public static List<LogEntry> loadScript(Path scriptPath, boolean debug) {
         FileParser parser = new FileParser();
         SkriptLogger logger = new SkriptLogger(debug);
         List<FileElement> elements;
         String scriptName;
         try {
-            List<String> lines = FileUtils.readAllLines(script);
-            scriptName = script.getName().replaceAll("(.+)\\..+", "$1");
+            List<String> lines = FileUtils.readAllLines(scriptPath);
+            scriptName = scriptPath.getFileName().toString().replaceAll("(.+)\\..+", "$1");
             elements = parser.parseFileLines(scriptName,
                     lines,
                     0,
@@ -54,7 +54,7 @@ public class ScriptLoader {
             e.printStackTrace();
             return Collections.emptyList();
         }
-        logger.setFileInfo(script.getName(), elements);
+        logger.setFileInfo(scriptPath.getFileName().toString(), elements);
         List<UnloadedTrigger> unloadedTriggers = new ArrayList<>();
         for (FileElement element : elements) {
             logger.logOutput();

--- a/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
@@ -3,6 +3,8 @@ package io.github.syst3ms.skriptparser.util;
 import java.io.*;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -39,13 +41,10 @@ public class FileUtils {
      * @return the lines of the file
      * @throws IOException if the file can't be read
      */
-    public static List<String> readAllLines(File file) throws IOException {
+    public static List<String> readAllLines(Path filePath) throws IOException {
         List<String> lines = new ArrayList<>();
-        InputStreamReader in = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
-        BufferedReader reader = new BufferedReader(in);
-        String line;
         StringBuilder multilineBuilder = new StringBuilder();
-        while ((line = reader.readLine()) != null) {
+        for (String line : Files.readAllLines(filePath, StandardCharsets.UTF_8)) {
             line = line.replaceAll("\\s*$", "");
             if (line.replace("\\" + MULTILINE_SYNTAX_TOKEN, "\0")
                     .endsWith(MULTILINE_SYNTAX_TOKEN)) {

--- a/src/test/java/io/github/syst3ms/skriptparser/file/FileParserTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/file/FileParserTest.java
@@ -105,8 +105,7 @@ public class FileParserTest {
 
     @Test
     public void readLines() throws Exception {
-        ClassLoader classLoader = getClass().getClassLoader();
-        Path filePath = Paths.get(classLoader.getResource("multiline.txt").getPath().substring(1));
+        Path filePath = Paths.get(ClassLoader.getSystemResource("multiline.txt").toURI());
         assertEquals(
             Arrays.asList(
                 "# Testing multiline syntax",

--- a/src/test/java/io/github/syst3ms/skriptparser/file/FileParserTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/file/FileParserTest.java
@@ -4,7 +4,8 @@ import io.github.syst3ms.skriptparser.log.SkriptLogger;
 import io.github.syst3ms.skriptparser.util.FileUtils;
 import org.junit.Test;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -105,7 +106,7 @@ public class FileParserTest {
     @Test
     public void readLines() throws Exception {
         ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource("multiline.txt").getFile());
+        Path filePath = Paths.get(classLoader.getResource("multiline.txt").getPath().substring(1));
         assertEquals(
             Arrays.asList(
                 "# Testing multiline syntax",
@@ -113,7 +114,7 @@ public class FileParserTest {
                 "section:",
                 "    with indent"
             ),
-            FileUtils.readAllLines(file)
+            FileUtils.readAllLines(filePath)
         );
     }
 }


### PR DESCRIPTION
This pull request includes:

 - A fix about paths: Paths would start from the folder where we were running skript-parser, but the paths should all start from skript-parser
 - A fix about addons (modules) which has not any ``Main-Class`` key in the manifest file
 - The transition from ``java.io`` to ``java.nio``: You can find a global explanation about ``java nio`` and its difference with ``java io`` [here](https://dzone.com/articles/java-nio-vs-io)