### PR TITLE
[Feature] Added Duration and Date types.

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
@@ -2,14 +2,12 @@ package io.github.syst3ms.skriptparser.registration;
 
 import io.github.syst3ms.skriptparser.Main;
 import io.github.syst3ms.skriptparser.types.changers.Arithmetic;
-import io.github.syst3ms.skriptparser.types.changers.ChangeMode;
-import io.github.syst3ms.skriptparser.types.changers.Changer;
 import io.github.syst3ms.skriptparser.types.comparisons.Comparator;
 import io.github.syst3ms.skriptparser.types.comparisons.Comparators;
 import io.github.syst3ms.skriptparser.types.comparisons.Relation;
 import io.github.syst3ms.skriptparser.types.conversions.Converters;
 import io.github.syst3ms.skriptparser.types.ranges.Ranges;
-import io.github.syst3ms.skriptparser.util.Date;
+import io.github.syst3ms.skriptparser.util.SkriptDate;
 import io.github.syst3ms.skriptparser.util.TimeUtils;
 import io.github.syst3ms.skriptparser.util.math.BigDecimalMath;
 
@@ -264,21 +262,21 @@ public class DefaultRegistration {
                     }
                 })
                 .register();
-        registration.newType(Date.class, "date", "date@s")
-                .toStringFunction(Date::toString)
-                .arithmetic(new Arithmetic<Date, Duration>() {
+        registration.newType(SkriptDate.class, "date", "date@s")
+                .toStringFunction(SkriptDate::toString)
+                .arithmetic(new Arithmetic<SkriptDate, Duration>() {
                     @Override
-                    public Duration difference(Date first, Date second) {
+                    public Duration difference(SkriptDate first, SkriptDate second) {
                         return first.difference(second);
                     }
 
                     @Override
-                    public Date add(Date value, Duration difference) {
+                    public SkriptDate add(SkriptDate value, Duration difference) {
                         return value.plus(difference);
                     }
 
                     @Override
-                    public Date subtract(Date value, Duration difference) {
+                    public SkriptDate subtract(SkriptDate value, Duration difference) {
                         return value.minus(difference);
                     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
@@ -2,16 +2,21 @@ package io.github.syst3ms.skriptparser.registration;
 
 import io.github.syst3ms.skriptparser.Main;
 import io.github.syst3ms.skriptparser.types.changers.Arithmetic;
+import io.github.syst3ms.skriptparser.types.changers.ChangeMode;
+import io.github.syst3ms.skriptparser.types.changers.Changer;
 import io.github.syst3ms.skriptparser.types.comparisons.Comparator;
 import io.github.syst3ms.skriptparser.types.comparisons.Comparators;
 import io.github.syst3ms.skriptparser.types.comparisons.Relation;
 import io.github.syst3ms.skriptparser.types.conversions.Converters;
 import io.github.syst3ms.skriptparser.types.ranges.Ranges;
+import io.github.syst3ms.skriptparser.util.Date;
+import io.github.syst3ms.skriptparser.util.TimeUtils;
 import io.github.syst3ms.skriptparser.util.math.BigDecimalMath;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -234,6 +239,56 @@ public class DefaultRegistration {
                     })
                     .toStringFunction(String::valueOf)
                     .register();
+        registration.newType(Duration.class, "duration", "duration@s")
+                .literalParser(TimeUtils::parseDuration)
+                .toStringFunction(TimeUtils::toStringDuration)
+                .arithmetic(new Arithmetic<Duration, Duration>() {
+                    @Override
+                    public Duration difference(Duration first, Duration second) {
+                        return first.minus(second).abs();
+                    }
+
+                    @Override
+                    public Duration add(Duration value, Duration difference) {
+                        return value.plus(difference);
+                    }
+
+                    @Override
+                    public Duration subtract(Duration value, Duration difference) {
+                        return value.minus(difference);
+                    }
+
+                    @Override
+                    public Class<? extends Duration> getRelativeType() {
+                        return Duration.class;
+                    }
+                })
+                .register();
+        registration.newType(Date.class, "date", "date@s")
+                .toStringFunction(Date::toString)
+                .arithmetic(new Arithmetic<Date, Duration>() {
+                    @Override
+                    public Duration difference(Date first, Date second) {
+                        return first.difference(second);
+                    }
+
+                    @Override
+                    public Date add(Date value, Duration difference) {
+                        return value.plus(difference);
+                    }
+
+                    @Override
+                    public Date subtract(Date value, Duration difference) {
+                        return value.minus(difference);
+                    }
+
+                    @Override
+                    public Class<? extends Duration> getRelativeType() {
+                        return Duration.class;
+                    }
+                })
+                .register();
+
         Comparators.registerComparator(
                 Number.class,
                 Number.class,

--- a/src/main/java/io/github/syst3ms/skriptparser/util/Date.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/Date.java
@@ -1,0 +1,145 @@
+package io.github.syst3ms.skriptparser.util;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.text.SimpleDateFormat;
+import java.time.*;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * Represents a date.
+ * @author Njol
+ */
+public class Date implements Comparable<Date> {
+
+    // TODO make a config for this
+    public final static String DATE_FORMAT = "EEEE dd MMMM yyyy HH:mm:ss.SSS zzzXXX";
+    public final static String DATE_LOCALE = "US";
+
+    /**
+     * Timestamp. Should always be in computer time/UTC/GMT+0.
+     */
+    private long timestamp;
+
+    public Date() {
+        this(System.currentTimeMillis());
+    }
+
+    public Date(final long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Date(final long timestamp, final TimeZone zone) {
+        final long offset = zone.getOffset(timestamp);
+        this.timestamp = timestamp - offset;
+    }
+
+    /**
+     * Get a new {@link Date} with the current time
+     * @return new {@link Date} with the current time
+     */
+    public static Date now() {
+        return new Date(System.currentTimeMillis());
+    }
+
+    public Duration difference(final Date other) {
+        return Duration.ZERO.plusMillis(Math.abs(timestamp - other.getTimestamp()));
+    }
+
+    @Override
+    public int compareTo(final @Nullable Date other) {
+        final long d = other == null ? timestamp : timestamp - other.timestamp;
+        return d < 0 ? -1 : d > 0 ? 1 : 0;
+    }
+
+
+
+    @Nullable
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        SimpleDateFormat format = new SimpleDateFormat(
+                DATE_FORMAT,
+                new Locale(DATE_LOCALE));
+
+
+        String str = format.format(new java.util.Date(timestamp));
+        sb.append(str);
+        if (sb.toString().isEmpty()) return null;
+
+        return sb.toString();
+    }
+
+    /**
+     * Get the timestamp of this date.
+     * @return The timestamp in milliseconds
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Add a {@link Duration} to this date.
+     * @param span {@link Duration} to add
+     */
+    public void add(final Duration span) {
+        timestamp += span.toMillis();
+    }
+
+    /**
+     * Subtract a {@link Duration} from this date.
+     * @param span {@link Duration} to subtract
+     */
+    public void subtract(final Duration span) {
+        timestamp -= span.toMillis();
+    }
+
+    /**
+     * Get a new instance of this date with the added Duration.
+     * @param span {@link Duration} to add to this Date
+     * @return new {@link Date} with the added Duration
+     */
+    public Date plus(Duration span) {
+        return new Date(timestamp + span.toMillis());
+    }
+
+    /**
+     * Get a new instance of this date with the subtracted Duration.
+     * @param span {@link Duration} to subtract from this Date
+     * @return new {@link Date} with the subtracted Duration
+     */
+    public Date minus(Duration span) {
+        return new Date(timestamp - span.toMillis());
+    }
+
+    /**
+     * Get the {@link LocalDate} instance of this date.
+     * @return the {@link LocalDate} instance of this date
+     */
+    public LocalDateTime toLocalDateTime() {
+        Instant in = new java.util.Date(timestamp).toInstant();
+        return in.atOffset(ZoneOffset.systemDefault().getRules().getOffset(in)).toLocalDateTime();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (int) (timestamp ^ (timestamp >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof Date))
+            return false;
+        final Date other = (Date) obj;
+        return timestamp == other.timestamp;
+    }
+
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/SkriptDate.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/SkriptDate.java
@@ -11,45 +11,45 @@ import java.util.TimeZone;
  * Represents a date.
  * @author Njol
  */
-public class Date implements Comparable<Date> {
+public class SkriptDate implements Comparable<SkriptDate> {
 
     // TODO make a config for this
     public final static String DATE_FORMAT = "EEEE dd MMMM yyyy HH:mm:ss.SSS zzzXXX";
-    public final static String DATE_LOCALE = "US";
+    public final static Locale DATE_LOCALE = new Locale("US");
 
     /**
      * Timestamp. Should always be in computer time/UTC/GMT+0.
      */
     private long timestamp;
 
-    public Date() {
+    public SkriptDate() {
         this(System.currentTimeMillis());
     }
 
-    public Date(final long timestamp) {
+    public SkriptDate(long timestamp) {
         this.timestamp = timestamp;
     }
 
-    public Date(final long timestamp, final TimeZone zone) {
-        final long offset = zone.getOffset(timestamp);
+    public SkriptDate(long timestamp, TimeZone zone) {
+        long offset = zone.getOffset(timestamp);
         this.timestamp = timestamp - offset;
     }
 
     /**
-     * Get a new {@link Date} with the current time
-     * @return new {@link Date} with the current time
+     * Get a new {@link SkriptDate} with the current time
+     * @return new {@link SkriptDate} with the current time
      */
-    public static Date now() {
-        return new Date(System.currentTimeMillis());
+    public static SkriptDate now() {
+        return new SkriptDate(System.currentTimeMillis());
     }
 
-    public Duration difference(final Date other) {
+    public Duration difference(SkriptDate other) {
         return Duration.ZERO.plusMillis(Math.abs(timestamp - other.getTimestamp()));
     }
 
     @Override
-    public int compareTo(final @Nullable Date other) {
-        final long d = other == null ? timestamp : timestamp - other.timestamp;
+    public int compareTo(@Nullable SkriptDate other) {
+        long d = other == null ? timestamp : timestamp - other.timestamp;
         return d < 0 ? -1 : d > 0 ? 1 : 0;
     }
 
@@ -61,7 +61,7 @@ public class Date implements Comparable<Date> {
 
         SimpleDateFormat format = new SimpleDateFormat(
                 DATE_FORMAT,
-                new Locale(DATE_LOCALE));
+                DATE_LOCALE);
 
 
         String str = format.format(new java.util.Date(timestamp));
@@ -83,7 +83,7 @@ public class Date implements Comparable<Date> {
      * Add a {@link Duration} to this date.
      * @param span {@link Duration} to add
      */
-    public void add(final Duration span) {
+    public void add(Duration span) {
         timestamp += span.toMillis();
     }
 
@@ -91,26 +91,26 @@ public class Date implements Comparable<Date> {
      * Subtract a {@link Duration} from this date.
      * @param span {@link Duration} to subtract
      */
-    public void subtract(final Duration span) {
+    public void subtract(Duration span) {
         timestamp -= span.toMillis();
     }
 
     /**
      * Get a new instance of this date with the added Duration.
      * @param span {@link Duration} to add to this Date
-     * @return new {@link Date} with the added Duration
+     * @return new {@link SkriptDate} with the added Duration
      */
-    public Date plus(Duration span) {
-        return new Date(timestamp + span.toMillis());
+    public SkriptDate plus(Duration span) {
+        return new SkriptDate(timestamp + span.toMillis());
     }
 
     /**
      * Get a new instance of this date with the subtracted Duration.
      * @param span {@link Duration} to subtract from this Date
-     * @return new {@link Date} with the subtracted Duration
+     * @return new {@link SkriptDate} with the subtracted Duration
      */
-    public Date minus(Duration span) {
-        return new Date(timestamp - span.toMillis());
+    public SkriptDate minus(Duration span) {
+        return new SkriptDate(timestamp - span.toMillis());
     }
 
     /**
@@ -124,21 +124,21 @@ public class Date implements Comparable<Date> {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
+        int prime = 31;
         int result = 1;
         result = prime * result + (int) (timestamp ^ (timestamp >>> 32));
         return result;
     }
 
     @Override
-    public boolean equals(final @Nullable Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj)
             return true;
         if (obj == null)
             return false;
-        if (!(obj instanceof Date))
+        if (!(obj instanceof SkriptDate))
             return false;
-        final Date other = (Date) obj;
+        SkriptDate other = (SkriptDate) obj;
         return timestamp == other.timestamp;
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/util/TimeUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/TimeUtils.java
@@ -1,0 +1,158 @@
+package io.github.syst3ms.skriptparser.util;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.Arrays;
+
+public class TimeUtils {
+
+    @Nullable
+    public static Duration parseDuration(String str) {
+        // TODO parsing gets in trouble with lists
+        if (str.isEmpty())
+            return null;
+        Duration dur = Duration.ZERO;
+
+        // If there is a ', and' in the string, like '5 days, and 3 seconds',
+        // then we return null since we need to keep consistency with lists.
+        if (str.contains(", and")) return null;
+
+        // Removing all ',' except the last one.
+        boolean endsComma = str.endsWith(",");
+        str = str.replaceAll(",", "");
+        if (endsComma) str = str.concat(",");
+
+        String[] split = str.split("\\s+");
+
+        // Days, hours, minutes, seconds, milliseconds. This is to keep track that they come in the right order.
+        // Like '5 days and 3 minutes', not '3 seconds and 5 hours'.
+        boolean[] passed = {false, false, false, false, false};
+
+        // Checks how many 'and' occurrences we had. We can only use 'and' once, before our last part.
+        // This is, again, to keep consistency with lists.
+        int currentAnd = 0;
+
+        for (int i = 0; i < split.length; i++) {
+            String s = split[i];
+
+            if (s.equals("and")) {
+                currentAnd++;
+                if ((split.length > 2 && !split[split.length - 3].equals("and")) || currentAnd > 1)
+                    return null;
+                continue;
+            }
+
+            long amount;
+
+            try {
+                amount = Long.parseLong(s);
+                s = split[++i];
+            } catch (NumberFormatException | ArrayIndexOutOfBoundsException ex) {
+                return null;
+            }
+
+            if (s.matches("days?")) {
+                if (passed[0] || oneIsTrue(passed[1], passed[2], passed[3], passed[4]))
+                    return null; // Days was already used elsewhere and is used again.
+                dur = dur.plusDays(amount);
+                passed[0] = true;
+            }
+
+            else if (s.matches("hours?")) {
+                if (passed[1] || oneIsTrue(passed[2], passed[3], passed[4]))
+                    return null; // Hours was already used elsewhere and is used again.
+                dur = dur.plusHours(amount);
+                passed[1] = true;
+            }
+
+            else if (s.matches("minutes?")) {
+                if (passed[2] || oneIsTrue(passed[3], passed[4]))
+                    return null; // Minutes was already used elsewhere and is used again.
+                dur = dur.plusMinutes(amount);
+                passed[2] = true;
+            }
+
+            else if (s.matches("seconds?")) {
+                if (passed[3] || oneIsTrue(passed[4]))
+                    return null; // Seconds was already used elsewhere and is used again.
+                dur = dur.plusSeconds(amount);
+                passed[3] = true;
+            }
+
+            else if (s.matches("milliseconds?")) {
+                if (passed[4]) return null; // Millis was already used elsewhere and is used again.
+                dur = dur.plusMillis(amount);
+                passed[4] = true;
+            }
+
+            else {
+                return null;
+            }
+        }
+        return dur;
+    }
+
+    @Nullable
+    public static String toStringDuration(Duration dur) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+
+        long days = dur.toDays();
+        if (days > 0) {
+            sb.append(days)
+                    .append(" day")
+                    .append(days == 1 ? "" : "s");
+            dur = dur.minusDays(days);
+            first = false;
+        }
+
+        long hours = dur.toHours();
+        if (hours > 0) {
+            sb.append(first ? "" : ", ")
+                    .append(hours)
+                    .append(" hour")
+                    .append(hours == 1 ? "" : "s");
+            dur = dur.minusHours(hours);
+            first = false;
+        }
+
+        long mins = dur.toMinutes();
+        if (mins > 0) {
+            sb.append(first ? "" : ", ")
+                    .append(mins)
+                    .append(" minute")
+                    .append(mins == 1 ? "" : "s");
+            dur = dur.minusMinutes(mins);
+            first = false;
+        }
+
+        long secs = dur.getSeconds();
+        if (secs > 0) {
+            sb.append(first ? "" : ", ")
+                    .append(secs)
+                    .append(" second")
+                    .append(secs == 1 ? "" : "s");
+            dur = dur.minusSeconds(secs);
+            first = false;
+        }
+
+        long millis = dur.toMillis();
+        if (millis > 0)
+            sb.append(first ? "" : ", ").append(millis).append(" millisecond").append(millis == 1 ? "" : "s");
+
+        String str = sb.toString();
+        if (str.isEmpty()) return null;
+
+        // Replaces the last ',' with 'and'.
+        int i = sb.lastIndexOf(",");
+        if (i != -1) sb.replace(i, i + 1, " and");
+
+        return sb.toString();
+    }
+
+    private static boolean oneIsTrue(Boolean... booleans) {
+        return Arrays.stream(booleans).anyMatch(Boolean::booleanValue);
+    }
+
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/TimeUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/TimeUtils.java
@@ -16,7 +16,8 @@ public class TimeUtils {
 
         // If there is a ', and' in the string, like '5 days, and 3 seconds',
         // then we return null since we need to keep consistency with lists.
-        if (str.contains(", and")) return null;
+        if (str.contains(", and"))
+            return null;
 
         // Removing all ',' except the last one.
         boolean endsComma = str.endsWith(",");
@@ -57,36 +58,26 @@ public class TimeUtils {
                     return null; // Days was already used elsewhere and is used again.
                 dur = dur.plusDays(amount);
                 passed[0] = true;
-            }
-
-            else if (s.matches("hours?")) {
+            } else if (s.matches("hours?")) {
                 if (passed[1] || oneIsTrue(passed[2], passed[3], passed[4]))
                     return null; // Hours was already used elsewhere and is used again.
                 dur = dur.plusHours(amount);
                 passed[1] = true;
-            }
-
-            else if (s.matches("minutes?")) {
+            } else if (s.matches("minutes?")) {
                 if (passed[2] || oneIsTrue(passed[3], passed[4]))
                     return null; // Minutes was already used elsewhere and is used again.
                 dur = dur.plusMinutes(amount);
                 passed[2] = true;
-            }
-
-            else if (s.matches("seconds?")) {
+            } else if (s.matches("seconds?")) {
                 if (passed[3] || oneIsTrue(passed[4]))
                     return null; // Seconds was already used elsewhere and is used again.
                 dur = dur.plusSeconds(amount);
                 passed[3] = true;
-            }
-
-            else if (s.matches("milliseconds?")) {
+            } else if (s.matches("milliseconds?")) {
                 if (passed[4]) return null; // Millis was already used elsewhere and is used again.
                 dur = dur.plusMillis(amount);
                 passed[4] = true;
-            }
-
-            else {
+            } else {
                 return null;
             }
         }
@@ -142,11 +133,13 @@ public class TimeUtils {
             sb.append(first ? "" : ", ").append(millis).append(" millisecond").append(millis == 1 ? "" : "s");
 
         String str = sb.toString();
-        if (str.isEmpty()) return null;
+        if (str.isEmpty())
+            return null;
 
         // Replaces the last ',' with 'and'.
         int i = sb.lastIndexOf(",");
-        if (i != -1) sb.replace(i, i + 1, " and");
+        if (i != -1)
+            sb.replace(i, i + 1, " and");
 
         return sb.toString();
     }


### PR DESCRIPTION
In this commit, I basically added the fundamentals for the Date and Duration types. I wanted to do this first before I start implementing them in Expressions.

- Added parsing and stringifying for Durations and dates
- Registered the new types and added Arithmetic function to both of them
- I used the Skript class for Date (with some minor adjustments) but I didn't use Timespan from Skript. I think the class is a bit unnecessary since the Java Duration class provides everything you need.

My major question is how I parse Duration. Currently, it follows the list syntax, so a few examples could be:
```
5 hours, 3 minutes and 2 seconds
5 days, 2 hours and 50 milliseconds

2 hours, 5 days # Error: wrong order
2 hours and 3 minutes and 1 second # Error: 2 times 'and'
```
It currently does not support the indefinite articles yet, I don't know if this should be added. Also, the parsing itself is probably unoptimised. I did some tests with this to check if it didn't interfere with lists, and it didn't as far as I know.