### PR TITLE
[Feat./Impr.] Many new expressions and fixes

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
@@ -26,6 +26,7 @@ public class EffAsync extends Effect {
     static {
         Main.getMainRegistration().addEffect(
             EffAsync.class,
+            3,
             "async[hronous[ly]] [do] <.+>"
         );
     }
@@ -43,7 +44,7 @@ public class EffAsync extends Effect {
 
     @Override
     public void execute(TriggerContext ctx) {
-        ThreadUtils.runAsync(() -> effect.walk(ctx));
+        ThreadUtils.runAsync(() -> effect.run(ctx));
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
@@ -44,7 +44,7 @@ public class EffAsync extends Effect {
 
     @Override
     public void execute(TriggerContext ctx) {
-        ThreadUtils.runAsync(() -> effect.run(ctx));
+        ThreadUtils.runAsync(() -> effect.walk(ctx));
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffContinue.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffContinue.java
@@ -52,7 +52,7 @@ public class EffContinue extends Effect {
     }
 
     @Override
-    protected Statement walk(TriggerContext ctx) {
+    public Statement walk(TriggerContext ctx) {
         return loop.walk(ctx);
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffContinue.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffContinue.java
@@ -1,0 +1,63 @@
+package io.github.syst3ms.skriptparser.effects;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.*;
+import io.github.syst3ms.skriptparser.log.ErrorType;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.sections.SecLoop;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Skips the current looped value and continues to the next one in the list, if it exists.
+ *
+ * @name Continue
+ * @pattern continue
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class EffContinue extends Effect {
+
+    static {
+        Main.getMainRegistration().addEffect(
+            EffContinue.class,
+            "continue"
+        );
+    }
+
+    private SecLoop loop;
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        List<SecLoop> loops = new ArrayList<>();
+        for (CodeSection sec : parseContext.getParserState().getCurrentSections()) {
+            if (sec instanceof SecLoop) {
+                loops.add((SecLoop) sec);
+            }
+        }
+        loop = loops.get(loops.size() - 1);
+
+        if (loop == null) {
+            parseContext.getLogger().error("You can only continue in a loop!", ErrorType.SEMANTIC_ERROR);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void execute(TriggerContext ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Statement walk(TriggerContext ctx) {
+        return loop.walk(ctx);
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return "continue";
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffDoIf.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffDoIf.java
@@ -4,36 +4,36 @@ import io.github.syst3ms.skriptparser.Main;
 import io.github.syst3ms.skriptparser.lang.Effect;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.parsing.SyntaxParser;
 import io.github.syst3ms.skriptparser.util.ThreadUtils;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Runs this effect asynchronously.
- * The difference between this and the section {@code async} is due to the fact that this effect will only run the specified action asunc,
- * while the section runs all the effects under the statement async.
- * If you only want to do one operation async, this is the effect you want to go with.
+ * Runs this effect if a given condition succeeds.
  *
- * @name Async
+ * @name Do If
  * @type EFFECT
- * @pattern async[hronous[ly]] <.+>
+ * @pattern [do] <.+> [only] if %=boolean%
  * @since ALPHA
  * @author Mwexim
  */
-public class EffAsync extends Effect {
+public class EffDoIf extends Effect {
 
     static {
         Main.getMainRegistration().addEffect(
-            EffAsync.class,
-            "async[hronous[ly]] [do] <.+>"
+            EffDoIf.class,
+            "[do] <.+> [only] if %=boolean%"
         );
     }
 
+    ConditionalExpression condition;
     private Effect effect;
 
     @Override
     public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        condition = (ConditionalExpression) expressions[0];
         String expr = parseContext.getMatches().get(0).group();
         parseContext.getLogger().recurse();
         effect = SyntaxParser.parseEffect(expr, parseContext.getParserState(), parseContext.getLogger());
@@ -43,11 +43,12 @@ public class EffAsync extends Effect {
 
     @Override
     public void execute(TriggerContext ctx) {
-        ThreadUtils.runAsync(() -> effect.walk(ctx));
+        if (condition.check(ctx))
+            effect.walk(ctx);
     }
 
     @Override
     public String toString(@Nullable TriggerContext ctx, boolean debug) {
-        return "async " + effect.toString(ctx, debug);
+        return effect.toString(ctx, debug) + " if " + condition.toString(ctx, debug);
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffDoIf.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffDoIf.java
@@ -48,11 +48,11 @@ public class EffDoIf extends Effect {
     @Override
     public void execute(TriggerContext ctx) {
         if (condition.check(ctx))
-            effect.run(ctx);
+            effect.walk(ctx);
     }
 
     @Override
     public String toString(@Nullable TriggerContext ctx, boolean debug) {
-        return effect.toString(ctx, debug) + " if " + condition.toString(ctx, debug);
+        return "if " + condition.toString(ctx, debug) + ", " + effect.toString(ctx, debug);
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffDoIf.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffDoIf.java
@@ -5,9 +5,9 @@ import io.github.syst3ms.skriptparser.lang.Effect;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
+import io.github.syst3ms.skriptparser.log.ErrorType;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.parsing.SyntaxParser;
-import io.github.syst3ms.skriptparser.util.ThreadUtils;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @name Do If
  * @type EFFECT
- * @pattern [do] <.+> [only] if %=boolean%
+ * @pattern if %=boolean%[,] [do] <.+>
  * @since ALPHA
  * @author Mwexim
  */
@@ -24,7 +24,8 @@ public class EffDoIf extends Effect {
     static {
         Main.getMainRegistration().addEffect(
             EffDoIf.class,
-            "[do] <.+> [only] if %=boolean%"
+            1,
+            "if %=boolean%[,] [do] <.+>"
         );
     }
 
@@ -38,13 +39,16 @@ public class EffDoIf extends Effect {
         parseContext.getLogger().recurse();
         effect = SyntaxParser.parseEffect(expr, parseContext.getParserState(), parseContext.getLogger());
         parseContext.getLogger().callback();
+        if (effect instanceof EffDoIf) {
+            parseContext.getLogger().error("You can't nest multiple do-if effects!", ErrorType.SEMANTIC_ERROR);
+        }
         return effect != null;
     }
 
     @Override
     public void execute(TriggerContext ctx) {
         if (condition.check(ctx))
-            effect.walk(ctx);
+            effect.run(ctx);
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffExit.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffExit.java
@@ -1,0 +1,118 @@
+package io.github.syst3ms.skriptparser.effects;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.*;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.sections.SecLoop;
+import io.github.syst3ms.skriptparser.sections.SecWhile;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Exits the entire trigger, preventing all upcoming statements to not get triggered.
+ * There's also a possibility to only exit certain sections.
+ * Note that stopping loops also stops while-loops.
+ *
+ * @name Exit
+ * @pattern (exit|stop) [[the] [current] trigger]
+ * @pattern (exit|stop) [(a|the [current]|this)] (section|loop|condition[al])
+ * @pattern (exit|stop) %*integer% (section|loop|condition[al])[s]
+ * @pattern (exit|stop) (every|all) [the] (section|loop|condition[al])s
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class EffExit extends Effect {
+
+    static {
+        Main.getMainRegistration().addEffect(
+            EffExit.class,
+            "(exit|stop) [the] [trigger]",
+                "(exit|stop) [(a|the [current]|this)] (0:section|1:loop|2:condition[al])",
+                "(exit|stop) %*integer% (0:section|1:loop|2:condition[al])[s]",
+                "(exit|stop) (every|all) [the] (0:section|1:loop|2:condition[al])s"
+        );
+    }
+
+    private final static String[] names = {"section", "loop", "conditional"};
+    private final List<CodeSection> currentSections = new ArrayList<>();
+
+    private int pattern;
+    private int parseMark;
+    private Expression<Long> amount;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        currentSections.addAll(parseContext.getParserState().getCurrentSections());
+        pattern = matchedPattern;
+        parseMark = parseContext.getParseMark();
+        if (pattern == 2)
+                amount = (Expression<Long>) expressions[0];
+        return true;
+    }
+
+    @Override
+    protected void execute(TriggerContext ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Statement walk(TriggerContext ctx) {
+        switch (pattern) {
+            case 0:
+                return null;
+            case 1:
+                return escapeSections(1, this);
+            case 2:
+                Long l = amount.getSingle(ctx);
+                if (l == null)
+                    return null;
+
+                return escapeSections(l, this);
+            case 3:
+                // The current Trigger itself is also a part of the current sections!
+                return escapeSections(currentSections.size() - 1, this);
+        }
+        return null;
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        switch (pattern) {
+            case 1:
+                return "exit this " + names[parseMark];
+            case 2:
+                return "exit " + amount.toString(ctx, debug) + " " + names[parseMark] + "s";
+            case 3:
+                return "exit all " + names[parseMark] + "s";
+            case 0:
+            default:
+                return "exit";
+        }
+    }
+
+    @Nullable
+    private Statement escapeSections(long amount, Statement start) {
+        Statement temp;
+        while (amount > 0) {
+            temp = start;
+            start = start.getParent();
+            if (start == null)
+                return null;
+            // 0 = all, 1 = only loops, 2 = only conditionals
+            if (parseMark == 0
+                    || parseMark == 1 && (start instanceof SecLoop || start instanceof SecWhile)
+                    || parseMark == 2 && start instanceof Conditional) {
+                amount--;
+                continue;
+            }
+            return temp.getNext();
+        }
+        System.out.println(start.getNext());
+        return start instanceof SecLoop ? ((SecLoop) start).getActualNext()
+                : start instanceof SecWhile ? ((SecWhile) start).getActualNext()
+                : start.getNext();
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprCompare.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprCompare.java
@@ -67,11 +67,11 @@ public class CondExprCompare extends ConditionalExpression {
 
     @SuppressWarnings("null")
     @Override
-    public boolean init(Expression<?>[] vars, int matchedPattern, ParseContext result) {
-        first = vars[0];
-        second = vars[1];
-        if (vars.length == 3)
-            third = vars[2];
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext result) {
+        first = expressions[0];
+        second = expressions[1];
+        if (expressions.length == 3)
+            third = expressions[2];
         SkriptLogger logger = result.getLogger();
         relation = PATTERNS.getInfo(matchedPattern);
         if ((result.getParseMark() & 2) != 0) // "not" somewhere in the condition

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
@@ -46,7 +46,7 @@ public class CondExprContains extends ConditionalExpression {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected boolean check(TriggerContext ctx) {
+    public boolean check(TriggerContext ctx) {
         if (onlyString) {
             String f = ((Expression<String>) first).getSingle(ctx);
             String s = ((Expression<String>) second).getSingle(ctx);

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprDateCompare.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprDateCompare.java
@@ -44,7 +44,7 @@ public class CondExprDateCompare extends ConditionalExpression {
     }
 
     @Override
-    protected boolean check(TriggerContext ctx) {
+    public boolean check(TriggerContext ctx) {
         SkriptDate d = date.getSingle(ctx);
         Duration dur = duration.getSingle(ctx);
         if (d == null || dur == null)

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprIsSet.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprIsSet.java
@@ -37,7 +37,7 @@ public class CondExprIsSet extends ConditionalExpression {
     }
 
     @Override
-    protected boolean check(TriggerContext ctx) {
+    public boolean check(TriggerContext ctx) {
         return isNegated() == (expr == null || expr.getValues(ctx).length == 0);
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprStartsEnds.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprStartsEnds.java
@@ -43,7 +43,7 @@ public class CondExprStartsEnds extends ConditionalExpression {
     }
 
     @Override
-    protected boolean check(TriggerContext ctx) {
+    public boolean check(TriggerContext ctx) {
         String[] strs = expr.getValues(ctx);
         String v = value.getSingle(ctx);
         if (v == null)

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDifference.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDifference.java
@@ -1,0 +1,80 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.log.ErrorType;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.types.Type;
+import io.github.syst3ms.skriptparser.types.TypeManager;
+import io.github.syst3ms.skriptparser.types.changers.Arithmetic;
+import io.github.syst3ms.skriptparser.util.ClassUtils;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The difference between two values.
+ * Note that only values that can be checked for difference are allowed
+ * (this is for example numbers, dates, durations and others).
+ *
+ * @name Difference
+ * @pattern difference (between|of) %object% and %object%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class ExprDifference implements Expression<Object> {
+
+    static {
+        Main.getMainRegistration().addExpression(
+                ExprDifference.class,
+                Object.class,
+                true,
+                "difference (between|of) %object% and %object%"
+        );
+    }
+
+    Expression<?> first, second;
+    Arithmetic<Object, Object> math;
+    Class<?> commonSuperClass;
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        first = expressions[0];
+        second = expressions[1];
+        Type<?> type = TypeManager.getByClass(
+                ClassUtils.getCommonSuperclass(true, first.getReturnType(), second.getReturnType())
+        );
+        if (type == null) {
+            // Should never happen!
+            return false;
+        }
+        math = (Arithmetic<Object, Object>) type.getArithmetic();
+        commonSuperClass = type.getTypeClass();
+        if (math == null) {
+            parseContext.getLogger().recurse();
+            parseContext.getLogger().error("Can't compare these two values.", ErrorType.SEMANTIC_ERROR);
+            parseContext.getLogger().callback();
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public Class<?> getReturnType() {
+        return commonSuperClass;
+    }
+
+    @Override
+    public Object[] getValues(TriggerContext ctx) {
+        Object f = first.getSingle(ctx);
+        Object s = second.getSingle(ctx);
+        if (f == null || s == null)
+            return new Object[0];
+
+        return new Object[] {math.difference(f, s)};
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return "difference between " + first.toString(ctx, debug) + " and " + second.toString(ctx, debug);
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDifference.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDifference.java
@@ -41,18 +41,16 @@ public class ExprDifference implements Expression<Object> {
         first = expressions[0];
         second = expressions[1];
         Type<?> type = TypeManager.getByClass(
-                ClassUtils.getCommonSuperclass(true, first.getReturnType(), second.getReturnType())
+                ClassUtils.getCommonSuperclass(first.getReturnType(), second.getReturnType())
         );
         if (type == null) {
-            // Should never happen!
-            return false;
+            type = TypeManager.getByClassExact(Object.class);
+            assert type != null;
         }
         math = (Arithmetic<Object, Object>) type.getArithmetic();
         commonSuperClass = type.getTypeClass();
         if (math == null) {
-            parseContext.getLogger().recurse();
-            parseContext.getLogger().error("Can't compare these two values.", ErrorType.SEMANTIC_ERROR);
-            parseContext.getLogger().callback();
+            parseContext.getLogger().error("Can't compare these two values", ErrorType.SEMANTIC_ERROR);
             return false;
         }
         return true;

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprElement.java
@@ -4,11 +4,12 @@ import io.github.syst3ms.skriptparser.Main;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.math.NumberMath;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * A certain element or multiple elements out of a list of objects.
@@ -33,6 +34,8 @@ public class ExprElement implements Expression<Object> {
 				"[the] (0:first|1:last) %*integer% elements out [of] %objects%",
 				"%objects%\\[%*integer%\\]");
 	}
+
+	private static final ThreadLocalRandom random = ThreadLocalRandom.current();
 
 	private Expression<Object> expr;
 	private Expression<Long> range;
@@ -100,7 +103,7 @@ public class ExprElement implements Expression<Object> {
 					case 1:
 						return new Object[] {values[values.length - 1]};
 					case 2:
-						return new Object[] {values[new Random().nextInt(values.length)]};
+						return new Object[] {values[NumberMath.random(0, values.length, true, random).intValue()]};
 					case 3:
 						return new Object[] {values[index - 1]};
 					default:

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprElement.java
@@ -67,6 +67,11 @@ public class ExprElement implements Expression<Object> {
 	}
 
 	@Override
+	public boolean isSingle() {
+		return pattern != 0;
+	}
+
+	@Override
 	public Object[] getValues(TriggerContext ctx) {
 		Object[] values = expr.getValues(ctx);
 		if (values.length == 0)

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprElement.java
@@ -1,0 +1,130 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * A certain element or multiple elements out of a list of objects.
+ * Remember that in Skript, indices start from 1.
+ *
+ * @name Element
+ * @type EXPRESSION
+ * @pattern ([the] first|[the] last|[a] random|[the] %*integer%(st|nd|rd|th)) element out [of] %objects%
+ * @pattern [the] (first|last) %*integer% elements out [of] %objects%
+ * @pattern %objects%\[%*integer%\]
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class ExprElement implements Expression<Object> {
+
+	static {
+		Main.getMainRegistration().addExpression(
+				ExprElement.class,
+				Object.class,
+				false,
+				"(0:[the] first|1:[the] last|2:[a] random|3:[the] %*integer%(st|nd|rd|th)) element out [of] %objects%",
+				"[the] (0:first|1:last) %*integer% elements out [of] %objects%",
+				"%objects%\\[%*integer%\\]");
+	}
+
+	private Expression<Object> expr;
+	private Expression<Long> range;
+	private int pattern;
+	private int parseMark;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+		pattern = matchedPattern;
+		parseMark = parseContext.getParseMark();
+
+		switch (pattern) {
+			case 0:
+				if (parseMark == 3) {
+					range = (Expression<Long>) expressions[0];
+					expr = (Expression<Object>) expressions[1];
+				} else {
+					expr = (Expression<Object>) expressions[0];
+				}
+				break;
+			case 1:
+				range = (Expression<Long>) expressions[0];
+				expr = (Expression<Object>) expressions[1];
+				break;
+			default:
+				expr = (Expression<Object>) expressions[0];
+				range = (Expression<Long>) expressions[1];
+				break;
+		}
+		return true;
+	}
+
+	@Override
+	public Object[] getValues(TriggerContext ctx) {
+		Object[] values = expr.getValues(ctx);
+		if (values.length == 0)
+			return new Object[0];
+		int index = 0;
+
+		if (range != null) {
+			Long r = range.getSingle(ctx);
+			if (r == null)
+				return new Object[0];
+			index = r.intValue();
+			if (index > values.length && pattern == 1) {
+				return values;
+			} else if (index > values.length) {
+				return new Object[0];
+			} else if (index <= 0) {
+				return new Object[0];
+			}
+		}
+
+		switch (pattern) {
+			case 0:
+				switch (parseMark) {
+					case 0:
+						return new Object[] {values[0]};
+					case 1:
+						return new Object[] {values[values.length - 1]};
+					case 2:
+						return new Object[] {values[new Random().nextInt(values.length)]};
+					case 3:
+						return new Object[] {values[index - 1]};
+					default:
+						return new Object[0];
+				}
+			case 1:
+				List<Object> selection = Arrays.asList(values.clone());
+				if (parseMark == 0) {
+					return selection.subList(0, index).toArray();
+				} else {
+					return selection.subList(selection.size() - index, selection.size()).toArray();
+				}
+			case 2:
+				return new Object[] {values[index - 1]};
+			default:
+				return new Object[0];
+		}
+	}
+
+	@Override
+	public String toString(@Nullable TriggerContext ctx, boolean debug) {
+		switch (pattern) {
+			case 0:
+			case 2:
+				return "element out of " + expr.toString(ctx, debug);
+			case 1:
+				return "elements out of " + expr.toString(ctx, debug);
+			default:
+				return "";
+		}
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprElement.java
@@ -103,7 +103,7 @@ public class ExprElement implements Expression<Object> {
 					case 1:
 						return new Object[] {values[values.length - 1]};
 					case 2:
-						return new Object[] {values[NumberMath.random(0, values.length, true, random).intValue()]};
+						return new Object[] {values[NumberMath.random(0, values.length - 1, true, random).intValue()]};
 					case 3:
 						return new Object[] {values[index - 1]};
 					default:

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLoopValue.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLoopValue.java
@@ -65,7 +65,7 @@ public class ExprLoopValue implements Expression<Object> {
 		}
 		int j = 1;
 		SecLoop loop = null;
-		for (final CodeSection sec : parser.getParserState().getCurrentSections()) {
+		for (CodeSection sec : parser.getParserState().getCurrentSections()) {
 			if (!(sec instanceof SecLoop))
 				continue;
 			final SecLoop l = (SecLoop) sec;

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprRandomNumber.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprRandomNumber.java
@@ -54,7 +54,7 @@ public class ExprRandomNumber implements Expression<Number> {
         Number max = maxNumber.getSingle(ctx);
         if (low == null || max == null)
             return new Number[0];
-        //Check to find out which number is the greater of the 2, while keeping the type
+        // Check to find out which number is the greater of the 2, while keeping the type
         Number realLow = Relation.SMALLER_OR_EQUAL.is(numComp.apply(low, max)) ? low : max;
         Number realMax = Relation.SMALLER_OR_EQUAL.is(numComp.apply(low, max)) ? max : low;
         return new Number[]{NumberMath.random(realLow, realMax, !isExclusive, random)};

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Effect.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Effect.java
@@ -11,7 +11,9 @@ public abstract class Effect extends Statement {
 
     @Override
     public boolean run(TriggerContext ctx) {
-        execute(ctx);
+        try {
+            execute(ctx);
+        } catch (UnsupportedOperationException ignored) { }
         return true;
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Effect.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Effect.java
@@ -11,9 +11,7 @@ public abstract class Effect extends Statement {
 
     @Override
     public boolean run(TriggerContext ctx) {
-        try {
-            execute(ctx);
-        } catch (UnsupportedOperationException ignored) { }
+        execute(ctx);
         return true;
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
@@ -32,8 +32,8 @@ public interface Expression<T> extends SyntaxElement {
     /*
      * This is staying until we figure out a better way to implement this
      */
-    default T[] getArray(TriggerContext e) {
-        return getValues(e);
+    default T[] getArray(TriggerContext ctx) {
+        return getValues(ctx);
     }
 
     /**
@@ -53,19 +53,19 @@ public interface Expression<T> extends SyntaxElement {
      * Changes this expression with the given values according to the given mode
      * @param ctx the event
      * @param changeWith the values to change this Expression with
-     * @param changeMode the mode of change
+     * @param mode the mode of change
      */
-    default void change(TriggerContext ctx, Object[] changeWith, ChangeMode changeMode) {}
+    default void change(TriggerContext ctx, Object[] changeWith, ChangeMode mode) {}
 
     /**
      * Gets a single value out of this Expression
-     * @param e the event
+     * @param ctx the event
      * @return the single value of this Expression, or {@code null} if it has no value
      * @throws SkriptRuntimeException if the expression returns more than one value
      */
     @Nullable
-    default T getSingle(TriggerContext e) {
-        T[] values = getValues(e);
+    default T getSingle(TriggerContext ctx) {
+        T[] values = getValues(ctx);
         if (values.length == 0) {
             return null;
         } else if (values.length > 1) {
@@ -152,23 +152,23 @@ public interface Expression<T> extends SyntaxElement {
 
     /**
      * Checks this expression against the given {@link Predicate}
-     * @param e the event
+     * @param ctx the event
      * @param predicate the predicate
      * @return whether the expression matches the predicate
      */
-    default boolean check(TriggerContext e, Predicate<? super T> predicate) {
-        return check(e, predicate, false);
+    default boolean check(TriggerContext ctx, Predicate<? super T> predicate) {
+        return check(ctx, predicate, false);
     }
 
     /**
      * Checks this expression against the given {@link Predicate}
-     * @param e the event
+     * @param ctx the event
      * @param predicate the predicate
      * @param negated whether the result should be inverted
      * @return whether the expression matches the predicate
      */
-    default boolean check(TriggerContext e, Predicate<? super T> predicate, boolean negated) {
-        return check(getValues(e), predicate, negated, isAndList());
+    default boolean check(TriggerContext ctx, Predicate<? super T> predicate, boolean negated) {
+        return check(getValues(ctx), predicate, negated, isAndList());
     }
 
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/ExpressionList.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/ExpressionList.java
@@ -57,14 +57,14 @@ public class ExpressionList<T> implements Expression<T> {
     }
 
     @Override
-    public T[] getArray(TriggerContext e) {
+    public T[] getArray(TriggerContext ctx) {
         if (and) {
-            return getValues(e);
+            return getValues(ctx);
         } else {
             List<Expression<? extends T>> shuffle = Arrays.asList(expressions);
             Collections.shuffle(shuffle);
             for (Expression<? extends T> expr : shuffle) {
-                T[] values = expr.getValues(e);
+                T[] values = expr.getValues(ctx);
                 if (values.length > 0)
                     return values;
             }

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/SimpleLiteral.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/SimpleLiteral.java
@@ -82,7 +82,7 @@ public class SimpleLiteral<T> implements Literal<T> {
     }
 
     @Override
-    public T[] getArray(TriggerContext e) {
+    public T[] getArray(TriggerContext ctx) {
         if (isAndList) {
             return values;
         } else {

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/base/ConditionalExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/base/ConditionalExpression.java
@@ -49,5 +49,5 @@ public abstract class ConditionalExpression implements Expression<Boolean> {
         return new Boolean[]{check(ctx)};
     }
 
-    protected abstract boolean check(TriggerContext ctx);
+    public abstract boolean check(TriggerContext ctx);
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
@@ -27,6 +27,10 @@ public class DefaultRegistration {
 
     public static void register() {
         SkriptRegistration registration = Main.getMainRegistration();
+
+        /*
+         * Classes
+         */
         registration.addType(
                 Object.class,
                 "object",
@@ -287,6 +291,9 @@ public class DefaultRegistration {
                 })
                 .register();
 
+        /*
+         * Comparators
+         */
         Comparators.registerComparator(
                 Number.class,
                 Number.class,
@@ -316,6 +323,17 @@ public class DefaultRegistration {
                     }
                 }
         );
+        Comparators.registerComparator(
+                Duration.class,
+                Duration.class,
+                new Comparator<Duration, Duration>(true) {
+                    @Override
+                    public Relation apply(Duration duration, Duration duration2) {
+                        return Relation.get(duration.compareTo(duration2));
+                    }
+                }
+        );
+
         /*
          * Ranges
          */
@@ -362,6 +380,7 @@ public class DefaultRegistration {
                             .toArray(String[]::new);
                 }
         );
+
         /*
          * Converters
          */

--- a/src/main/java/io/github/syst3ms/skriptparser/sections/SecChance.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/sections/SecChance.java
@@ -47,7 +47,7 @@ public class SecChance extends CodeSection {
     }
 
     @Override
-    protected Statement walk(TriggerContext ctx) {
+    public Statement walk(TriggerContext ctx) {
         Number c = chance.getSingle(ctx);
         if (c == null || Math.random() > (percent ? c.doubleValue() / 100 : c.doubleValue())) {
             return getNext();

--- a/src/main/java/io/github/syst3ms/skriptparser/sections/SecChance.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/sections/SecChance.java
@@ -1,0 +1,63 @@
+package io.github.syst3ms.skriptparser.sections;
+
+import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.file.FileSection;
+import io.github.syst3ms.skriptparser.lang.CodeSection;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.Statement;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.log.SkriptLogger;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.parsing.ParserState;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A condition that randomly succeeds or fails, given the chance for it to do succeed.
+ * Note that when the percent sign (%) is omitted, the chance is calculated from 0 to 1.
+ *
+ * @name Chance
+ * @type SECTION
+ * @pattern chance of %number%[\%]
+ * @since ALPHA
+ * @author Mwexim
+ */
+@SuppressWarnings("unchecked")
+public class SecChance extends CodeSection {
+
+    static {
+        Main.getMainRegistration().addSection(
+                SecChance.class,
+                "chance of %number%[1:\\%]"
+        );
+    }
+
+    private Expression<Number> chance;
+    private boolean percent;
+
+    @Override
+    public void loadSection(FileSection section, ParserState parserState, SkriptLogger logger) {
+        super.loadSection(section, parserState, logger);
+    }
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        chance = (Expression<Number>) expressions[0];
+        percent = parseContext.getParseMark() == 1;
+        return true;
+    }
+
+    @Override
+    protected Statement walk(TriggerContext ctx) {
+        Number c = chance.getSingle(ctx);
+        if (c == null || Math.random() > (percent ? c.doubleValue() / 100 : c.doubleValue())) {
+            return getNext();
+        } else {
+            return getFirst();
+        }
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return "chance of " + chance.toString(ctx, debug) + (percent ? "%" : "");
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/ClassUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/ClassUtils.java
@@ -10,6 +10,14 @@ public class ClassUtils {
      * @return the nearest common superclass of the provided classes, accounting for interfaces
      */
     public static Class<?> getCommonSuperclass(Class<?>... cs) {
+        return getCommonSuperclass(false, cs);
+    }
+
+    /**
+     * @param cs the array of classes
+     * @return the nearest common superclass of the provided classes, <b>not</b> accounting for interfaces
+     */
+    public static Class<?> getCommonSuperclass(boolean classOnly, Class<?>... cs) {
         Class<?> r = cs[0];
         outer:
         for (Class<?> c : cs) {
@@ -25,11 +33,13 @@ public class ClassUtils {
                         continue outer;
                     }
                 }
-                for (Class<?> i : c.getInterfaces()) {
-                    s = getCommonSuperclass(i, r);
-                    if (s != Object.class) {
-                        r = s;
-                        continue outer;
+                if (!classOnly) {
+                    for (Class<?> i : c.getInterfaces()) {
+                        s = getCommonSuperclass(i, r);
+                        if (s != Object.class) {
+                            r = s;
+                            continue outer;
+                        }
                     }
                 }
                 return Object.class;

--- a/src/main/java/io/github/syst3ms/skriptparser/util/ThreadUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/ThreadUtils.java
@@ -1,7 +1,10 @@
 package io.github.syst3ms.skriptparser.util;
 
 import java.time.Duration;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public class ThreadUtils {
 
@@ -12,6 +15,7 @@ public class ThreadUtils {
 	public static void runAsync(Runnable code) {
 		ExecutorService executor = Executors.newCachedThreadPool();
 		executor.submit(code);
+		executor.shutdown();
 	}
 
 	/**


### PR DESCRIPTION
This pull request's main purpose is to add all the current expressions that are **not** related to any object (like string or number expressions) from Skript to skript-parser. I am currently at the letter 'E' in the alphabet (of course I skip all Minecraft-related syntax). This means that this pull request is not complete yet, but open for review.

Currently added syntax:
- EffContinue
- ExprElement
- SecChance (probably needed as condition as well)
- ExprDifference
- EffDoIf

Furthermore, I added error-handling for the Effect#run(TriggerContext) method, since some effects (like EffAsync and EffDoIf) were calling it, but this would result in an UnsupportedOperationException if the effect used was EffWait or something like that.

I also added a Comparator for durations and refactored some code to be convenient over the whole project.