### PR TITLE
[Feature] EffWait, EvtPeriodical, Thread utils and small fixes

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/Main.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/Main.java
@@ -3,6 +3,7 @@ package io.github.syst3ms.skriptparser;
 import io.github.syst3ms.skriptparser.log.LogEntry;
 import io.github.syst3ms.skriptparser.parsing.ScriptLoader;
 import io.github.syst3ms.skriptparser.registration.DefaultRegistration;
+import io.github.syst3ms.skriptparser.registration.SkriptAddon;
 import io.github.syst3ms.skriptparser.registration.SkriptRegistration;
 import io.github.syst3ms.skriptparser.util.ConsoleColors;
 import io.github.syst3ms.skriptparser.util.FileUtils;
@@ -118,7 +119,6 @@ public class Main {
         if (!logs.isEmpty()) {
             System.out.print(ConsoleColors.RED.toString());
             System.out.println("Registration log :");
-            System.out.println("---");
         }
         printLogs(logs, time);
         System.out.print(ConsoleColors.RESET.toString());
@@ -130,10 +130,10 @@ public class Main {
         if (!logs.isEmpty()) {
             System.out.print(ConsoleColors.RED.toString());
             System.out.println("Parsing log :");
-            System.out.println("---");
         }
         printLogs(logs, time);
         System.out.print(ConsoleColors.RESET.toString());
+        SkriptAddon.getAddons().forEach(SkriptAddon::finishedLoading);
     }
 
     private static void printLogs(List<LogEntry> logs, Calendar time) {

--- a/src/main/java/io/github/syst3ms/skriptparser/Skript.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/Skript.java
@@ -35,10 +35,11 @@ public class Skript extends SkriptAddon {
         if (!canHandleEvent(event))
             return;
 
-        if (event instanceof EvtScriptLoad)
+        if (event instanceof EvtScriptLoad) {
             mainTriggers.add(trigger);
-        else if (event instanceof EvtPeriodical)
+        } else if (event instanceof EvtPeriodical) {
             periodicalTriggers.add(trigger);
+        }
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/Skript.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/Skript.java
@@ -1,12 +1,16 @@
 package io.github.syst3ms.skriptparser;
 
+import io.github.syst3ms.skriptparser.event.EvtPeriodical;
+import io.github.syst3ms.skriptparser.event.PeriodicalContext;
 import io.github.syst3ms.skriptparser.event.ScriptLoadContext;
 import io.github.syst3ms.skriptparser.event.EvtScriptLoad;
 import io.github.syst3ms.skriptparser.lang.SkriptEvent;
 import io.github.syst3ms.skriptparser.lang.Statement;
 import io.github.syst3ms.skriptparser.lang.Trigger;
 import io.github.syst3ms.skriptparser.registration.SkriptAddon;
+import io.github.syst3ms.skriptparser.util.ThreadUtils;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,8 +18,11 @@ import java.util.List;
  * The {@link SkriptAddon} representing Skript itself
  */
 public class Skript extends SkriptAddon {
+
     private final String[] mainArgs;
+
     private final List<Trigger> mainTriggers = new ArrayList<>();
+    private final List<Trigger> periodicalTriggers = new ArrayList<>();
 
     public Skript(String[] mainArgs) {
         this.mainArgs = mainArgs;
@@ -24,16 +31,26 @@ public class Skript extends SkriptAddon {
     @Override
     public void handleTrigger(Trigger trigger) {
         SkriptEvent event = trigger.getEvent();
+
         if (!canHandleEvent(event))
             return;
+
         if (event instanceof EvtScriptLoad)
             mainTriggers.add(trigger);
+        else if (event instanceof EvtPeriodical)
+            periodicalTriggers.add(trigger);
     }
 
     @Override
     public void finishedLoading() {
         for (Trigger trigger : mainTriggers) {
             Statement.runAll(trigger, new ScriptLoadContext(mainArgs));
+        }
+        for (Trigger trigger : periodicalTriggers) {
+            PeriodicalContext ctx = new PeriodicalContext();
+            Duration dur = ((EvtPeriodical) trigger.getEvent()).getDuration().getSingle(ctx);
+            assert dur != null;
+            ThreadUtils.runPeriodically(() -> Statement.runAll(trigger, ctx), dur);
         }
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
@@ -35,7 +35,9 @@ public class EffAsync extends Effect {
     @Override
     public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
         String expr = parseContext.getMatches().get(0).group();
+        parseContext.getLogger().recurse();
         effect = SyntaxParser.parseEffect(expr, parseContext.getParserState(), parseContext.getLogger());
+        parseContext.getLogger().callback();
         return effect != null;
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
@@ -1,0 +1,51 @@
+package io.github.syst3ms.skriptparser.effects;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.Effect;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.parsing.SyntaxParser;
+import io.github.syst3ms.skriptparser.util.ThreadUtils;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Runs this effect asynchronously.
+ * The difference between this and the section {@code async} is due to the fact that this effect will only run the specified action asunc,
+ * while the section runs all the effects under the statement async.
+ * If you only want to do one operation async, this is the effect you want to go with.
+ *
+ * @name Async
+ * @type EFFECT
+ * @pattern async[hronous[ly]] <.+>
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class EffAsync extends Effect {
+
+    static {
+        Main.getMainRegistration().addEffect(
+            EffAsync.class,
+            "async[hronous[ly]] [do] <.+>"
+        );
+    }
+
+    private Effect effect;
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        String expr = parseContext.getMatches().get(0).group();
+        effect = SyntaxParser.parseEffect(expr, parseContext.getParserState(), parseContext.getLogger());
+        return effect != null;
+    }
+
+    @Override
+    public void execute(TriggerContext ctx) {
+        ThreadUtils.runAsync(() -> effect.run(ctx));
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return "async " + effect.toString(ctx, debug);
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
@@ -1,0 +1,65 @@
+package io.github.syst3ms.skriptparser.effects;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.Effect;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.Statement;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.ThreadUtils;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+
+/**
+ * Waits a certain duration and then executes all the code after this effect.
+ * Note that new events may be triggered during the wait time.
+ *
+ * @name Wait
+ * @pattern (wait|halt) [for] %duration%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class EffWait extends Effect {
+
+    static {
+        Main.getMainRegistration().addEffect(
+            EffWait.class,
+            "(wait|halt) [for] %duration%"
+        );
+    }
+
+    private Expression<Duration> duration;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        duration = (Expression<Duration>) expressions[0];
+        return true;
+    }
+
+    @Override
+    protected void execute(TriggerContext ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Statement walk(TriggerContext ctx) {
+        Duration dur = duration.getSingle(ctx);
+        if (dur == null)
+            return getNext();
+        final Statement[] item = {getNext()};
+
+        ThreadUtils.runAfter(() -> {
+            while (!item[0].equals(item[0].getNext())) {
+                item[0] = item[0].walk(ctx);
+            }
+        }, dur);
+        return null;
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return "wait " + duration.toString(ctx, debug);
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
@@ -48,15 +48,10 @@ public class EffWait extends Effect {
         Duration dur = duration.getSingle(ctx);
         if (dur == null)
             return getNext();
-        final Statement[] item = {getNext()};
-        if (item[0] == null)
+        if (getNext() == null)
             return null;
 
-        ThreadUtils.runAfter(() -> {
-            while (!item[0].equals(item[0].getNext())) {
-                item[0] = item[0].walk(ctx);
-            }
-        }, dur);
+        ThreadUtils.runAfter(() -> Statement.runAll(getNext(), ctx), dur);
         return null;
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
@@ -49,6 +49,8 @@ public class EffWait extends Effect {
         if (dur == null)
             return getNext();
         final Statement[] item = {getNext()};
+        if (item[0] == null)
+            return null;
 
         ThreadUtils.runAfter(() -> {
             while (!item[0].equals(item[0].getNext())) {

--- a/src/main/java/io/github/syst3ms/skriptparser/event/EvtPeriodical.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/event/EvtPeriodical.java
@@ -1,0 +1,55 @@
+package io.github.syst3ms.skriptparser.event;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.SkriptEvent;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+
+/**
+ * The periodical event.
+ * This will be triggered after each interval of a certain duration.
+ * Note that when the duration is very precise, like milliseconds, it may be executed a bit later.
+ * Large duration that go up to days are not recommended.
+ *
+ * @name Periodical
+ * @type EVENT
+ * @pattern every %duration%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class EvtPeriodical extends SkriptEvent {
+
+    static {
+        Main.getMainRegistration()
+                .newEvent(EvtPeriodical.class, "*every %duration%")
+                .setHandledContexts(PeriodicalContext.class)
+                .register();
+    }
+
+    private Expression<Duration> duration;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        duration = (Expression<Duration>) expressions[0];
+        return true;
+    }
+
+    @Override
+    public boolean check(TriggerContext ctx) {
+        return ctx instanceof PeriodicalContext && duration.getSingle(ctx) != null;
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return "every " + duration.toString(ctx, debug);
+    }
+
+    public Expression<Duration> getDuration() {
+        return duration;
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/event/PeriodicalContext.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/event/PeriodicalContext.java
@@ -1,0 +1,15 @@
+package io.github.syst3ms.skriptparser.event;
+
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+
+/**
+ * The script loading context, which corresponds to running code inside {@code public static void main(String[] args)}
+ * in Java.
+ */
+public class PeriodicalContext implements TriggerContext {
+
+    @Override
+    public String getName() {
+        return "periodical";
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/CodeSection.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/CodeSection.java
@@ -52,7 +52,7 @@ public abstract class CodeSection extends Statement {
     }
 
     @Override
-    protected abstract Statement walk(TriggerContext ctx);
+    public abstract Statement walk(TriggerContext ctx);
 
     /**
      * Sets the items inside this lists, and also modifies other fields, reflected through the outputs of {@link #getFirst()},

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Conditional.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Conditional.java
@@ -38,7 +38,7 @@ public class Conditional extends CodeSection {
     }
 
     @Override
-    protected Statement walk(TriggerContext ctx) {
+    public Statement walk(TriggerContext ctx) {
         assert condition != null || mode == ConditionalMode.ELSE;
         if (mode == ConditionalMode.ELSE) {
             return getFirst();

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Effect.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Effect.java
@@ -6,6 +6,7 @@ package io.github.syst3ms.skriptparser.lang;
  * @see Statement
  */
 public abstract class Effect extends Statement {
+
     protected abstract void execute(TriggerContext ctx);
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Statement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Statement.java
@@ -90,7 +90,7 @@ public abstract class Statement implements SyntaxElement {
      * @param ctx the event
      * @return the next item to be ran, or {@code null} if this is the last item to be executed
      */
-    protected Statement walk(TriggerContext ctx) {
+    public Statement walk(TriggerContext ctx) {
         boolean proceed = run(ctx);
         if (proceed) {
             return getNext();   

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Trigger.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Trigger.java
@@ -32,7 +32,7 @@ public class Trigger extends CodeSection {
     }
 
     @Override
-    protected Statement walk(TriggerContext ctx) {
+    public Statement walk(TriggerContext ctx) {
         return event.check(ctx) ? getFirst() : null;
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/ScriptLoader.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/ScriptLoader.java
@@ -82,7 +82,6 @@ public class ScriptLoader {
             triggerMap.putOne(scriptName, loaded);
         }
         logger.logOutput();
-        SkriptAddon.getAddons().forEach(SkriptAddon::finishedLoading);
         return logger.close();
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/sections/SecAsync.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/sections/SecAsync.java
@@ -1,0 +1,62 @@
+package io.github.syst3ms.skriptparser.sections;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.file.FileSection;
+import io.github.syst3ms.skriptparser.lang.CodeSection;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.Statement;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.log.SkriptLogger;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.parsing.ParserState;
+import io.github.syst3ms.skriptparser.util.ThreadUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Executes the code in the section asynchronously, meaning in another thread.
+ * Note that the next code that isn't part of the section (intended the same amount of times) will be executed in the current thread again.
+ * Only the code that is inside the section will be executed from another thread.
+ * This may cause some delay. If you don't know what this is, you probably don't need it.
+ *
+ * @name Async
+ * @type SECTION
+ * @pattern async[hronous[ly]]
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class SecAsync extends CodeSection {
+
+    static {
+        Main.getMainRegistration().addSection(
+                SecAsync.class,
+                "async[hronous[ly]]"
+        );
+    }
+
+    @Override
+    public void loadSection(@NotNull FileSection section, @NotNull ParserState parserState, SkriptLogger logger) {
+        super.loadSection(section, parserState, logger);
+    }
+
+    @Override
+    public boolean init(Expression<?> @NotNull [] expressions, int matchedPattern, @NotNull ParseContext parseContext) {
+        return true;
+    }
+
+    @Override
+    public Statement walk(TriggerContext ctx) {
+        final Statement[] item = {getFirst()};
+
+        ThreadUtils.runAsync(() -> {
+            while (!item[0].equals(getNext()))
+                item[0] = item[0].walk(ctx);
+        });
+        return getNext();
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return "async";
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/sections/SecLoop.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/sections/SecLoop.java
@@ -47,7 +47,7 @@ public class SecLoop extends CodeSection {
 	}
 
 	@Override
-    protected Statement walk(TriggerContext ctx) {
+	public Statement walk(TriggerContext ctx) {
 		Iterator<?> iter = currentIter.get(ctx);
 		if (iter == null) {
 			iter = expr instanceof Variable ? ((Variable<?>) expr).variablesIterator(ctx) : expr.iterator(ctx);

--- a/src/main/java/io/github/syst3ms/skriptparser/sections/SecWhile.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/sections/SecWhile.java
@@ -40,7 +40,7 @@ public class SecWhile extends CodeSection {
     }
 
     @Override
-    protected Statement walk(TriggerContext ctx) {
+    public Statement walk(TriggerContext ctx) {
         Boolean cond = condition.getSingle(ctx);
         if (cond == null || !cond) {
             return actualNext;

--- a/src/main/java/io/github/syst3ms/skriptparser/util/ThreadUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/ThreadUtils.java
@@ -1,0 +1,38 @@
+package io.github.syst3ms.skriptparser.util;
+
+import java.time.Duration;
+import java.util.concurrent.*;
+
+public class ThreadUtils {
+
+	/**
+	 * Run certain code once on a separate thread
+	 * @param code the runnable that needs to be executed
+	 */
+	public static void runAsync(Runnable code) {
+		ExecutorService executor = Executors.newCachedThreadPool();
+		executor.submit(code);
+	}
+
+	/**
+	 * Run certain code once after a certain delay.
+	 * @param code the runnable that needs to be executed
+	 * @param duration the delay
+	 */
+	public static void runAfter(Runnable code, Duration duration) {
+		ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+		executor.schedule(code, duration.toMillis(), TimeUnit.MILLISECONDS);
+		executor.shutdown();
+	}
+
+	/**
+	 * Runs certain code periodically.
+	 * @param code the runnable that needs to be executed
+	 * @param duration the delay
+	 */
+	public static void runPeriodically(Runnable code, Duration duration) {
+		ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+		scheduler.scheduleAtFixedRate(code, duration.toMillis(), duration.toMillis(), TimeUnit.MILLISECONDS);
+	}
+
+}


### PR DESCRIPTION
This is the start into creating all sort of Thread-based things. Note that this pull request is a draft and will be changed a lot over time to optimise it to Skript's needs.

To start off, I added a simple EffWait effect to delay all the code after the statement.

Furthermore, the general thread tools were quickly scrambled together. I did 'as much' research as I could and found that the methods used are generally advised for these sorts of tasks. I don't know if I optimised them enough though:
- It currently creates a separate thread for each method called. This is because when one task gets an error, all other tasks would stop as well, essentially breaking every 'wait' effect and periodical event.
  - `runAsync()` will automatically execute itself after no activity for over 60 seconds, so don't worry about that.
  - `runAfter()` will execute itself as well

The periodical event works as it should and each event runs on another thread, to ensure better timing.

So please leave suggestions and sooner or later, we will be able to merge this.