### PR TITLE
[Improvement/Fix] Added String expressions and fixed NPE.

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffPrint.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffPrint.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
  * Prints some text to the console
  *
  * @name Print
- * @pattern print %string% [to [the] console]
+ * @pattern print %strings% [to [the] console]
  * @since ALPHA
  * @author Syst3ms
  */
@@ -21,7 +21,7 @@ public class EffPrint extends Effect {
     static {
         Main.getMainRegistration().addEffect(
             EffPrint.class,
-            "print %string% [to [the] console]"
+            "print %strings% [to [the] console]"
         );
     }
 
@@ -33,11 +33,14 @@ public class EffPrint extends Effect {
     }
 
     @Override
-    public void execute(TriggerContext e) {
-        String str = string.getSingle(e);
-        if (str == null)
+    public void execute(TriggerContext ctx) {
+        String[] strs = string.getValues(ctx);
+        if (strs.length == 0)
             return;
-        System.out.println(str);
+
+        for (String str : strs) {
+            System.out.println(str);
+        }
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
@@ -1,0 +1,70 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * See if a given list of objects contain a given element.
+ * You can also check if a string contains another string.
+ *
+ * @name Contain
+ * @type CONDITION
+ * @pattern %string% [does(n't| not)] contains %string%
+ * @pattern %objects% [do[es](n't| not)] contain[s] %object%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class CondExprContains extends ConditionalExpression {
+
+    static {
+        Main.getMainRegistration().addExpression(
+                CondExprContains.class,
+                Boolean.class,
+                true,
+                "%string% [1:does(n't| not)] contains %string%",
+                "%objects% [1:do[es](n't| not)] contain[s] %object%"
+        );
+    }
+
+    private Expression<?> first;
+    private Expression<?> second;
+
+    private boolean onlyString;
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        first = expressions[0];
+        second = expressions[1];
+        onlyString = matchedPattern == 0;
+        setNegated(parseContext.getParseMark() == 1);
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected boolean check(TriggerContext ctx) {
+        if (onlyString) {
+            String f = ((Expression<String>) first).getSingle(ctx);
+            String s = ((Expression<String>) second).getSingle(ctx);
+            if (f == null || s == null) {
+                return false;
+            }
+            return isNegated() != f.contains(s);
+        } else {
+            Object[] f = ((Expression<Object>) first).getValues(ctx);
+            Object[] s = ((Expression<Object>) second).getValues(ctx);
+            return isNegated() != Arrays.asList(f).containsAll(Arrays.asList(s));
+        }
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return first.toString(ctx, debug) + (isNegated() ? " does not contain " : " contains ") + second.toString(ctx, debug);
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
@@ -27,7 +27,7 @@ public class CondExprContains extends ConditionalExpression {
                 CondExprContains.class,
                 Boolean.class,
                 true,
-                "%string% [1:does(n't| not)] contains %string%",
+                "%string% [1:does(n't| not)] contain[s] %string%",
                 "%objects% [1:do[es](n't| not)] contain[s] %object%"
         );
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
@@ -32,9 +32,7 @@ public class CondExprContains extends ConditionalExpression {
         );
     }
 
-    private Expression<?> first;
-    private Expression<?> second;
-
+    private Expression<?> first, second;
     private boolean onlyString;
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprStartsEnds.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprStartsEnds.java
@@ -1,0 +1,63 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Check if a given string starts or ends with a certain string.
+ *
+ * @name Starts/Ends With
+ * @type CONDITION
+ * @pattern %strings% (start|end)[s] with %string%
+ * @pattern %strings% do[es](n't| not) (start|end) with %string%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class CondExprStartsEnds extends ConditionalExpression {
+
+    static {
+        Main.getMainRegistration()
+                .addExpression(CondExprStartsEnds.class,
+                        Boolean.class,
+                        true,
+                        "%strings% (1:start|2:end)[s] with %string%",
+                        "%strings% do[es](n't| not) (1:start|2:end) with %string%");
+    }
+
+    private Expression<String> expr;
+    private Expression<String> value;
+    private boolean start;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        expr = (Expression<String>) expressions[0];
+        value = (Expression<String>) expressions[1];
+        start = parseContext.getParseMark() == 1;
+        setNegated(matchedPattern == 1);
+        return true;
+    }
+
+    @Override
+    protected boolean check(TriggerContext ctx) {
+        String[] strs = expr.getValues(ctx);
+        String v = value.getSingle(ctx);
+        if (v == null) return false;
+
+        for (String s : strs) {
+            if (isNegated() == (start ? s.startsWith(v) : s.endsWith(v))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return expr.toString(ctx, debug) + (isNegated() ? " does not" : "") + (start ? " start with " : " end with ") + value.toString(ctx, debug);
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprStartsEnds.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprStartsEnds.java
@@ -24,8 +24,8 @@ public class CondExprStartsEnds extends ConditionalExpression {
                 .addExpression(CondExprStartsEnds.class,
                         Boolean.class,
                         true,
-                        "%strings% (1:start|2:end)[s] with %string%",
-                        "%strings% do[es](n't| not) (1:start|2:end) with %string%");
+                        "%strings% (0:start|1:end)[s] with %string%",
+                        "%strings% do[es](n't| not) (0:start|1:end) with %string%");
     }
 
     private Expression<String> expr;
@@ -37,7 +37,7 @@ public class CondExprStartsEnds extends ConditionalExpression {
     public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
         expr = (Expression<String>) expressions[0];
         value = (Expression<String>) expressions[1];
-        start = parseContext.getParseMark() == 1;
+        start = parseContext.getParseMark() == 0;
         setNegated(matchedPattern == 1);
         return true;
     }
@@ -46,7 +46,8 @@ public class CondExprStartsEnds extends ConditionalExpression {
     protected boolean check(TriggerContext ctx) {
         String[] strs = expr.getValues(ctx);
         String v = value.getSingle(ctx);
-        if (v == null) return false;
+        if (v == null)
+            return false;
 
         for (String s : strs) {
             if (isNegated() == (start ? s.startsWith(v) : s.endsWith(v))) {

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringCases.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringCases.java
@@ -33,7 +33,7 @@ public class ExprStringCases implements Expression<String> {
 				"%strings% in upper[ ]case",
 				"%strings% in lower[ ]case",
 				"%strings% in camel[ ]case",
-				"%strings% in pascal case",
+				"%strings% in (pascal |capital[ized] camel[ ])case",
 				"%strings% in snake case",
 				"%strings% in kebab case",
 				"(reverse[d] %strings%|%strings% in reverse[d] case)",

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringCases.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringCases.java
@@ -1,0 +1,99 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.StringUtils;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Converts a given string into a certain case type.
+ * Click <a href="https://www.chaseadams.io/posts/most-common-programming-case-types/">here</a> to learn about all these cases.
+ *
+ * @name Cased String
+ * @type EXPRESSION
+ * @pattern %strings% in (upper|lower)[ ]case
+ * @pattern %strings% in camel[ ]case
+ * @pattern %strings% in pascal case
+ * @pattern %strings% in snake case
+ * @pattern %strings% in kebab case
+ * @pattern %strings% in reverse[d] case
+ * @pattern mirror[ed] %strings%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class ExprStringCases implements Expression<String> {
+
+	static {
+		Main.getMainRegistration().addExpression(
+				ExprStringCases.class,
+				String.class,
+				false,
+				"%strings% in upper[ ]case",
+				"%strings% in lower[ ]case",
+				"%strings% in camel[ ]case",
+				"%strings% in pascal case",
+				"%strings% in snake case",
+				"%strings% in kebab case",
+				"(reverse[d] %strings%|%strings% in reverse[d] case)",
+				"mirror[ed] %strings%");
+	}
+
+	private final static String[] CHOICES = {
+			"upper", "lower", "camel", "pascal", "snake", "kebab", "reverse", "mirrored"
+	};
+	private Expression<String> expr;
+	int pattern;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+		expr = (Expression<String>) expressions[0];
+		pattern = matchedPattern;
+		return true;
+	}
+
+	@Override
+	public String[] getValues(TriggerContext ctx) {
+		String[] strs = expr.getValues(ctx);
+		if (strs.length == 0)
+			return new String[0];
+
+		for (int i = 0; i < strs.length; i++) {
+			switch (pattern) {
+				case 0:
+					strs[i] = strs[i].toUpperCase();
+					break;
+				case 1:
+					strs[i] = strs[i].toLowerCase();
+					break;
+				case 2:
+					strs[i] = StringUtils.camelCase(strs[i], true);
+					break;
+				case 3:
+					strs[i] = StringUtils.camelCase(strs[i], false);
+					break;
+				case 4:
+					strs[i] = strs[i].toLowerCase().replaceAll(" ", "_");
+					break;
+				case 5:
+					strs[i] = strs[i].toLowerCase().replaceAll(" ", "-");
+					break;
+				case 6:
+					strs[i] = StringUtils.reverseCase(strs[i]);
+					break;
+				case 7:
+					strs[i] = StringUtils.mirrored(strs[i]);
+					break;
+			}
+		}
+		return strs;
+	}
+
+	@Override
+	public String toString(@Nullable TriggerContext ctx, boolean debug) {
+		return expr.toString(ctx, debug) + " in " + CHOICES[pattern] + " case";
+	}
+
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringOccurrence.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringOccurrence.java
@@ -22,18 +22,16 @@ public class ExprStringOccurrence implements Expression<Number> {
 				ExprStringOccurrence.class,
 				Number.class,
 				true,
-				"[the] (1:first|2:last) occurrence of %string% in %string%");
+				"[the] (0:first|1:last) occurrence of %string% in %string%");
 	}
 
-	private Expression<String> value;
-	private Expression<String> expr;
-
+	private Expression<String> value, expr;
 	private boolean first;
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
-		first = parseContext.getParseMark() == 1;
+		first = parseContext.getParseMark() == 0;
 		value = (Expression<String>) expressions[0];
 		expr = (Expression<String>) expressions[1];
 		return true;
@@ -42,7 +40,8 @@ public class ExprStringOccurrence implements Expression<Number> {
 	@Override
 	public Number[] getValues(TriggerContext ctx) {
 		String v = value.getSingle(ctx), e = expr.getSingle(ctx);
-		if (v == null || e == null) return new Number[0];
+		if (v == null || e == null)
+			return new Number[0];
 
 		int i = first ? e.indexOf(v) : e.lastIndexOf(v);
 		// Return i + 1, since Skript indices start at 1.

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringOccurrence.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringOccurrence.java
@@ -1,0 +1,56 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The index of the first or last occurrence of a given string in a string.
+ *
+ * @name Occurrence
+ * @type EXPRESSION
+ * @pattern [the] (first|last) occurrence of %string% in %string%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class ExprStringOccurrence implements Expression<Number> {
+
+	static {
+		Main.getMainRegistration().addExpression(
+				ExprStringOccurrence.class,
+				Number.class,
+				true,
+				"[the] (1:first|2:last) occurrence of %string% in %string%");
+	}
+
+	private Expression<String> value;
+	private Expression<String> expr;
+
+	private boolean first;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+		first = parseContext.getParseMark() == 1;
+		value = (Expression<String>) expressions[0];
+		expr = (Expression<String>) expressions[1];
+		return true;
+	}
+
+	@Override
+	public Number[] getValues(TriggerContext ctx) {
+		String v = value.getSingle(ctx), e = expr.getSingle(ctx);
+		if (v == null || e == null) return new Number[0];
+
+		int i = first ? e.indexOf(v) : e.lastIndexOf(v);
+		// Return i + 1, since Skript indices start at 1.
+		return i == -1 ? new Number[0] : new Number[] {i + 1};
+	}
+
+	@Override
+	public String toString(@Nullable TriggerContext ctx, boolean debug) {
+		return (first ? "first" : "last") + " occurrence of " + value.toString(ctx, debug) + " in " + expr.toString(ctx, debug);
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringSplitJoin.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringSplitJoin.java
@@ -18,9 +18,9 @@ import java.util.regex.Pattern;
  *
  * @name Join/Split
  * @type EXPRESSION
- * @pattern (concat[enate]|join) [(all|every)] %strings% [(with|using|by) [[the] delimiter] %string%]
+ * @pattern (concat[enate]|join) %strings% [(with|using|by) [[the] delimiter] %string%]
  * @pattern (split %string%|%string% split) (at|using|by) [[the] delimiter] %string%
- * @pattern (split %string%|%string% split) (with|using|by) %number% [char[acter][s]]
+ * @pattern (split %string%|%string% split) (with|using|by|every) %number% [char[acter][s]]
  * @since ALPHA
  * @author Mwexim
  */
@@ -31,9 +31,9 @@ public class ExprStringSplitJoin implements Expression<String> {
 				ExprStringSplitJoin.class,
 				String.class,
 				false,
-				"(concat[enate]|join) [(all|every)] %strings% [1:[(with|using|by) [[the] delimiter] %string%]]",
+				"(concat[enate]|join) %strings% [1:[(with|using|by) [[the] delimiter] %string%]]",
 				"(split %string%|%string% split) (at|using|by) [[the] delimiter] %string%",
-				"(split %string%|%string% split) (with|using|by) %number% [char[acter]][s]");
+				"(split %string%|%string% split) (with|using|by|every) %number% [char[acter]][s]");
 	}
 
 	private Expression<String> expr;

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringSplitJoin.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringSplitJoin.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
  *
  * @name Join/Split
  * @type EXPRESSION
- * @pattern (concat[enate]|join) %strings% [(with|using|by) [[the] delimiter] %string%]
+ * @pattern (concat[enate]|join) [(all|every)] %strings% [(with|using|by) [[the] delimiter] %string%]
  * @pattern (split %string%|%string% split) (at|using|by) [[the] delimiter] %string%
  * @pattern (split %string%|%string% split) (with|using|by) %number% [char[acter][s]]
  * @since ALPHA
@@ -31,7 +31,7 @@ public class ExprStringSplitJoin implements Expression<String> {
 				ExprStringSplitJoin.class,
 				String.class,
 				false,
-				"(concat[enate]|join) %strings% [1:[(with|using|by) [[the] delimiter] %string%]]",
+				"(concat[enate]|join) [(all|every)] %strings% [1:[(with|using|by) [[the] delimiter] %string%]]",
 				"(split %string%|%string% split) (at|using|by) [[the] delimiter] %string%",
 				"(split %string%|%string% split) (with|using|by) %number% [char[acter]][s]");
 	}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprUnaryMathFunctions.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprUnaryMathFunctions.java
@@ -37,6 +37,7 @@ import java.util.function.UnaryOperator;
  * @author Syst3ms
  */
 public class ExprUnaryMathFunctions implements Expression<Number> {
+
 	private static final PatternInfos<UnaryOperator<Number>> PATTERNS = new PatternInfos<>(
 		new Object[][]{
 			{"abs %number%|\\|%number%\\|", (UnaryOperator<Number>) NumberMath::abs},

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/ParserState.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/ParserState.java
@@ -68,7 +68,7 @@ public class ParserState {
      * Clears the previously enforced syntax restrictions
      */
     public void clearSyntaxRestrictions() {
-        allowedSyntaxes = null;
+        allowedSyntaxes = Collections.emptyList();
         restrictingExpressions = false;
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
@@ -326,6 +326,8 @@ public class StringUtils {
                 chars[i] = Character.toLowerCase(c);
             else if (Character.isLowerCase(c))
                 chars[i] = Character.toUpperCase(c);
+            else
+                chars[i] = c;
         }
         return new String(chars);
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
@@ -303,4 +303,43 @@ public class StringUtils {
                 return "a " + noun;
         }
     }
+
+    public static String camelCase(String str, boolean firstNoCase) {
+        String[] parts = str.split(" ");
+        StringBuilder ret = new StringBuilder();
+        for (String part : parts) {
+            if (firstNoCase) {
+                firstNoCase = false;
+                ret.append(part.toLowerCase());
+            } else {
+                ret.append(part.substring(0, 1).toUpperCase()).append(part.substring(1).toLowerCase());
+            }
+        }
+        return ret.toString();
+    }
+
+    public static String reverseCase(String str) {
+        char[] chars = str.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            char c = chars[i];
+            if (Character.isUpperCase(c))
+                chars[i] = Character.toLowerCase(c);
+            else if (Character.isLowerCase(c))
+                chars[i] = Character.toUpperCase(c);
+        }
+        return new String(chars);
+    }
+
+    public static String mirrored(String str) {
+        char[] chars = str.toCharArray();
+        char[] ret = new char[chars.length];
+        for (int i = 0; i < chars.length; i++) {
+            ret[i] = chars[chars.length - i - 1];
+        }
+        return new String(ret);
+    }
+
+    public static String capitalize(String str) {
+        return str.substring(0, 1).toUpperCase() + str.substring(1).toLowerCase();
+    }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
@@ -305,14 +305,15 @@ public class StringUtils {
     }
 
     public static String camelCase(String str, boolean firstNoCase) {
-        String[] parts = str.split(" ");
+        String[] parts = str.split("\\s+");
         StringBuilder ret = new StringBuilder();
         for (String part : parts) {
             if (firstNoCase) {
                 firstNoCase = false;
                 ret.append(part.toLowerCase());
             } else {
-                ret.append(part.substring(0, 1).toUpperCase()).append(part.substring(1).toLowerCase());
+                ret.append(Character.toUpperCase(part.charAt(0)))
+                        .append(part.substring(1).toLowerCase());
             }
         }
         return ret.toString();
@@ -342,6 +343,6 @@ public class StringUtils {
     }
 
     public static String capitalize(String str) {
-        return str.substring(0, 1).toUpperCase() + str.substring(1).toLowerCase();
+        return Character.toUpperCase(str.charAt(0)) + str.substring(1).toLowerCase();
     }
 }


### PR DESCRIPTION
This commit adds several expressions for strings and fixes an important NPE.

Added syntax:
- CondExprContains
- CondExprStartsEnds
- ExprStringCases
- ExprStringOccurence
- ExprStringSplitJoin

I added some methods to StringUtils as well, but I don't know if they fit there (probably not). If necessary, I'll just move them as private methods to the ExprStringCases class instead. That class is also a sort of 'experiment' since I added all these unofficial cases other than upper- and lowercase.

The NPE was some weird stuff in ParserState. I don't know if this fix can be used as an official one, but it fixed the NPE I was getting.