### PR TITLE
Switch from nullability to the Optional API and update to Java 11 (master)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [8, 11, 12, 13]
+        java-version: [11, 12, 13]
     steps:
       - uses: actions/checkout@v2
 
@@ -28,10 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       - name: Build skript-parser
         run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'application'
 
 mainClassName = "io.github.syst3ms.skriptparser.Main"
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.11
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/github/syst3ms/skriptparser/Skript.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/Skript.java
@@ -49,8 +49,7 @@ public class Skript extends SkriptAddon {
         }
         for (Trigger trigger : periodicalTriggers) {
             PeriodicalContext ctx = new PeriodicalContext();
-            Duration dur = ((EvtPeriodical) trigger.getEvent()).getDuration().getSingle(ctx);
-            assert dur != null;
+            Duration dur = ((EvtPeriodical) trigger.getEvent()).getDuration().getSingle(ctx).orElseThrow(AssertionError::new);
             ThreadUtils.runPeriodically(() -> Statement.runAll(trigger, ctx), dur);
         }
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
@@ -9,8 +9,6 @@ import io.github.syst3ms.skriptparser.parsing.SyntaxParser;
 import io.github.syst3ms.skriptparser.util.ThreadUtils;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Optional;
-
 /**
  * Runs this effect asynchronously.
  * The difference between this and the section {@code async} is due to the fact that this effect will only run the specified action asunc,

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffAsync.java
@@ -9,6 +9,8 @@ import io.github.syst3ms.skriptparser.parsing.SyntaxParser;
 import io.github.syst3ms.skriptparser.util.ThreadUtils;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * Runs this effect asynchronously.
  * The difference between this and the section {@code async} is due to the fact that this effect will only run the specified action asunc,
@@ -36,7 +38,7 @@ public class EffAsync extends Effect {
     public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
         String expr = parseContext.getMatches().get(0).group();
         parseContext.getLogger().recurse();
-        effect = SyntaxParser.parseEffect(expr, parseContext.getParserState(), parseContext.getLogger());
+        effect = SyntaxParser.parseEffect(expr, parseContext.getParserState(), parseContext.getLogger()).orElse(null);
         parseContext.getLogger().callback();
         return effect != null;
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
@@ -10,6 +10,7 @@ import io.github.syst3ms.skriptparser.util.ThreadUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
+import java.util.Optional;
 
 /**
  * Waits a certain duration and then executes all the code after this effect.
@@ -44,15 +45,14 @@ public class EffWait extends Effect {
     }
 
     @Override
-    public Statement walk(TriggerContext ctx) {
-        Duration dur = duration.getSingle(ctx);
-        if (dur == null)
+    public Optional<? extends Statement> walk(TriggerContext ctx) {
+        Optional<? extends Duration> dur = duration.getSingle(ctx);
+        if (dur.isEmpty())
             return getNext();
-        if (getNext() == null)
-            return null;
-
-        ThreadUtils.runAfter(() -> Statement.runAll(getNext(), ctx), dur);
-        return null;
+        if (getNext().isEmpty())
+            return Optional.empty();
+        ThreadUtils.runAfter(() -> Statement.runAll(getNext().get(), ctx), dur.get());
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/event/EvtPeriodical.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/event/EvtPeriodical.java
@@ -41,7 +41,7 @@ public class EvtPeriodical extends SkriptEvent {
 
     @Override
     public boolean check(TriggerContext ctx) {
-        return ctx instanceof PeriodicalContext && duration.getSingle(ctx) != null;
+        return ctx instanceof PeriodicalContext && duration.getSingle(ctx).isPresent();
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprCompare.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprCompare.java
@@ -19,6 +19,7 @@ import io.github.syst3ms.skriptparser.util.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * A very general condition, it simply compares two values. Usually you can only compare for equality (e.g. text is/isn't &lt;text&gt;),
@@ -207,34 +208,34 @@ public class CondExprCompare extends ConditionalExpression {
     private String errorString(Expression<?> expr, boolean debug) {
         if (expr.getReturnType() == Object.class)
             return expr.toString(null, debug);
-        Type<?> exprType = TypeManager.getByClass(expr.getReturnType());
-        assert exprType != null;
-        return StringUtils.withIndefiniteArticle(exprType.getBaseName(), !expr.isSingle());
+        Optional<? extends Type<?>> exprType = TypeManager.getByClass(expr.getReturnType());
+        assert exprType.isPresent();
+        return StringUtils.withIndefiniteArticle(exprType.get().getBaseName(), !expr.isSingle());
     }
 
     @SuppressWarnings({"unchecked"})
     private boolean initialize() {
         Expression<?> third = this.third;
         if (first.getReturnType() == Object.class) {
-            Expression<?> e = first.convertExpression(Object.class);
-            if (e == null) {
+            Optional<? extends Expression<Object>> e = first.convertExpression(Object.class);
+            if (e.isEmpty()) {
                 return false;
             }
-            first = e;
+            first = e.get();
         }
         if (second.getReturnType() == Object.class) {
-            Expression<?> e = second.convertExpression(Object.class);
-            if (e == null) {
+            Optional<? extends Expression<Object>> e = second.convertExpression(Object.class);
+            if (e.isEmpty()) {
                 return false;
             }
-            second = e;
+            second = e.get();
         }
         if (third != null && third.getReturnType() == Object.class) {
-            Expression<?> e = third.convertExpression(Object.class);
-            if (e == null) {
+            Optional<? extends Expression<Object>> e = third.convertExpression(Object.class);
+            if (e.isEmpty()) {
                 return false;
             }
-            this.third = third = e;
+            this.third = third = e.get();
         }
         Class<?> f = first.getReturnType();
         Class<?> s = third == null
@@ -242,8 +243,7 @@ public class CondExprCompare extends ConditionalExpression {
                 : ClassUtils.getCommonSuperclass(second.getReturnType(), third.getReturnType());
         if (f == Object.class || s == Object.class)
             return true;
-        comp = (Comparator<Object, Object>) Comparators.getComparator(f, s);
-        return comp != null;
+        return (comp = (Comparator<Object, Object>) Comparators.getComparator(f, s).orElse(null)) != null;
     }
 
     /*

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
@@ -8,6 +8,7 @@ import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * See if a given list of objects contain a given element.
@@ -48,12 +49,9 @@ public class CondExprContains extends ConditionalExpression {
     @Override
     protected boolean check(TriggerContext ctx) {
         if (onlyString) {
-            String f = ((Expression<String>) first).getSingle(ctx);
-            String s = ((Expression<String>) second).getSingle(ctx);
-            if (f == null || s == null) {
-                return false;
-            }
-            return isNegated() != f.contains(s);
+            Optional<? extends String> f = ((Expression<String>) first).getSingle(ctx);
+            Optional<? extends String> s = ((Expression<String>) second).getSingle(ctx);
+            return isNegated() != f.filter(o1 -> s.map(o1::contains).isPresent()).isPresent();
         } else {
             Object[] f = ((Expression<Object>) first).getValues(ctx);
             Object[] s = ((Expression<Object>) second).getValues(ctx);

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprDateCompare.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprDateCompare.java
@@ -1,7 +1,6 @@
 package io.github.syst3ms.skriptparser.expressions;
 
 import io.github.syst3ms.skriptparser.Main;
-import io.github.syst3ms.skriptparser.Skript;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
@@ -11,7 +10,6 @@ import io.github.syst3ms.skriptparser.util.SkriptDate;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
-import java.util.Optional;
 
 /**
  * Check if a given date is a certain duration before or after the current date.

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprDateCompare.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprDateCompare.java
@@ -1,14 +1,17 @@
 package io.github.syst3ms.skriptparser.expressions;
 
 import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.Skript;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.DoubleOptional;
 import io.github.syst3ms.skriptparser.util.SkriptDate;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
+import java.util.Optional;
 
 /**
  * Check if a given date is a certain duration before or after the current date.
@@ -45,13 +48,10 @@ public class CondExprDateCompare extends ConditionalExpression {
 
     @Override
     protected boolean check(TriggerContext ctx) {
-        SkriptDate d = date.getSingle(ctx);
-        Duration dur = duration.getSingle(ctx);
-        if (d == null || dur == null)
-            return false;
-        long timestamp = d.getTimestamp();
-
-        return isNegated() == (SkriptDate.now().getTimestamp() - dur.toMillis() <= timestamp);
+        DoubleOptional<? extends SkriptDate, ? extends Duration> opt = DoubleOptional.ofOptional(date.getSingle(ctx), duration.getSingle(ctx));
+        return opt.filter(
+                (dat, dur) -> isNegated() != (dat.getTimestamp() < SkriptDate.now().getTimestamp() - dur.toMillis())
+        ).isPresent();
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprIsSet.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprIsSet.java
@@ -38,7 +38,7 @@ public class CondExprIsSet extends ConditionalExpression {
 
     @Override
     protected boolean check(TriggerContext ctx) {
-        return isNegated() == (expr == null || expr.getValues(ctx).length == 0);
+        return isNegated() != (expr == null || expr.getValues(ctx).length == 0);
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprStartsEnds.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprStartsEnds.java
@@ -7,6 +7,8 @@ import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * Check if a given string starts or ends with a certain string.
  *
@@ -45,16 +47,14 @@ public class CondExprStartsEnds extends ConditionalExpression {
     @Override
     protected boolean check(TriggerContext ctx) {
         String[] strs = expr.getValues(ctx);
-        String v = value.getSingle(ctx);
-        if (v == null)
-            return false;
-
-        for (String s : strs) {
-            if (isNegated() == (start ? s.startsWith(v) : s.endsWith(v))) {
-                return false;
+        return value.getSingle(ctx).filter(v -> {
+            for (String s : strs) {
+                if (isNegated() != (start ? s.startsWith(v) : s.endsWith(v))) {
+                    return false;
+                }
             }
-        }
-        return true;
+            return true;
+        }).isPresent();
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprStartsEnds.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprStartsEnds.java
@@ -7,8 +7,6 @@ import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Optional;
-
 /**
  * Check if a given string starts or ends with a certain string.
  *

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprAgoLater.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprAgoLater.java
@@ -1,13 +1,16 @@
 package io.github.syst3ms.skriptparser.expressions;
 
 import io.github.syst3ms.skriptparser.Main;
+import io.github.syst3ms.skriptparser.Skript;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.DoubleOptional;
 import io.github.syst3ms.skriptparser.util.SkriptDate;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
+import java.util.Optional;
 
 /**
  * The date that was a certain duration ago or is a certain duration in the future.
@@ -40,7 +43,6 @@ public class ExprAgoLater implements Expression<SkriptDate> {
 	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
 		past = matchedPattern == 0;
 		relative = parseContext.getParseMark() == 1;
-
 		duration = (Expression<Duration>) expressions[0];
 		if (relative)
 			date = (Expression<SkriptDate>) expressions[1];
@@ -49,17 +51,11 @@ public class ExprAgoLater implements Expression<SkriptDate> {
 
 	@Override
 	public SkriptDate[] getValues(TriggerContext ctx) {
-		Duration dur = duration.getSingle(ctx);
-		if (dur == null)
-			return new SkriptDate[0];
-
-		if (relative) {
-			SkriptDate d = date.getSingle(ctx);
-			if (d == null)
-				return new SkriptDate[0];
-			return new SkriptDate[] {past ? d.minus(dur) : d.plus(dur)};
-		}
-		return new SkriptDate[] {past ? SkriptDate.now().minus(dur) : SkriptDate.now().plus(dur)};
+		Optional<? extends Duration> dur = duration.getSingle(ctx);
+		Optional<? extends SkriptDate> dat = relative ? date.getSingle(ctx) : Optional.of(SkriptDate.now());
+		DoubleOptional<? extends SkriptDate, ? extends Duration> opt = DoubleOptional.ofOptional(dat, dur);
+		return opt.mapToOptional((da, du) -> new SkriptDate[]{past ? da.minus(du) : da.plus(du)})
+				.orElse(new SkriptDate[0]);
 	}
 
 	@Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprAgoLater.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprAgoLater.java
@@ -1,7 +1,6 @@
 package io.github.syst3ms.skriptparser.expressions;
 
 import io.github.syst3ms.skriptparser.Main;
-import io.github.syst3ms.skriptparser.Skript;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprAmount.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprAmount.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * The amount of elements in a given list.
@@ -53,9 +54,9 @@ public class ExprAmount extends PropertyExpression<Number, Object> {
 	@Override
 	public Number[] getValues(TriggerContext ctx) {
 		if (recursive) {
-			Object var = ((Variable<?>) getOwner()).getRaw(ctx);
-			if (var != null)
-				return new Number[] {getRecursiveSize((Map<String, ?>) var)}; // Should already be a Map
+			Optional<Object> var = ((Variable<?>) getOwner()).getRaw(ctx);
+			if (var.isPresent())
+				return new Number[] {getRecursiveSize((Map<String, ?>) var.get())}; // Should already be a Map
 		}
 		return new Number[] {getOwner().getValues(ctx).length};
 	}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprBinaryMathFunctions.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprBinaryMathFunctions.java
@@ -5,6 +5,7 @@ import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.registration.PatternInfos;
+import io.github.syst3ms.skriptparser.util.DoubleOptional;
 import io.github.syst3ms.skriptparser.util.math.BigDecimalMath;
 import io.github.syst3ms.skriptparser.util.math.NumberMath;
 import org.jetbrains.annotations.Nullable;
@@ -62,12 +63,12 @@ public class ExprBinaryMathFunctions implements Expression<Number> {
 
 	@Override
 	public Number[] getValues(TriggerContext ctx) {
-		Number f = first.getSingle(ctx);
-		Number s = second.getSingle(ctx);
-		if (f == null || s == null)
-			return new Number[0];
+		DoubleOptional<? extends Number, ? extends Number> args = DoubleOptional.ofOptional(
+				first.getSingle(ctx),
+				second.getSingle(ctx)
+		);
 		BinaryOperator<Number> operator = PATTERNS.getInfo(pattern);
-		return new Number[]{operator.apply(f, s)};
+		return args.mapToOptional((f, s) -> new Number[]{operator.apply(f, s)}).orElse(new Number[0]);
 	}
 
 	@Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprBinaryMathFunctions.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprBinaryMathFunctions.java
@@ -23,7 +23,7 @@ import java.util.function.BinaryOperator;
  * @author Syst3ms
  */
 public class ExprBinaryMathFunctions implements Expression<Number> {
-	public static PatternInfos<BinaryOperator<Number>> PATTERNS = new PatternInfos<>(
+	public static final PatternInfos<BinaryOperator<Number>> PATTERNS = new PatternInfos<>(
 		new Object[][] {
 			{"log[arithm] [base] %number% of %number%", (BinaryOperator<Number>) NumberMath::log},
 			{"root %number% of %number%", (BinaryOperator<Number>) (n, r) -> {

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprBooleanOperators.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprBooleanOperators.java
@@ -6,6 +6,8 @@ import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * Basic boolean operators. It is possible to use conditions inside the operators.
  *
@@ -48,21 +50,22 @@ public class ExprBooleanOperators implements Expression<Boolean> {
     @Override
     public Boolean[] getValues(TriggerContext ctx) {
         assert second != null || pattern == 0;
-        Boolean f = first.getSingle(ctx);
-        if (f == null)
-            return new Boolean[0];
-        if (pattern == 0) {
-            return new Boolean[]{!f};
-        } else {
-            Boolean s = second.getSingle(ctx);
-            if (s == null)
-                return new Boolean[0];
-            if (pattern == 1) {
-                return new Boolean[]{f || s};
+        return first.getSingle(ctx).flatMap(f -> {
+            if (pattern == 0) {
+                return Optional.of(new Boolean[]{!f});
             } else {
-                return new Boolean[]{f && s};
+                return second.getSingle(ctx)
+                        .map(
+                            s -> {
+                                if (pattern == 1) {
+                                    return new Boolean[]{f || s};
+                                } else {
+                                    return new Boolean[]{f && s};
+                                }
+                            }
+                        );
             }
-        }
+        }).orElse(new Boolean[0]);
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateFromUnix.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateFromUnix.java
@@ -7,6 +7,8 @@ import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.util.SkriptDate;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * The date from a (unix) timestamp.
  * The default timestamp returns the amount of <b>milliseconds</b> since the Unix Epoch.
@@ -42,14 +44,12 @@ public class ExprDateFromUnix implements Expression<SkriptDate> {
 
 	@Override
 	public SkriptDate[] getValues(TriggerContext ctx) {
-		Number t = timestamp.getSingle(ctx);
-		if (t == null)
-			return new SkriptDate[0];
-
-		return new SkriptDate[] {unix
-				? new SkriptDate(t.longValue() * 1000)
-				: new SkriptDate(t.longValue())
-		};
+		return timestamp.getSingle(ctx)
+				.map(
+					t -> new SkriptDate[]{
+							unix ? new SkriptDate(t.longValue() * 1000) : new SkriptDate(t.longValue())
+					}
+				).orElse(new SkriptDate[0]);
 	}
 
 	@Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateFromUnix.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateFromUnix.java
@@ -7,8 +7,6 @@ import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.util.SkriptDate;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Optional;
-
 /**
  * The date from a (unix) timestamp.
  * The default timestamp returns the amount of <b>milliseconds</b> since the Unix Epoch.

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateInformation.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateInformation.java
@@ -9,6 +9,7 @@ import io.github.syst3ms.skriptparser.util.SkriptDate;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -39,8 +40,8 @@ public class ExprDateInformation extends PropertyExpression<Number, SkriptDate> 
 	int parseMark;
 
 	@Override
-	public Function<SkriptDate[], Number[]> getPropertyFunction() {
-		return dates -> {
+	public Optional<? extends Function<? super SkriptDate[], ? extends Number[]>> getPropertyFunction() {
+		return Optional.of(dates -> {
 			LocalDateTime lcd = dates[0].toLocalDateTime();
 			switch (parseMark) {
 				case 0:
@@ -62,7 +63,7 @@ public class ExprDateInformation extends PropertyExpression<Number, SkriptDate> 
 				default:
 					return new Number[0];
 			}
-		};
+		});
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateTimestamp.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateTimestamp.java
@@ -8,6 +8,7 @@ import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.util.SkriptDate;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -37,11 +38,14 @@ public class ExprDateTimestamp extends PropertyExpression<Number, SkriptDate> {
 	boolean unix;
 
 	@Override
-	public Function<SkriptDate[], Number[]> getPropertyFunction() {
-		return dates -> new Number[] {unix
+	public Optional<? extends Function<? super SkriptDate[], ? extends Number[]>> getPropertyFunction() {
+		return Optional.of(
+				dates -> new Number[] {
+					unix
 						? Math.floorDiv(dates[0].getTimestamp(), 1000)
 						: dates[0].getTimestamp()
-		};
+				}
+		);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateValues.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateValues.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.time.LocalDateTime;
 import java.time.format.TextStyle;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -36,8 +37,8 @@ public class ExprDateValues extends PropertyExpression<String, SkriptDate> {
 	int parseMark;
 
 	@Override
-	public Function<SkriptDate[], String[]> getPropertyFunction() {
-		return dates -> {
+	public Optional<? extends Function<? super SkriptDate[], ? extends String[]>> getPropertyFunction() {
+		return Optional.of(dates -> {
 			LocalDateTime lcd = dates[0].toLocalDateTime();
 			switch (parseMark) {
 				case 0:
@@ -55,7 +56,7 @@ public class ExprDateValues extends PropertyExpression<String, SkriptDate> {
 				default:
 					return new String[0];
 			}
-		};
+		});
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
@@ -5,6 +5,7 @@ import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.lang.base.PropertyExpression;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -29,8 +30,8 @@ public class ExprLength extends PropertyExpression<Number, String> {
     }
 
     @Override
-    public Function<String[], Number[]> getPropertyFunction() {
-        return strings -> new Number[]{strings[0].length()};
+    public Optional<? extends Function<? super String[], ? extends Number[]>> getPropertyFunction() {
+        return Optional.of(strings -> new Number[]{strings[0].length()});
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLoopValue.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLoopValue.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Array;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -57,12 +58,9 @@ public class ExprLoopValue implements Expression<Object> {
 			i = Integer.parseInt(m.group(2));
 		}
 		Class<?> c;
-		PatternType<?> type = TypeManager.getPatternType(s);
-		if (type != null) { // And that, people, is why I like Kotlin
-			c = type.getType().getTypeClass();
-		} else {
-			c = null;
-		}
+		Optional<PatternType<?>> type = TypeManager.getPatternType(s);
+		// And that, people, is why I like Kotlin
+		c = type.map(patternType -> patternType.getType().getTypeClass()).orElse(null);
 		int j = 1;
 		SecLoop loop = null;
 		for (final CodeSection sec : parser.getParserState().getCurrentSections()) {
@@ -99,9 +97,9 @@ public class ExprLoopValue implements Expression<Object> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <R> Expression<R> convertExpression(Class<R> to) {
+	public <R> Optional<? extends Expression<R>> convertExpression(Class<R> to) {
 		if (isVariableLoop && !isIndex) {
-			return new ConvertedExpression<>(this, (Class<R>) ClassUtils.getCommonSuperclass(to), o -> Converters.convert(o, to));
+			return Optional.of(new ConvertedExpression<>(this, (Class<R>) ClassUtils.getCommonSuperclass(to), o -> Converters.convert(o, to)));
 		} else {
 			return Expression.super.convertExpression(to);
 		}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprRandomNumber.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprRandomNumber.java
@@ -11,7 +11,6 @@ import io.github.syst3ms.skriptparser.util.DoubleOptional;
 import io.github.syst3ms.skriptparser.util.math.NumberMath;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 /**
  * Generate a random number (double) or integer.

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprRandomNumber.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprRandomNumber.java
@@ -7,9 +7,11 @@ import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.types.comparisons.Comparator;
 import io.github.syst3ms.skriptparser.types.comparisons.Comparators;
 import io.github.syst3ms.skriptparser.types.comparisons.Relation;
+import io.github.syst3ms.skriptparser.util.DoubleOptional;
 import io.github.syst3ms.skriptparser.util.math.NumberMath;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 /**
  * Generate a random number (double) or integer.
@@ -43,21 +45,19 @@ public class ExprRandomNumber implements Expression<Number> {
         maxNumber = (Expression<Number>) expressions[1];
         isInteger = matchedPattern == 0;
         isExclusive = context.getParseMark() == 1;
-        numComp = Comparators.getComparator(Number.class, Number.class);
-        assert numComp != null;
+        numComp = Comparators.getComparator(Number.class, Number.class).orElseThrow(AssertionError::new);
         return true;
     }
 
     @Override
     public Number[] getValues(TriggerContext ctx) {
-        Number low = lowerNumber.getSingle(ctx);
-        Number max = maxNumber.getSingle(ctx);
-        if (low == null || max == null)
-            return new Number[0];
-        //Check to find out which number is the greater of the 2, while keeping the type
-        Number realLow = Relation.SMALLER_OR_EQUAL.is(numComp.apply(low, max)) ? low : max;
-        Number realMax = Relation.SMALLER_OR_EQUAL.is(numComp.apply(low, max)) ? max : low;
-        return new Number[]{NumberMath.random(realLow, realMax, !isExclusive, random)};
+        return DoubleOptional.ofOptional(lowerNumber.getSingle(ctx), maxNumber.getSingle(ctx))
+                .flatMap((l, m) -> DoubleOptional.of(
+                        Relation.SMALLER_OR_EQUAL.is(numComp.apply(l, m)) ? l : m,
+                        Relation.SMALLER_OR_EQUAL.is(numComp.apply(l, m)) ? m : l
+                    )
+                ).mapToOptional((l, m) -> new Number[]{NumberMath.random(l, m, !isExclusive, random)})
+                .orElse(new Number[0]);
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprRange.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprRange.java
@@ -16,12 +16,7 @@ import io.github.syst3ms.skriptparser.util.CollectionUtils;
 import io.github.syst3ms.skriptparser.util.DoubleOptional;
 import org.jetbrains.annotations.Nullable;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.BiFunction;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
 
 /**
  * Returns a range of values between two endpoints. Types supported by default are integers and characters (length 1 strings).

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringCases.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringCases.java
@@ -63,11 +63,9 @@ public class ExprStringCases implements Expression<String> {
 
 	@Override
 	public String[] getValues(TriggerContext ctx) {
-		String str = expr.getSingle(ctx);
-		if (str == null)
-			return new String[0];
-
-		return new String[] {PATTERNS.getInfo(pattern).apply(str)};
+		return expr.getSingle(ctx)
+				.map(s -> new String[]{ PATTERNS.getInfo(pattern).apply(s) })
+				.orElse(new String[0]);
 	}
 
 	@Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringOccurrence.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringOccurrence.java
@@ -4,6 +4,7 @@ import io.github.syst3ms.skriptparser.Main;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.DoubleOptional;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -39,13 +40,14 @@ public class ExprStringOccurrence implements Expression<Number> {
 
 	@Override
 	public Number[] getValues(TriggerContext ctx) {
-		String v = value.getSingle(ctx), e = expr.getSingle(ctx);
-		if (v == null || e == null)
-			return new Number[0];
-
-		int i = first ? e.indexOf(v) : e.lastIndexOf(v);
-		// Return i + 1, since Skript indices start at 1.
-		return i == -1 ? new Number[0] : new Number[] {i + 1};
+		return DoubleOptional.ofOptional(value.getSingle(ctx), expr.getSingle(ctx))
+				.mapToOptional((v, e) -> first ? e.indexOf(v) : e.lastIndexOf(v))
+				.filter(i -> i != -1)
+				.map(i -> {
+					// Return i + 1, since Skript indices start at 1.
+					return new Number[]{i + 1};
+				})
+				.orElse(new Number[0]);
 	}
 
 	@Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringSplitJoin.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringSplitJoin.java
@@ -4,6 +4,8 @@ import io.github.syst3ms.skriptparser.Main;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.registration.PatternInfos;
+import io.github.syst3ms.skriptparser.util.DoubleOptional;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -63,35 +65,29 @@ public class ExprStringSplitJoin implements Expression<String> {
 
 	@Override
 	public String[] getValues(TriggerContext ctx) {
-		String str;
-		String del;
 		if (pattern == 0) {
 			String[] strs = expr.getValues(ctx);
-			del = delimiterPresent ? delimiter.getSingle(ctx) : "";
+			String del = delimiterPresent ? delimiter.getSingle(ctx).orElse(null) : "";
 			if (strs.length == 0 || del == null) {
 				return new String[0];
 			}
 			return new String[]{String.join(del, strs)};
 		} else if (pattern == 1) {
-			str = expr.getSingle(ctx);
-			del = delimiter.getSingle(ctx);
-			if (str == null || del == null) {
-				return new String[0];
-			}
-			return str.split(Pattern.quote(del));
+			return DoubleOptional.ofOptional(expr.getSingle(ctx), delimiter.getSingle(ctx))
+					.mapToOptional((str, del) -> str.split(Pattern.quote(del)))
+					.orElse(new String[0]);
 		} else {
-			str = expr.getSingle(ctx);
-			Number c = chars.getSingle(ctx);
-			if (str == null || c == null) {
-				return new String[0];
-			}
-			List<String> ret = new ArrayList<>();
-			int i = 0;
-			while (i < str.length()) {
-				ret.add(str.substring(i, Math.min(i + c.intValue(), str.length())));
-				i += c.intValue();
-			}
-			return ret.toArray(new String[0]);
+			return DoubleOptional.ofOptional(expr.getSingle(ctx), chars.getSingle(ctx))
+					.mapToOptional((str, c) -> {
+						List<String> ret = new ArrayList<>();
+						int i = 0;
+						while (i < str.length()) {
+							ret.add(str.substring(i, Math.min(i + c.intValue(), str.length())));
+							i += c.intValue();
+						}
+						return ret.toArray(new String[0]);
+					})
+					.orElse(new String[0]);
 		}
 	}
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringSplitJoin.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringSplitJoin.java
@@ -4,7 +4,6 @@ import io.github.syst3ms.skriptparser.Main;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
-import io.github.syst3ms.skriptparser.registration.PatternInfos;
 import io.github.syst3ms.skriptparser.util.DoubleOptional;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprTernary.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprTernary.java
@@ -42,15 +42,9 @@ public class ExprTernary implements Expression<Object> {
 
     @Override
     public Object[] getValues(TriggerContext ctx) {
-        Boolean check = valueToCheck.getSingle(ctx);
-        Object[] first = firstValue.getValues(ctx);
-        Object[] second = secondValue.getValues(ctx);
-        if (check == null)
-            return new Object[0];
-        Object[] result = check ? first : second;
-        if (result == null)
-            return new Object[0];
-        return result;
+        return valueToCheck.getSingle(ctx)
+                .map(check -> check ? firstValue.getValues(ctx) : secondValue.getValues(ctx))
+                .orElse(new Object[0]);
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprUnaryMathFunctions.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprUnaryMathFunctions.java
@@ -81,10 +81,9 @@ public class ExprUnaryMathFunctions implements Expression<Number> {
 
 	@Override
 	public Number[] getValues(TriggerContext ctx) {
-		Number num = number.getSingle(ctx);
-		if (num == null)
-			return new Number[0];
-		return new Number[]{PATTERNS.getInfo(pattern).apply(num)};
+		return number.getSingle(ctx)
+				.map(n -> new Number[]{ PATTERNS.getInfo(pattern).apply(n) })
+				.orElse(new Number[0]);
 	}
 
 	@Override

--- a/src/main/java/io/github/syst3ms/skriptparser/file/FileElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/file/FileElement.java
@@ -1,7 +1,5 @@
 package io.github.syst3ms.skriptparser.file;
 
-import io.github.syst3ms.skriptparser.util.StringUtils;
-
 /**
  * Represents any non-blank and not comment-only line in a file. It is important to note that information about comments
  * is absent from this class, as they are discarded before being passed to the constructor.<br>
@@ -39,7 +37,7 @@ public class FileElement {
         if (!(obj instanceof FileElement)) {
             return false;
         } else {
-            FileElement other = (FileElement) obj;
+            var other = (FileElement) obj;
             return indentation == other.indentation &&
                    line == other.line &&
                    content.equalsIgnoreCase(other.content) &&
@@ -56,7 +54,7 @@ public class FileElement {
 
     @Override
     public String toString() {
-        return StringUtils.repeat("    ", indentation) + content;
+        return "    ".repeat(indentation) + content;
     }
 
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/file/FileParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/file/FileParser.java
@@ -29,10 +29,10 @@ public class FileParser {
      */
     public List<FileElement> parseFileLines(String fileName, List<String> lines, int expectedIndentation, int lastLine, SkriptLogger logger) {
         List<FileElement> elements = new ArrayList<>();
-        for (int i = 0; i < lines.size(); i++) {
-            String line = lines.get(i);
+        for (var i = 0; i < lines.size(); i++) {
+            var line = lines.get(i);
             String content;
-            Matcher m = LINE_PATTERN.matcher(line);
+            var m = LINE_PATTERN.matcher(line);
             if (m.matches()) {
                 content = m.group(1).replace("##", "#").trim();
             } else {
@@ -42,7 +42,7 @@ public class FileParser {
                 elements.add(new VoidElement(fileName, lastLine + i, expectedIndentation));
                 continue;
             }
-            int lineIndentation = FileUtils.getIndentationLevel(line, false);
+            var lineIndentation = FileUtils.getIndentationLevel(line, false);
             if (lineIndentation > expectedIndentation) { // The line is indented too much
                 logger.error("The line is indented too much (line " + (lastLine + i) + ": \"" + content + "\")", ErrorType.STRUCTURE_ERROR);
                 continue;
@@ -55,7 +55,7 @@ public class FileParser {
                             new ArrayList<>(), expectedIndentation
                     ));
                 } else {
-                    List<FileElement> sectionElements = parseFileLines(fileName, lines.subList(i + 1, lines.size()),
+                    var sectionElements = parseFileLines(fileName, lines.subList(i + 1, lines.size()),
                             expectedIndentation + 1, lastLine + i + 1,
                             logger);
                     elements.add(new FileSection(fileName, lastLine + i, content.substring(0, content.length() - 1),
@@ -71,8 +71,8 @@ public class FileParser {
     }
 
     private int count(List<FileElement> elements) {
-        int count = 0;
-        for (FileElement element : elements) {
+        var count = 0;
+        for (var element : elements) {
             if (element instanceof FileSection) {
                 count += count(((FileSection) element).getElements()) + 1;
             } else {

--- a/src/main/java/io/github/syst3ms/skriptparser/file/FileParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/file/FileParser.java
@@ -33,9 +33,9 @@ public class FileParser {
             String content;
             var m = LINE_PATTERN.matcher(line);
             if (m.matches()) {
-                content = m.group(1).replace("##", "#").trim();
+                content = m.group(1).replace("##", "#").strip();
             } else {
-                content = line.replace("##", "#").trim();
+                content = line.replace("##", "#").strip();
             }
             if (content.matches("[\\s#]*")) {
                 elements.add(new VoidElement(fileName, lastLine + i, expectedIndentation));

--- a/src/main/java/io/github/syst3ms/skriptparser/file/FileParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/file/FileParser.java
@@ -6,7 +6,6 @@ import io.github.syst3ms.skriptparser.util.FileUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**

--- a/src/main/java/io/github/syst3ms/skriptparser/file/FileSection.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/file/FileSection.java
@@ -27,7 +27,7 @@ public class FileSection extends FileElement {
         if (length >= 0)
             return length;
         length = 0;
-        for (FileElement e : elements) {
+        for (var e : elements) {
             if (e instanceof FileSection) {
                 length += ((FileSection) e).length() + 1;
             } else {

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/CodeSection.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/CodeSection.java
@@ -8,10 +8,10 @@ import io.github.syst3ms.skriptparser.parsing.ScriptLoader;
 import io.github.syst3ms.skriptparser.sections.SecLoop;
 import io.github.syst3ms.skriptparser.sections.SecWhile;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a section of runnable code. This parser guarantees the existence of {@link Conditional}, {@link SecLoop} and
@@ -52,7 +52,7 @@ public abstract class CodeSection extends Statement {
     }
 
     @Override
-    public abstract Statement walk(TriggerContext ctx);
+    public abstract Optional<? extends Statement> walk(TriggerContext ctx);
 
     /**
      * Sets the items inside this lists, and also modifies other fields, reflected through the outputs of {@link #getFirst()},
@@ -61,11 +61,11 @@ public abstract class CodeSection extends Statement {
      */
     public final void setItems(List<Statement> items) {
         this.items = items;
-        for (Statement item : items) {
+        for (var item : items) {
             item.setParent(this);
         }
         first = items.isEmpty() ? null : items.get(0);
-        last = items.isEmpty() ? null : items.get(items.size() - 1).setNext(getNext());
+        last = items.isEmpty() ? null : items.get(items.size() - 1).setNext(getNext().orElse(null));
     }
 
     /**
@@ -82,18 +82,16 @@ public abstract class CodeSection extends Statement {
      * @return the first item of this section, or the item after the section if it's empty, or {@code null} if there is
      * no item after this section, in the latter case
      */
-    @Nullable
-    protected final Statement getFirst() {
-        return first == null ? getNext() : first;
+    protected final Optional<? extends Statement> getFirst() {
+        return Optional.ofNullable(first).or(this::getNext);
     }
 
     /**
      * @return the last item of this section, or the item after the section if it's empty, or {@code null} if there is
      * no item after this section, in the latter case
      */
-    @Nullable
-    protected final Statement getLast() {
-        return last == null ? getNext() : last;
+    protected final Optional<? extends Statement> getLast() {
+        return Optional.ofNullable(last).or(this::getNext);
     }
 
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Conditional.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Conditional.java
@@ -6,6 +6,8 @@ import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.parsing.ParserState;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * A {@linkplain CodeSection code section} representing a condition. It can either be :
  * <ul>
@@ -38,16 +40,16 @@ public class Conditional extends CodeSection {
     }
 
     @Override
-    public Statement walk(TriggerContext ctx) {
+    public Optional<? extends Statement> walk(TriggerContext ctx) {
         assert condition != null || mode == ConditionalMode.ELSE;
         if (mode == ConditionalMode.ELSE) {
             return getFirst();
         }
-        Boolean c = condition.getSingle(ctx);
-        if (c != null && c) {
+        Optional<? extends Boolean> c = condition.getSingle(ctx);
+        if (c.filter(b -> b).isPresent()) {
             return getFirst();
         } else if (fallingClause != null){
-            return fallingClause;
+            return Optional.of(fallingClause);
         } else {
             return getNext();
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Conditional.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Conditional.java
@@ -48,7 +48,7 @@ public class Conditional extends CodeSection {
         Optional<? extends Boolean> c = condition.getSingle(ctx);
         if (c.filter(b -> b).isPresent()) {
             return getFirst();
-        } else if (fallingClause != null){
+        } else if (fallingClause != null) {
             return Optional.of(fallingClause);
         } else {
             return getNext();

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
@@ -21,8 +21,7 @@ import java.util.function.Predicate;
  */
 public interface Expression<T> extends SyntaxElement {
     /**
-     * Retrieves all values of this Expression. This should never return null ! Doing so will most likely throw a {@linkplain NullPointerException NPE} in
-     * the following instructions.
+     * Retrieves all values of this Expression.
      * @param ctx the event
      * @return an array of the values
      */
@@ -89,16 +88,16 @@ public interface Expression<T> extends SyntaxElement {
      * @return the return type of this expression. By default, this is defined on registration, but, like {@linkplain #isSingle()}, can be overriden.
      */
     default Class<? extends T> getReturnType() {
-        ExpressionInfo<?, T> info = SyntaxManager.getExpressionExact(this);
-        if (info == null) {
-            throw new SkriptParserException("Unregistered expression class : " + getClass().getName());
-        }
-        return info.getReturnType().getType().getTypeClass();
+        return SyntaxManager.getExpressionExact(this)
+                .orElseThrow(() -> new SkriptParserException("Unregistered expression class : " + getClass().getName()))
+                .getReturnType()
+                .getType()
+                .getTypeClass();
     }
 
     /**
      * @param ctx the event
-     * @return an iterator, used inside of a {@link SecLoop loop}
+     * @return an iterator of the values of this expression
      */
     default Iterator<? extends T> iterator(TriggerContext ctx) {
         return CollectionUtils.iterator(getValues(ctx));

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -44,9 +45,8 @@ public interface Expression<T> extends SyntaxElement {
      *         shouldn't be changed with the given {@linkplain ChangeMode change mode}. If the change mode is
      *         {@link ChangeMode#DELETE} or {@link ChangeMode#RESET}, then an empty array should be returned.
      */
-    @Nullable
-    default Class<?>[] acceptsChange(ChangeMode mode) {
-        return null;
+    default Optional<Class<?>[]> acceptsChange(ChangeMode mode) {
+        return Optional.empty();
     }
 
     /**
@@ -63,15 +63,14 @@ public interface Expression<T> extends SyntaxElement {
      * @return the single value of this Expression, or {@code null} if it has no value
      * @throws SkriptRuntimeException if the expression returns more than one value
      */
-    @Nullable
-    default T getSingle(TriggerContext e) {
-        T[] values = getValues(e);
+    default Optional<? extends T> getSingle(TriggerContext e) {
+        var values = getValues(e);
         if (values.length == 0) {
-            return null;
+            return Optional.empty();
         } else if (values.length > 1) {
             throw new SkriptRuntimeException("Can't call getSingle on an expression that returns multiple values !");
         } else {
-            return values[0];
+            return Optional.ofNullable(values[0]);
         }
     }
 
@@ -80,7 +79,7 @@ public interface Expression<T> extends SyntaxElement {
      * be overriden.
      */
     default boolean isSingle() {
-        for (ExpressionInfo<?, ?> info : SyntaxManager.getAllExpressions()) {
+        for (var info : SyntaxManager.getAllExpressions()) {
             if (info.getSyntaxClass() == getClass()) {
                 return info.getReturnType().isSingle();
             }
@@ -114,8 +113,7 @@ public interface Expression<T> extends SyntaxElement {
      * @param <C> the type to convert this Expression to
      * @return a converted Expression, or {@code null} if it couldn't be converted
      */
-    @Nullable
-    default <C> Expression<C> convertExpression(Class<C> to) {
+    default <C> Optional<? extends Expression<C>> convertExpression(Class<C> to) {
         return ConvertedExpression.newInstance(this, to);
     }
 
@@ -181,12 +179,12 @@ public interface Expression<T> extends SyntaxElement {
      * @return whether the elements match the given predicate
      */
     static <T> boolean check(T[] all, Predicate<? super T> predicate, boolean invert, boolean and) {
-        boolean hasElement = false;
-        for (T t : all) {
+        var hasElement = false;
+        for (var t : all) {
             if (t == null)
                 continue;
             hasElement = true;
-            boolean b = predicate.test(t);
+            var b = predicate.test(t);
             if (and && !b)
                 return invert;
             if (!and && b)

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
@@ -10,8 +10,6 @@ import io.github.syst3ms.skriptparser.registration.ExpressionInfo;
 import io.github.syst3ms.skriptparser.registration.SyntaxManager;
 import io.github.syst3ms.skriptparser.types.conversions.Converters;
 import io.github.syst3ms.skriptparser.util.CollectionUtils;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Iterator;
 import java.util.Optional;

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/ExpressionList.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/ExpressionList.java
@@ -25,8 +25,7 @@ public class ExpressionList<T> implements Expression<T> {
     }
 
     protected ExpressionList(@Nullable Expression<? extends T>[] expressions, Class<T> returnType, boolean and, @Nullable ExpressionList<?> source) {
-        assert expressions != null
-               && expressions.length > 1;
+        assert expressions != null && expressions.length > 1;
         this.expressions = expressions;
         this.returnType = returnType;
         this.and = and;

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/ExpressionList.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/ExpressionList.java
@@ -33,7 +33,7 @@ public class ExpressionList<T> implements Expression<T> {
         if (and) {
             single = false;
         } else {
-            boolean single = true;
+            var single = true;
             for (Expression<?> e : expressions) {
                 assert e != null;
                 if (!e.isSingle()) {
@@ -61,10 +61,10 @@ public class ExpressionList<T> implements Expression<T> {
         if (and) {
             return getValues(e);
         } else {
-            List<Expression<? extends T>> shuffle = Arrays.asList(expressions);
+            var shuffle = Arrays.asList(expressions);
             Collections.shuffle(shuffle);
-            for (Expression<? extends T> expr : shuffle) {
-                T[] values = expr.getValues(e);
+            for (var expr : shuffle) {
+                var values = expr.getValues(e);
                 if (values.length > 0)
                     return values;
             }
@@ -75,7 +75,7 @@ public class ExpressionList<T> implements Expression<T> {
     @Override
     public T[] getValues(TriggerContext ctx) {
         List<T> values = new ArrayList<>();
-        for (Expression<? extends T> expression : expressions) {
+        for (var expression : expressions) {
             Collections.addAll(values, expression.getValues(ctx));
         }
         return values.toArray((T[]) Array.newInstance(returnType, values.size()));
@@ -83,8 +83,8 @@ public class ExpressionList<T> implements Expression<T> {
 
     @Override
     public String toString(@Nullable TriggerContext ctx, boolean debug) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < expressions.length; i++) {
+        var sb = new StringBuilder();
+        for (var i = 0; i < expressions.length; i++) {
             if (i > 0) {
                 if (i == expressions.length - 1) {
                     sb.append(and ? " and " : " or ");
@@ -92,20 +92,19 @@ public class ExpressionList<T> implements Expression<T> {
                     sb.append(", ");
                 }
             }
-            Expression<? extends T> expr = expressions[i];
+            var expr = expressions[i];
             sb.append(expr.toString(ctx, debug));
         }
         return sb.toString();
     }
 
-    @Nullable
     @Override
-    public <R> Expression<R> convertExpression(Class<R> to) {
+    public <R> Optional<? extends Expression<R>> convertExpression(Class<R> to) {
         Expression<? extends R>[] exprs = new Expression[expressions.length];
-        for (int i = 0; i < exprs.length; i++)
-            if ((exprs[i] = expressions[i].convertExpression(to)) == null)
-                return null;
-        return new ExpressionList<>(exprs, (Class<R>) ClassUtils.getCommonSuperclass(to), and, this);
+        for (var i = 0; i < exprs.length; i++)
+            if ((exprs[i] = expressions[i].convertExpression(to).orElse(null)) == null)
+                return Optional.empty();
+        return Optional.of(new ExpressionList<>(exprs, (Class<R>) ClassUtils.getCommonSuperclass(to), and, this));
     }
 
     @Override
@@ -119,10 +118,10 @@ public class ExpressionList<T> implements Expression<T> {
     @Override
     public Iterator<? extends T> iterator(TriggerContext ctx) {
         if (!and) {
-            List<Expression<? extends T>> shuffle = Arrays.asList(expressions);
+            var shuffle = Arrays.asList(expressions);
             Collections.shuffle(shuffle);
-            for (Expression<? extends T> expression : shuffle) {
-                Iterator<? extends T> it = expression.iterator(ctx);
+            for (var expression : shuffle) {
+                var it = expression.iterator(ctx);
                 if (it.hasNext())
                     return it;
             }
@@ -135,7 +134,7 @@ public class ExpressionList<T> implements Expression<T> {
 
             @Override
             public boolean hasNext() {
-                Iterator<? extends T> c = current;
+                var c = current;
                 while (i < expressions.length && (c == null || !c.hasNext()))
                     current = c = expressions[i++].iterator(ctx);
                 return c != null && c.hasNext();
@@ -145,7 +144,7 @@ public class ExpressionList<T> implements Expression<T> {
             public T next() {
                 if (!hasNext())
                     throw new NoSuchElementException();
-                Iterator<? extends T> c = current;
+                var c = current;
                 if (c == null)
                     throw new NoSuchElementException();
                 return c.next();

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/ExpressionList.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/ExpressionList.java
@@ -127,7 +127,7 @@ public class ExpressionList<T> implements Expression<T> {
             }
             return Collections.emptyIterator();
         }
-        return new Iterator<T>() {
+        return new Iterator<>() {
             private int i = 0;
             @Nullable
             private Iterator<? extends T> current = null;

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/InlineCondition.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/InlineCondition.java
@@ -4,6 +4,8 @@ import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * A condition that is executed as a single line.
  * Useful to make quick assertions without having to make sections for each one.
@@ -24,8 +26,7 @@ public class InlineCondition extends Statement {
 
     @Override
     public boolean run(TriggerContext ctx) {
-        Boolean cond = condition.getSingle(ctx);
-        return cond != null && cond;
+        return condition.getSingle(ctx).filter(b -> b).isPresent();
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/InlineCondition.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/InlineCondition.java
@@ -4,8 +4,6 @@ import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Optional;
-
 /**
  * A condition that is executed as a single line.
  * Useful to make quick assertions without having to make sections for each one.

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Literal.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Literal.java
@@ -1,7 +1,5 @@
 package io.github.syst3ms.skriptparser.lang;
 
-import org.jetbrains.annotations.Nullable;
-
 import java.util.Optional;
 
 /**

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Literal.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Literal.java
@@ -2,6 +2,8 @@ package io.github.syst3ms.skriptparser.lang;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * An expression whose value is known at parse time
  * @param <T> the type of the literal
@@ -9,8 +11,7 @@ import org.jetbrains.annotations.Nullable;
 public interface Literal<T> extends Expression<T> {
     T[] getValues();
 
-    @Nullable
-    default T getSingle() {
+    default Optional<? extends T> getSingle() {
         return getSingle(TriggerContext.DUMMY);
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/LiteralList.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/LiteralList.java
@@ -1,7 +1,8 @@
 package io.github.syst3ms.skriptparser.lang;
 
 import io.github.syst3ms.skriptparser.util.ClassUtils;
-import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 /**
  * A list of literals, whose values are known at parse time
@@ -23,23 +24,22 @@ public class LiteralList<T> extends ExpressionList<T> implements Literal<T> {
         return getValues(TriggerContext.DUMMY);
     }
 
-    @Nullable
     @Override
-    public T getSingle() {
+    public Optional<? extends T> getSingle() {
         return getSingle(TriggerContext.DUMMY);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <R> Expression<R> convertExpression(Class<R> to) {
+    public <R> Optional<? extends Expression<R>> convertExpression(Class<R> to) {
         Literal<? extends R>[] exprs = new Literal[expressions.length];
         Class<?>[] classes = new Class[expressions.length];
-        for (int i = 0; i < exprs.length; i++) {
-            if ((exprs[i] = (Literal<? extends R>) expressions[i].convertExpression(to)) == null)
-                return null;
+        for (var i = 0; i < exprs.length; i++) {
+            if ((exprs[i] = (Literal<? extends R>) expressions[i].convertExpression(to).orElse(null)) == null)
+                return Optional.empty();
             classes[i] = exprs[i].getReturnType();
         }
-        return new LiteralList<>(exprs, (Class<R>) ClassUtils.getCommonSuperclass(classes), and, this);
+        return Optional.of(new LiteralList<>(exprs, (Class<R>) ClassUtils.getCommonSuperclass(classes), and, this));
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/SimpleLiteral.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/SimpleLiteral.java
@@ -50,7 +50,6 @@ public class SimpleLiteral<T> implements Literal<T> {
         }
     }
 
-    @SuppressWarnings("RedundantCast")
     @Override
     public String toString(@Nullable TriggerContext ctx, boolean debug) {
         if (isSingle()) {

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/SimpleLiteral.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/SimpleLiteral.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Array;
 import java.util.Iterator;
+import java.util.Optional;
 
 /**
  * A simple literal with a fixed set of values
@@ -43,7 +44,7 @@ public class SimpleLiteral<T> implements Literal<T> {
         if (isAndList) {
             return values;
         } else {
-            T[] copy = (T[]) Array.newInstance(getReturnType(), 1);
+            var copy = (T[]) Array.newInstance(getReturnType(), 1);
             copy[0] = CollectionUtils.getRandom(values);
             return copy;
         }
@@ -65,10 +66,11 @@ public class SimpleLiteral<T> implements Literal<T> {
     }
 
     public Class<? extends T> getReturnType() {
-        if (returnType == null)
-            return (returnType = (Class<T>) values.getClass().getComponentType());
-        else
+        if (returnType != null) {
             return returnType;
+        } else {
+            return (returnType = (Class<T>) values.getClass().getComponentType());
+        }
     }
 
     @Override
@@ -86,21 +88,21 @@ public class SimpleLiteral<T> implements Literal<T> {
         if (isAndList) {
             return values;
         } else {
-            T[] newArray = (T[]) Array.newInstance(getReturnType(), 1);
+            var newArray = (T[]) Array.newInstance(getReturnType(), 1);
             newArray[0] = CollectionUtils.getRandom(values);
             return newArray;
         }
     }
 
     @Override
-    public <R> Expression<R> convertExpression(Class<R> to) {
+    public <R> Optional<? extends Expression<R>> convertExpression(Class<R> to) {
         if (to.isAssignableFrom(getReturnType()))
-            return (SimpleLiteral<R>) this;
-        Class<R> superType = (Class<R>) ClassUtils.getCommonSuperclass(to);
-        R[] converted = Converters.convertArray(values, to, superType);
+            return Optional.of((SimpleLiteral<R>) this);
+        var superType = (Class<R>) ClassUtils.getCommonSuperclass(to);
+        var converted = Converters.convertArray(values, to, superType);
         if (converted.length != values.length)
-            return null;
-        return new SimpleLiteral<>(superType, converted);
+            return Optional.empty();
+        return Optional.of(new SimpleLiteral<>(superType, converted));
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/SkriptEvent.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/SkriptEvent.java
@@ -23,6 +23,7 @@ import java.util.List;
  * </ul>
  */
 public abstract class SkriptEvent implements SyntaxElement {
+
     /**
      * Whether this event should trigger, given the {@link TriggerContext}
      * @param ctx the TriggerContext to check

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Statement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Statement.java
@@ -2,6 +2,8 @@ package io.github.syst3ms.skriptparser.lang;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * The base class for any runnable line of code inside of a script.
  * @see CodeSection
@@ -20,10 +22,10 @@ public abstract class Statement implements SyntaxElement {
      * @return {@code true} if the code ran normally, and {@code false} if any exception occurred
      */
     public static boolean runAll(Statement start, TriggerContext context) {
-        Statement item = start;
+        Optional<? extends Statement> item = Optional.of(start);
         try {
-            while (item != null)
-                item = item.walk(context);
+            while (item.isPresent())
+                item = item.flatMap(i -> i.walk(context));
             return true;
         } catch (StackOverflowError so) {
             System.err.println("The script repeated itself infinitely !");
@@ -63,14 +65,13 @@ public abstract class Statement implements SyntaxElement {
      * @return the Statement after this one in the file. If this Statement is the last item of the section, returns the item after
      *         said section. If this Statement is the very last item of a trigger, returns {@code null}
      */
-    @Nullable
-    public final Statement getNext() {
+    public final Optional<? extends Statement> getNext() {
         if (next != null) {
-            return next;
+            return Optional.of(next);
         } else if (parent != null) {
             return parent.getNext();
         } else {
-            return null;
+            return Optional.empty();
         }
     }
 
@@ -90,14 +91,14 @@ public abstract class Statement implements SyntaxElement {
      * @param ctx the event
      * @return the next item to be ran, or {@code null} if this is the last item to be executed
      */
-    public Statement walk(TriggerContext ctx) {
-        boolean proceed = run(ctx);
+    public Optional<? extends Statement> walk(TriggerContext ctx) {
+        var proceed = run(ctx);
         if (proceed) {
-            return getNext();   
+            return getNext();
         } else if (parent != null) {
             return parent.getNext();
         } else {
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Statement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Statement.java
@@ -46,9 +46,8 @@ public abstract class Statement implements SyntaxElement {
     /**
      * @return the parent of this Statement
      */
-    @Nullable
-    public CodeSection getParent() {
-        return parent;
+    public Optional<? extends CodeSection> getParent() {
+        return Optional.ofNullable(parent);
     }
 
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/SyntaxElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/SyntaxElement.java
@@ -52,11 +52,11 @@ public interface SyntaxElement {
      */
     @SafeVarargs
     static boolean checkIsInSection(ParseContext parseContext, boolean isStrict, Class<? extends CodeSection>... requiredSections) {
-        List<CodeSection> currentSections = parseContext.getParserState().getCurrentSections();
-        List<Class<? extends CodeSection>> sections = Arrays.asList(requiredSections);
-        int limit = isStrict ? 1 : currentSections.size();
-        for (int i = 0; i < limit; i++) {
-            CodeSection sec = currentSections.get(i);
+        var currentSections = parseContext.getParserState().getCurrentSections();
+        var sections = Arrays.asList(requiredSections);
+        var limit = isStrict ? 1 : currentSections.size();
+        for (var i = 0; i < limit; i++) {
+            var sec = currentSections.get(i);
             if (sections.contains(sec.getClass())) {
                 return true;
             }

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/SyntaxElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/SyntaxElement.java
@@ -8,7 +8,6 @@ import io.github.syst3ms.skriptparser.registration.SkriptRegistration;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
-import java.util.List;
 
 /**
  * The base class for all elements that are described by a syntax

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Trigger.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Trigger.java
@@ -6,6 +6,8 @@ import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.parsing.ParserState;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * A top-level section, that is not contained in code.
  * Usually declares an event.
@@ -32,8 +34,8 @@ public class Trigger extends CodeSection {
     }
 
     @Override
-    public Statement walk(TriggerContext ctx) {
-        return event.check(ctx) ? getFirst() : null;
+    public Optional<? extends Statement> walk(TriggerContext ctx) {
+        return getFirst().filter(__ -> event.check(ctx));
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Variable.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Variable.java
@@ -45,9 +45,9 @@ public class Variable<T> implements Expression<T> {
             return Optional.empty();
         return Variables.getVariable(n, ctx, local)
                 .or(() -> Variables.getVariable(
-                            (local ? Variables.LOCAL_VARIABLE_TOKEN : "") + name.defaultVariableName(),
-                            ctx,
-                            false
+                        (local ? Variables.LOCAL_VARIABLE_TOKEN : "") + name.defaultVariableName(),
+                        ctx,
+                        false
                     )
                 );
     }
@@ -77,8 +77,9 @@ public class Variable<T> implements Expression<T> {
         if(list)
             return getConvertedArray(ctx);
         Optional<? extends T> o = getConverted(ctx);
-        if (o.isEmpty())
+        if (o.isEmpty()) {
             return (T[]) Array.newInstance(supertype, 0);
+        }
         var one = (T[]) Array.newInstance(supertype, 1);
         one[0] = o.get();
         return one;
@@ -406,7 +407,7 @@ public class Variable<T> implements Expression<T> {
                         ((Changer<Object>) changer.get()).change(one, l.toArray(), mode);
                     }
                     break;
-                }
+            }
         }
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Variable.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Variable.java
@@ -39,25 +39,27 @@ public class Variable<T> implements Expression<T> {
         this.supertype = ClassUtils.getCommonSuperclass(this.type);
     }
 
-    public Object getRaw(TriggerContext ctx) {
-        String n = name.toString(ctx);
+    public Optional<Object> getRaw(TriggerContext ctx) {
+        var n = name.toString(ctx);
         if (n.endsWith(Variables.LIST_SEPARATOR + "*") != list) // prevents e.g. {%expr%} where "%expr%" ends with "::*" from returning a Map
-            return null;
-        Object val = Variables.getVariable(n, ctx, local);
-        if (val == null)
-            return Variables.getVariable((local ? Variables.LOCAL_VARIABLE_TOKEN : "") + name.defaultVariableName(),
-                    ctx, false);
-        return val;
+            return Optional.empty();
+        return Variables.getVariable(n, ctx, local)
+                .or(() -> Variables.getVariable(
+                            (local ? Variables.LOCAL_VARIABLE_TOKEN : "") + name.defaultVariableName(),
+                            ctx,
+                            false
+                    )
+                );
     }
 
-    private Object get(TriggerContext ctx) {
-        Object val = getRaw(ctx);
+    private Optional<Object> get(TriggerContext ctx) {
+        var val = getRaw(ctx);
         if (!list)
             return val;
-        if (val == null)
-            return Array.newInstance(type, 0);
+        if (val.isEmpty())
+            return Optional.of(Array.newInstance(type, 0));
         List<Object> l = new ArrayList<>();
-        for (Map.Entry<String, ?> v : ((Map<String, ?>) val).entrySet()) {
+        for (Map.Entry<String, ?> v : ((Map<String, ?>) val.get()).entrySet()) {
             if (v.getKey() != null && v.getValue() != null) {
                 Object o;
                 if (v.getValue() instanceof Map)
@@ -67,28 +69,28 @@ public class Variable<T> implements Expression<T> {
                 l.add(o);
             }
         }
-        return l.toArray();
+        return Optional.ofNullable(l.toArray());
     }
 
     @Override
     public T[] getValues(TriggerContext ctx) {
         if(list)
             return getConvertedArray(ctx);
-        T o = getConverted(ctx);
-        if (o == null) {
+        Optional<? extends T> o = getConverted(ctx);
+        if (o.isEmpty())
             return (T[]) Array.newInstance(supertype, 0);
-        }
-        T[] one = (T[]) Array.newInstance(supertype, 1);
-        one[0] = o;
+        var one = (T[]) Array.newInstance(supertype, 1);
+        one[0] = o.get();
         return one;
     }
 
-    private T getConverted(TriggerContext ctx) {
-        return (T) Converters.convert(get(ctx), type);
+    private Optional<? extends T> getConverted(TriggerContext ctx) {
+        return (Optional<? extends T>) Converters.convert(get(ctx).orElse(null), type);
     }
 
+    @SuppressWarnings("ConstantConditions")
     private T[] getConvertedArray(TriggerContext ctx) {
-        return Converters.convertArray((Object[]) get(ctx), (Class<T>) type, (Class<T>) supertype);
+        return Converters.convertArray((Object[]) get(ctx).orElse(null), (Class<T>) type, (Class<T>) supertype);
     }
 
     @Override
@@ -113,15 +115,15 @@ public class Variable<T> implements Expression<T> {
     public Iterator<T> iterator(TriggerContext ctx) {
         if (!list)
             throw new SkriptRuntimeException("");
-        String n = this.name.toString(ctx);
-        String name = n.substring(0, n.length() - 1);
-        Object val = Variables.getVariable(name + "*", ctx, local);
-        if (val == null)
+        var n = this.name.toString(ctx);
+        var name = n.substring(0, n.length() - 1);
+        var val = Variables.getVariable(name + "*", ctx, local);
+        if (val.isEmpty())
             return Collections.emptyIterator();
-        assert val instanceof TreeMap;
+        assert val.get() instanceof TreeMap;
         // temporary list to prevent CMEs
-        Iterator<String> keys = new ArrayList<>(((Map<String, Object>) val).keySet()).iterator();
-        return new Iterator<T>() {
+        var keys = new ArrayList<>(((Map<String, Object>) val.get()).keySet()).iterator();
+        return new Iterator<>() {
             @Nullable
             private String key;
             @Nullable
@@ -134,7 +136,7 @@ public class Variable<T> implements Expression<T> {
                 while (keys.hasNext()) {
                     key = keys.next();
                     if (key != null) {
-                        next = (T) Converters.convert(Variables.getVariable(name + key, ctx, local), type);
+                        next = (T) Converters.convert(Variables.getVariable(name + key, ctx, local), type).orElse(null);
                         if (next != null && !(next instanceof TreeMap))
                             return true;
                     }
@@ -147,7 +149,7 @@ public class Variable<T> implements Expression<T> {
             public T next() {
                 if (!hasNext())
                     throw new NoSuchElementException();
-                T n = next;
+                var n = next;
                 assert n != null;
                 next = null;
                 return n;
@@ -167,15 +169,16 @@ public class Variable<T> implements Expression<T> {
     public Iterator<Pair<String, Object>> variablesIterator(TriggerContext ctx) {
         if (!list)
             throw new SkriptRuntimeException("Looping a non-list variable");
-        String n = this.name.toString(ctx);
-        String name = n.substring(0, n.length() - 1);
-        Object val = Variables.getVariable(name + "*", ctx, local);
-        if (val == null)
+        var n = this.name.toString(ctx);
+        var name = n.substring(0, n.length() - 1);
+        var val = Variables.getVariable(name + "*", ctx, local);
+        if (val.isEmpty())
             return Collections.emptyIterator();
-        assert val instanceof TreeMap;
+        assert val.get() instanceof TreeMap;
         // temporary list to prevent CMEs
-        Iterator<String> keys = new ArrayList<>(((Map<String, Object>) val).keySet()).iterator();
-        return new Iterator<Pair<String, Object>>() {
+        @SuppressWarnings("unchecked")
+        var keys = new ArrayList<>(((Map<String, Object>) val.get()).keySet()).iterator();
+        return new Iterator<>() {
             @Nullable
             private String key;
             @Nullable
@@ -188,7 +191,7 @@ public class Variable<T> implements Expression<T> {
                 while (keys.hasNext()) {
                     key = keys.next();
                     if (key != null) {
-                        next = Variables.getVariable(name + key, ctx, local) ;
+                        next = Variables.getVariable(name + key, ctx, local).orElse(null);
                         if (next != null && !(next instanceof TreeMap))
                             return true;
                     }
@@ -201,7 +204,8 @@ public class Variable<T> implements Expression<T> {
             public Pair<String, Object> next() {
                 if (!hasNext())
                     throw new NoSuchElementException();
-                Pair<String, Object> n = new Pair<>(key, next);
+                assert next != null && key != null;
+                var n = new Pair<>(key, next);
                 next = null;
                 return n;
             }
@@ -217,7 +221,7 @@ public class Variable<T> implements Expression<T> {
     public String toString(@Nullable TriggerContext ctx, boolean debug) {
         if (ctx != null)
             return TypeManager.toString((Object[]) getValues(ctx));
-        String name = this.name.toString(null, debug);
+        var name = this.name.toString(null, debug);
         return "{" + (local ? Variables.LOCAL_VARIABLE_TOKEN : "") + name.substring(1, name.length() - 1) + "}" + (debug ? "(as " + supertype.getSimpleName() + ")" : "");
     }
 
@@ -225,10 +229,9 @@ public class Variable<T> implements Expression<T> {
         return (Class<? extends T>) supertype;
     }
 
-    @Nullable
     @Override
-    public <C> Expression<C> convertExpression(Class<C> to) {
-        return new Variable<>(name, local, list, to);
+    public <C> Optional<? extends Expression<C>> convertExpression(Class<C> to) {
+        return Optional.of(new Variable<>(name, local, list, to));
     }
 
     private void set(TriggerContext ctx, @Nullable Object value) {
@@ -237,16 +240,14 @@ public class Variable<T> implements Expression<T> {
 
     private void setIndex(TriggerContext ctx, String index, @Nullable Object value) {
         assert list;
-        String s = name.toString(ctx);
+        var s = name.toString(ctx);
         assert s.endsWith("::*") : s + "; " + name;
         Variables.setVariable(s.substring(0, s.length() - 1) + index, value, ctx, local);
     }
 
     @Override
-    public Class<?>[] acceptsChange(ChangeMode mode) {
-        if (!list && mode == ChangeMode.SET)
-            return new Class[]{Object[].class};
-        return new Class[]{Object[].class};
+    public Optional<Class<?>[]> acceptsChange(ChangeMode mode) {
+        return Optional.of(new Class[]{Object[].class});
     }
 
     @SuppressWarnings("rawtypes")
@@ -255,31 +256,30 @@ public class Variable<T> implements Expression<T> {
         switch (mode) {
             case DELETE:
                 if (list) {
-                    ArrayList<String> rem = new ArrayList<>();
-                    Map<String, Object> o = (Map<String, Object>) getRaw(ctx);
+                    var rem = new ArrayList<String>();
+                    var o = (Map<String, Object>) getRaw(ctx).orElseThrow(AssertionError::new);
                     if (o == null)
                         return;
-                    for (Map.Entry<String, Object> i : o.entrySet()) {
+                    for (var i : o.entrySet()) {
                         if (i.getKey() != null){
                             rem.add(i.getKey());
                         }
                     }
-                    for (String r : rem) {
+                    for (var r : rem) {
                         assert r != null;
                         setIndex(ctx, r, null);
                     }
                 }
-
                 set(ctx, null);
                 break;
             case SET:
                 assert changeWith.length > 0;
                 if (list) {
                     set(ctx, null);
-                    int i = 1;
-                    for (Object d : changeWith) {
+                    var i = 1;
+                    for (var d : changeWith) {
                         if (d instanceof Object[]) {
-                            for (int j = 0; j < ((Object[]) d).length; j++)
+                            for (var j = 0; j < ((Object[]) d).length; j++)
                                 setIndex(ctx, i + Variables.LIST_SEPARATOR + j, ((Object[]) d)[j]);
                         } else {
                             setIndex(ctx, String.valueOf(i), d);
@@ -291,18 +291,21 @@ public class Variable<T> implements Expression<T> {
                 }
                 break;
             case RESET:
-                Object x = getRaw(ctx);
-                if (x == null)
+                Optional<? extends Collection<?>> x = getRaw(ctx).map(r -> r instanceof Map
+                        ? ((Map<?, ?>) r).values()
+                        : Collections.singletonList(r)
+                );
+                if (x.isEmpty())
                     return;
-                for (Object o : x instanceof Map ? ((Map<?, ?>) x).values() : Collections.singletonList(x)) {
-                    Class<?> c = o.getClass();
-                    Type<?> type = TypeManager.getByClass(c);
-                    assert type != null;
-                    Changer<?> changer = type.getDefaultChanger();
-                    if (changer != null && changer.acceptsChange(ChangeMode.RESET) != null) {
-                        Object[] one = (Object[]) Array.newInstance(o.getClass(), 1);
+                for (Object o : x.get()) {
+                    var c = o.getClass();
+                    var type = TypeManager.getByClass(c);
+                    assert type.isPresent();
+                    var changer = type.get().getDefaultChanger();
+                    if (changer.map(ch -> ch.acceptsChange(ChangeMode.RESET)).isPresent()) {
+                        var one = (Object[]) Array.newInstance(o.getClass(), 1);
                         one[0] = o;
-                        ((Changer) changer).change(one, new Object[0], ChangeMode.RESET);
+                        changer.ifPresent(ch -> ((Changer) ch).change(one, new Object[0], ChangeMode.RESET));
                     }
                 }
                 break;
@@ -311,100 +314,99 @@ public class Variable<T> implements Expression<T> {
             case REMOVE_ALL:
                 assert changeWith.length > 0;
                 if (list) {
-                    Map<String, Object> o = (Map<String, Object>) getRaw(ctx);
+                    Optional<? extends Map<String, Object>> o = getRaw(ctx).map(r -> (Map<String, Object>) r);
                     if (mode == ChangeMode.REMOVE) {
-                        if (o == null)
+                        if (o.isEmpty())
                             return;
-                        ArrayList<String> rem = new ArrayList<>(); // prevents CMEs
-                        for (Object d : changeWith) {
-                            for (Map.Entry<String, Object> i : o.entrySet()) {
+                        var rem = new ArrayList<String>(); // prevents CMEs
+                        for (var d : changeWith) {
+                            for (var i : o.get().entrySet()) {
                                 if (Relation.EQUAL.is(Comparators.compare(i.getValue(), d))) {
                                     rem.add(i.getKey());
                                     break;
                                 }
                             }
                         }
-                        for (String r : rem) {
+                        for (var r : rem) {
                             assert r != null;
                             setIndex(ctx, r, null);
                         }
                     } else if (mode == ChangeMode.REMOVE_ALL) {
-                        if (o == null)
+                        if (o.isEmpty())
                             return;
-                        ArrayList<String> rem = new ArrayList<>(); // prevents CMEs
-                        for (Map.Entry<String, Object> i : o.entrySet()) {
-                            for (Object d : changeWith) {
+                        var rem = new ArrayList<String>(); // prevents CMEs
+                        for (var i : o.get().entrySet()) {
+                            for (var d : changeWith) {
                                 if (Relation.EQUAL.is(Comparators.compare(i.getValue(), d)))
                                     rem.add(i.getKey());
                             }
                         }
-                        for (String r : rem) {
+                        for (var r : rem) {
                             assert r != null;
                             setIndex(ctx, r, null);
                         }
                     } else {
                         assert mode == ChangeMode.ADD;
-                        int i = 1;
-                        for (Object d : changeWith) {
-                            if (o != null)
-                                while (o.containsKey(String.valueOf(i)))
+                        var i = 1;
+                        for (var d : changeWith) {
+                            if (o.isPresent())
+                                while (o.get().containsKey(String.valueOf(i)))
                                     i++;
                             setIndex(ctx, String.valueOf(i), d);
                             i++;
                         }
                     }
                 } else {
-                    Object o = get(ctx);
-                    Type<?> type;
-                    if (o == null) {
-                        type = null;
-                    } else {
-                        type = TypeManager.getByClass(o.getClass());
-                    }
-                    Arithmetic a = null;
-                    Changer<?> changer;
+                    Optional<?> o = get(ctx);
+                    var type = o.flatMap(ob -> (Optional<? extends Type<?>>) TypeManager.getByClass(ob.getClass()));
+                    Optional<? extends Arithmetic> a = Optional.empty();
+                    Optional<? extends Changer<?>> changer;
                     Class<?>[] cs;
-                    if (o == null || type == null || (a = type.getArithmetic()) != null) {
-                        boolean changed = false;
-                        for (Object d : changeWith) {
-                            if (o == null || type == null) {
+                    if (o.isEmpty() || type.isEmpty() || (a = type.get().getArithmetic()).isPresent()) {
+                        var changed = false;
+                        for (var d : changeWith) {
+                            if (o.isEmpty() || type.isEmpty()) {
                                 type = TypeManager.getByClass(d.getClass());
                                 //Mirre Start
-                                if (type != null && type.getArithmetic() != null || d instanceof Number)
-                                    o = d;
+                                if (type.isPresent() && type.get().getArithmetic().isPresent() || d instanceof Number)
+                                    o = o.map(__ -> d);
                                 //Mirre End
                                 changed = true;
                                 continue;
                             }
-                            assert a != null;
-                            Class<?> r = a.getRelativeType();
-                            Object diff = Converters.convert(d, r);
-                            if (diff != null) {
-                                if (mode == ChangeMode.ADD)
-                                    o = a.add(o, diff);
-                                else
-                                    o = a.subtract(o, diff);
+                            assert a.isPresent();
+                            Class<?> r = a.get().getRelativeType();
+                            var diff = Converters.convert(d, r);
+                            if (diff.isPresent()) {
+                                var finalA = a;
+                                o = o.map(ob -> {
+                                    if (mode == ChangeMode.ADD) {
+                                        return finalA.get().add(ob, diff.get());
+                                    } else {
+                                        return finalA.get().subtract(ob, diff.get());
+                                    }
+                                });
                                 changed = true;
                             }
                         }
                         if (changed)
                             set(ctx, o);
-                    } else if ((changer = type.getDefaultChanger()) != null && (cs = changer.acceptsChange(mode)) != null) {
-                        Object[] one = (Object[]) Array.newInstance(o.getClass(), 1);
+                    } else if ((changer = type.get().getDefaultChanger()).isPresent() && (cs = changer.get().acceptsChange(mode)) != null) {
+                        var one = (Object[]) Array.newInstance(o.getClass(), 1);
                         one[0] = o;
-                        Class<?>[] cs2 = new Class<?>[cs.length];
-                        for (int i = 0; i < cs.length; i++)
+                        var cs2 = new Class<?>[cs.length];
+                        for (var i = 0; i < cs.length; i++)
                             cs2[i] = cs[i].isArray() ? cs[i].getComponentType() : cs[i];
-                        ArrayList<Object> l = new ArrayList<>();
-                        for (Object d : changeWith) {
+                        var l = new ArrayList<>();
+                        for (var d : changeWith) {
                             Object d2 = Converters.convert(d, cs2);
                             if (d2 != null)
                                 l.add(d2);
                         }
-                        ((Changer<Object>) changer).change(one, l.toArray(), mode);
+                        ((Changer<Object>) changer.get()).change(one, l.toArray(), mode);
+                    }
+                    break;
                 }
-                break;
-            }
         }
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -34,6 +35,7 @@ public class VariableString implements Expression<String> {
         this.simple = data.length == 1 && data[0] instanceof String;
     }
 
+
     /**
      * Creates a new instance of a VariableString.
      * @param s the text to create a new instance from, with its surrounding quotes
@@ -47,24 +49,23 @@ public class VariableString implements Expression<String> {
      *     </li>
      * </ul>. Returns a new instance of a VariableString otherwise.
      */
-    @Nullable
-    public static VariableString newInstanceWithQuotes(String s, ParserState parserState, SkriptLogger logger) {
+    public static Optional<VariableString> newInstanceWithQuotes(String s, ParserState parserState, SkriptLogger logger) {
         if (s.startsWith("\"") && s.endsWith("\"") && StringUtils.nextSimpleCharacterIndex(s, 0) == s.length()) {
             return newInstance(s.substring(1, s.length() - 1), parserState, logger);
         } else if (s.startsWith("'") && s.endsWith("'") && StringUtils.nextSimpleCharacterIndex(s, 0) == s.length()) {
-            return new VariableString(new String[]{
-                s.substring(1, s.length() - 1).replace("\\'", "'")
-            });
+            return Optional.of(new VariableString(new String[]{
+                    s.substring(1, s.length() - 1).replace("\\'", "'")
+            }));
         } else if (s.startsWith("R\"") && s.endsWith("\"")) {
-            String content = s.substring(2, s.length() - 1);
-            Matcher m = R_LITERAL_CONTENT_PATTERN.matcher(content);
+            var content = s.substring(2, s.length() - 1);
+            var m = R_LITERAL_CONTENT_PATTERN.matcher(content);
             if (m.matches()) {
-                return new VariableString(new String[]{m.group(2)});
+                return Optional.of(new VariableString(new String[]{m.group(2)}));
             } else {
                 logger.error("Invalid R literal string", ErrorType.MALFORMED_INPUT);
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     /**
@@ -74,36 +75,34 @@ public class VariableString implements Expression<String> {
      * @param logger
      * @return a new instance of a VariableString, or {@code null} if there are unbalanced {@literal %} symbols
      */
-    public static VariableString newInstance(String s, ParserState parserState, SkriptLogger logger) {
+    public static Optional<VariableString> newInstance(String s, ParserState parserState, SkriptLogger logger) {
         List<Object> data = new ArrayList<>(StringUtils.count(s, "%"));
-        StringBuilder sb = new StringBuilder();
-        char[] charArray = s.toCharArray();
-        for (int i = 0; i < charArray.length; i++) {
-            char c = charArray[i];
+        var sb = new StringBuilder();
+        var charArray = s.toCharArray();
+        for (var i = 0; i < charArray.length; i++) {
+            var c = charArray[i];
             if (c == '%') {
                 if (i == charArray.length - 1) {
-                    return null;
+                    return Optional.empty();
                 }
-                String content = StringUtils.getPercentContent(s, i + 1);
-                if (content == null) {
-                    return null;
-                }
-                String toParse = content.replaceAll("\\\\(.)", "$1");
+                var content = StringUtils.getPercentContent(s, i + 1);
+                var toParse = content.map(co -> co.replaceAll("\\\\(.)", "$1"));
+                if (toParse.isEmpty())
+                    return Optional.empty();
                 logger.recurse();
-                Expression<?> expression = SyntaxParser.parseExpression(toParse, SyntaxParser.OBJECTS_PATTERN_TYPE, parserState, logger);
+                var expression = SyntaxParser.parseExpression(toParse.get(), SyntaxParser.OBJECTS_PATTERN_TYPE, parserState, logger);
                 logger.callback();
-                if (expression == null) {
-                    return null;
-                }
+                if (expression.isEmpty())
+                    return Optional.empty();
                 if (sb.length() > 0) {
                     data.add(sb.toString());
                     sb.setLength(0);
                 }
-                data.add(expression);
-                i += content.length() + 1;
+                data.add(expression.get());
+                i += content.get().length() + 1;
             } else if (c == '\\') {
                 if (i + 1 == charArray.length) {
-                    return null;
+                    return Optional.empty();
                 }
                 sb.append(charArray[++i]);
             } else {
@@ -113,7 +112,7 @@ public class VariableString implements Expression<String> {
         if (sb.length() > 0) {
             data.add(sb.toString());
         }
-        return new VariableString(data.toArray());
+        return Optional.of(new VariableString(data.toArray()));
     }
 
     /**
@@ -142,10 +141,10 @@ public class VariableString implements Expression<String> {
     public String toString(TriggerContext ctx) {
         if (simple)
             return (String) data[0];
-        StringBuilder sb = new StringBuilder();
-        for (Object o : data) {
+        var sb = new StringBuilder();
+        for (var o : data) {
             if (o instanceof Expression) {
-                sb.append(TypeManager.toString(((Expression<?>) o).getValues(ctx)));
+                sb.append(TypeManager.toString((Object[]) ((Expression<?>) o).getValues(ctx)));
             } else {
                 sb.append(o);
             }
@@ -157,8 +156,8 @@ public class VariableString implements Expression<String> {
     public String toString(@Nullable TriggerContext ctx, boolean debug) {
         if (simple)
             return "\"" + data[0] + "\"";
-        StringBuilder sb = new StringBuilder("\"");
-        for (Object o : data) {
+        var sb = new StringBuilder("\"");
+        for (var o : data) {
             if (o instanceof Expression) {
                 sb.append('%').append(((Expression<?>) o).toString(ctx, debug)).append('%');
             } else {
@@ -171,8 +170,8 @@ public class VariableString implements Expression<String> {
     public String defaultVariableName() {
         if (simple)
             return (String) data[0];
-        StringBuilder sb = new StringBuilder();
-        for (Object o : data) {
+        var sb = new StringBuilder();
+        for (var o : data) {
             if (o instanceof String) {
                 sb.append(o);
             } else {

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
@@ -175,9 +175,9 @@ public class VariableString implements Expression<String> {
                 sb.append(o);
             } else {
                 assert o instanceof Expression;
-                ExpressionInfo<?, ?> exprInfo = SyntaxManager.getExpressionExact((Expression<?>) o);
-                assert exprInfo != null;
-                sb.append("<").append(exprInfo.getReturnType().toString()).append(">");
+                Optional<? extends ExpressionInfo<? extends Expression<?>, ?>> exprInfo = SyntaxManager.getExpressionExact((Expression<?>) o);
+                assert exprInfo.isPresent();
+                sb.append("<").append(exprInfo.get().getReturnType().toString()).append(">");
             }
         }
         return sb.toString();

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/base/ConvertedExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/base/ConvertedExpression.java
@@ -79,7 +79,7 @@ public class ConvertedExpression<F, T> implements Expression<T> {
         var sourceIterator = source.iterator(context);
         if (!sourceIterator.hasNext())
             return Collections.emptyIterator();
-        return new Iterator<T>() {
+        return new Iterator<>() {
             @Nullable T next = null;
 
             @Override
@@ -93,7 +93,6 @@ public class ConvertedExpression<F, T> implements Expression<T> {
                 return next != null;
             }
 
-            @Nullable
             @Override
             public T next() {
                 if (!hasNext())

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/base/RestrictedExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/base/RestrictedExpression.java
@@ -4,7 +4,6 @@ import io.github.syst3ms.skriptparser.lang.CodeSection;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.log.ErrorType;
-import io.github.syst3ms.skriptparser.log.SkriptLogger;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.parsing.ParserState;
 

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/base/RestrictedExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/base/RestrictedExpression.java
@@ -1,0 +1,65 @@
+package io.github.syst3ms.skriptparser.lang.base;
+
+import io.github.syst3ms.skriptparser.lang.CodeSection;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.log.ErrorType;
+import io.github.syst3ms.skriptparser.log.SkriptLogger;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.parsing.ParserState;
+
+import java.util.List;
+
+/**
+ * An expression that can only be used in select CodeSections. It is possible to make a RestrictedExpression "strict" ;
+ * that is, it would be invalid to use it when not directly enclosed in one of its required sections.
+ * It is possible to specify the error message that should be shown if the restrictions aren't followed.
+ *
+ * This class shouldn't be used for expressions that should only work with specific {@link TriggerContext}s.
+ * For this purpose, use {@link ParseContext#getParserState()} in conjuction with {@link ParserState#getCurrentContexts()}.
+ * @param <T> the return type
+ * @see ParserState#getCurrentContexts()
+ */
+public abstract class RestrictedExpression<T> implements Expression<T> {
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        var requiredSections = getRequiredSections();
+        var currentSections = parseContext.getParserState().getCurrentSections();
+        var limit = isStrict() ? 1 : currentSections.size();
+        CodeSection required = null;
+        for (var i = 0; i < limit; i++) {
+            var sec = currentSections.get(i);
+            if (requiredSections.contains(sec.getClass())) {
+                required = sec;
+                break;
+            }
+        }
+        if (required == null) {
+            var logger = parseContext.getLogger();
+            logger.error(getSpecificErrorMessage() + " : '" + this.toString(null, logger.isDebug()) + "'", ErrorType.SEMANTIC_ERROR);
+            return false;
+        }
+        return initialize(expressions, required, matchedPattern, parseContext);
+    }
+
+    protected abstract boolean initialize(Expression<?>[] expressions, CodeSection requiredSection, int matchedPattern, ParseContext parseContext);
+
+    /**
+     * The error message that should be displayed if this expression is used outside of one of its required sections
+     * @return the error message that should be displayed if this expression is used outside of one of its required sections
+     */
+    protected abstract String getSpecificErrorMessage();
+
+    /**
+     * Returns a list of the classes of all the sections inside of which this expression can be used
+     * @return a list of the classes of all the sections inside of which this expression can be used
+     */
+    protected abstract List<Class<? extends CodeSection>> getRequiredSections();
+
+    /**
+     * True if the directly enclosing section must be a required one (a member of {@link #getRequiredSections()}), false otherwise.
+     * @return whether the directly enclosing section must be a required one or not
+     */
+    protected abstract boolean isStrict();
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/log/LogEntry.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/log/LogEntry.java
@@ -38,7 +38,7 @@ public class LogEntry {
         return errorType;
     }
 
-    int getLine() {
+    public int getLine() {
         return line;
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/log/SkriptLogger.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/log/SkriptLogger.java
@@ -38,10 +38,10 @@ public class SkriptLogger {
         List<ErrorContext> c1 = e1.getErrorContext(),
                 c2 = e2.getErrorContext();
         if (!c1.equals(c2)) {
-            String s1 = c1.stream()
+            var s1 = c1.stream()
                     .map(c -> Integer.toString(c.ordinal()))
                     .collect(Collectors.joining());
-            String s2 = c2.stream()
+            var s2 = c2.stream()
                     .map(c -> Integer.toString(c.ordinal()))
                     .collect(Collectors.joining());
             return s1.compareTo(s2);
@@ -83,7 +83,7 @@ public class SkriptLogger {
 
     private List<FileElement> flatten(List<FileElement> fileElements) {
         List<FileElement> list = new ArrayList<>();
-        for (FileElement element : fileElements) {
+        for (var element : fileElements) {
             list.add(element);
             if (element instanceof FileSection) {
                 list.addAll(flatten(((FileSection) element).getElements()));
@@ -223,7 +223,7 @@ public class SkriptLogger {
                 .filter(e -> e.getType() == LogType.ERROR)
                 .min(ERROR_COMPARATOR)
                 .ifPresent(logged::add);
-        for (LogEntry entry : logEntries) { // If no errors have been logged, then all other LogTypes get logged here, DEBUG being the special case
+        for (var entry : logEntries) { // If no errors have been logged, then all other LogTypes get logged here, DEBUG being the special case
             if (entry.getType() != LogType.ERROR) {
                 logged.add(entry);
             }

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/MatchContext.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/MatchContext.java
@@ -23,6 +23,7 @@ public class MatchContext {
     // Provided to the syntax's class
     private final ParserState parserState;
     private final SkriptLogger logger;
+    @Nullable
     private final MatchContext source;
     private final List<Expression<?>> parsedExpressions = new ArrayList<>();
     private final List<MatchResult> regexMatches = new ArrayList<>();

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/MatchContext.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/MatchContext.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.MatchResult;
 
 /**
@@ -114,9 +115,8 @@ public class MatchContext {
      * tracks what the original MatchContext was. This is non-null only after {@link #branch(PatternElement)} is called.
      * @return the source of this MatchContext
      */
-    @Nullable
-    public MatchContext getSource() {
-        return source;
+    public Optional<MatchContext> getSource() {
+        return Optional.ofNullable(source);
     }
 
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/ScriptLoader.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/ScriptLoader.java
@@ -4,9 +4,7 @@ import io.github.syst3ms.skriptparser.file.FileElement;
 import io.github.syst3ms.skriptparser.file.FileParser;
 import io.github.syst3ms.skriptparser.file.FileSection;
 import io.github.syst3ms.skriptparser.file.VoidElement;
-import io.github.syst3ms.skriptparser.lang.CodeSection;
 import io.github.syst3ms.skriptparser.lang.Conditional;
-import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.Statement;
 import io.github.syst3ms.skriptparser.lang.Trigger;
 import io.github.syst3ms.skriptparser.lang.UnloadedTrigger;
@@ -14,7 +12,6 @@ import io.github.syst3ms.skriptparser.log.ErrorContext;
 import io.github.syst3ms.skriptparser.log.ErrorType;
 import io.github.syst3ms.skriptparser.log.LogEntry;
 import io.github.syst3ms.skriptparser.log.SkriptLogger;
-import io.github.syst3ms.skriptparser.registration.SkriptAddon;
 import io.github.syst3ms.skriptparser.util.FileUtils;
 import io.github.syst3ms.skriptparser.util.MultiMap;
 

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/SkriptParserException.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/SkriptParserException.java
@@ -4,8 +4,6 @@ package io.github.syst3ms.skriptparser.parsing;
  * An exception thrown whenever something goes wrong at parse time.
  */
 public class SkriptParserException extends RuntimeException {
-    private static final long serialVersionUID = 0L;
-
     public SkriptParserException(String msg) {
         super(msg);
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
@@ -171,7 +171,7 @@ public class SyntaxParser {
         }
         var variable = (Optional<? extends Variable<Boolean>>) Variables.parseVariable(s, Boolean.class, parserState, logger);
         if (variable.isPresent()) {
-            if (variable.filter(v -> !v.isSingle()).isEmpty()) {
+            if (variable.filter(v -> !v.isSingle()).isPresent()) {
                 logger.error("A single value was expected, but " +
                         s +
                         " represents multiple values.", ErrorType.SEMANTIC_ERROR);
@@ -419,7 +419,7 @@ public class SyntaxParser {
             Expression<?>[] exprs = expressions.toArray(new Expression[0]);
             var returnType = ClassUtils.getCommonSuperclass(Arrays.stream(exprs).map(Expression::getReturnType).toArray(Class[]::new));
             return Optional.of(new ExpressionList<>(
-                    (Literal<? extends T>[]) exprs,
+                    (Expression<? extends T>[]) exprs,
                     (Class<T>) returnType,
                     isAndList
             ));

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
@@ -1,13 +1,11 @@
 package io.github.syst3ms.skriptparser.parsing;
 
-import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.file.FileSection;
 import io.github.syst3ms.skriptparser.lang.*;
 import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
 import io.github.syst3ms.skriptparser.log.ErrorContext;
 import io.github.syst3ms.skriptparser.log.ErrorType;
 import io.github.syst3ms.skriptparser.log.SkriptLogger;
-import io.github.syst3ms.skriptparser.pattern.PatternElement;
 import io.github.syst3ms.skriptparser.registration.ExpressionInfo;
 import io.github.syst3ms.skriptparser.registration.SkriptEventInfo;
 import io.github.syst3ms.skriptparser.registration.SyntaxInfo;
@@ -21,13 +19,11 @@ import io.github.syst3ms.skriptparser.util.RecentElementList;
 import io.github.syst3ms.skriptparser.util.StringUtils;
 import io.github.syst3ms.skriptparser.variables.Variables;
 import org.intellij.lang.annotations.MagicConstant;
-import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.util.function.Function;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
@@ -24,10 +24,8 @@ import org.intellij.lang.annotations.MagicConstant;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -56,18 +54,15 @@ public class SyntaxParser {
     /**
      * The pattern type representing {@link Boolean}
      */
-    @SuppressWarnings("ConstantConditions")
-    public static final PatternType<Boolean> BOOLEAN_PATTERN_TYPE = new PatternType<>((Type<Boolean>) TypeManager.getByClass(Boolean.class), true);
+    public static final PatternType<Boolean> BOOLEAN_PATTERN_TYPE = new PatternType<>((Type<Boolean>) TypeManager.getByClass(Boolean.class).orElseThrow(AssertionError::new), true);
     /**
      * The pattern type representing {@link Object}
      */
-    @SuppressWarnings({"ConstantConditions", "RedundantCast", "RedundantSuppression"})
-    // Gradle requires the cast, but IntelliJ considers it redundant
-    public static final PatternType<Object> OBJECT_PATTERN_TYPE = new PatternType<>((Type<Object>) TypeManager.getByClass(Object.class), true);
+    @SuppressWarnings({"RedundantCast"}) // Gradle requires the cast, but IntelliJ considers it redundant
+    public static final PatternType<Object> OBJECT_PATTERN_TYPE = new PatternType<>((Type<Object>) TypeManager.getByClass(Object.class).orElseThrow(AssertionError::new), true);
 
-    @SuppressWarnings({"ConstantConditions", "RedundantCast", "RedundantSuppression"})
-    // Gradle requires the cast, but IntelliJ considers it redundant
-    public static final PatternType<Object> OBJECTS_PATTERN_TYPE = new PatternType<>((Type<Object>) TypeManager.getByClass(Object.class), false);
+    @SuppressWarnings({"RedundantCast"}) // Gradle requires the cast, but IntelliJ considers it redundant
+    public static final PatternType<Object> OBJECTS_PATTERN_TYPE = new PatternType<>((Type<Object>) TypeManager.getByClass(Object.class).orElseThrow(AssertionError::new), false);
 
     /**
      * All {@link Effect effects} that are successfully parsed during parsing, in order of last successful parsing
@@ -95,38 +90,42 @@ public class SyntaxParser {
      * @param <T> the type of the expression
      * @param s the string to be parsed as an expression
      * @param expectedType the expected return type
+     * @param parserState the current parser state
      * @param logger the logger
      * @return an expression that was successfully parsed, or {@literal null} if the string is empty,
      * no match was found
      * or for another reason detailed in an error message.
      */
-    public static <T> Expression<? extends T> parseExpression(String s, PatternType<T> expectedType, ParserState parserState, SkriptLogger logger) {
+    public static <T> Optional<? extends Expression<? extends T>> parseExpression(String s, PatternType<T> expectedType, ParserState parserState, SkriptLogger logger) {
         if (s.isEmpty())
-            return null;
+            return Optional.empty();
         if (s.startsWith("(") && s.endsWith(")") && StringUtils.findClosingIndex(s, '(', ')', 0) == s.length() - 1) {
             s = s.substring(1, s.length() - 1);
         }
-        Expression<? extends T> literal = parseLiteral(s, expectedType, parserState, logger);
-        if (literal != null) {
+        var literal = parseLiteral(s, expectedType, parserState, logger);
+        if (literal.isPresent()) {
             return literal;
         }
-        Variable<? extends T> variable = (Variable<? extends T>) Variables.parseVariable(s, expectedType.getType().getTypeClass(), parserState, logger);
-        if (variable != null) {
-            if (!variable.isSingle() && expectedType.isSingle()) {
-                logger.error("A single value was expected, but " + s + " represents multiple values.", ErrorType.SEMANTIC_ERROR);
-                return null;
+        var variable = (Optional<? extends Variable<? extends T>>) Variables.parseVariable(s, expectedType.getType().getTypeClass(), parserState, logger);
+        if (variable.isPresent()) {
+            if (variable.filter(v -> !v.isSingle() && expectedType.isSingle()).isPresent()) {
+                logger.error("A single value was expected, but " +
+                        s +
+                        " represents multiple values.", ErrorType.SEMANTIC_ERROR);
+                return Optional.empty();
+            } else {
+                return variable;
             }
-            return variable;
         }
         if (!expectedType.isSingle()) {
-            Expression<? extends T> listLiteral = parseListLiteral(s, expectedType, parserState, logger);
-            if (listLiteral != null) {
+            var listLiteral = parseListLiteral(s, expectedType, parserState, logger);
+            if (listLiteral.isPresent()) {
                 return listLiteral;
             }
         }
-        for (ExpressionInfo<?, ?> info : recentExpressions) {
-            Expression<? extends T> expr = matchExpressionInfo(s, info, expectedType, parserState, logger);
-            if (expr != null) {
+        for (var info : recentExpressions) {
+            var expr = matchExpressionInfo(s, info, expectedType, parserState, logger);
+            if (expr.isPresent()) {
                 recentExpressions.acknowledge(info);
                 logger.clearLogs();
                 return expr;
@@ -134,11 +133,11 @@ public class SyntaxParser {
             logger.forgetError();
         }
         // Let's not loop over the same elements again
-        List<ExpressionInfo<?, ?>> remainingExpressions = SyntaxManager.getAllExpressions();
+        var remainingExpressions = SyntaxManager.getAllExpressions();
         recentExpressions.removeFrom(remainingExpressions);
-        for (ExpressionInfo<?, ?> info : remainingExpressions) {
-            Expression<? extends T> expr = matchExpressionInfo(s, info, expectedType, parserState, logger);
-            if (expr != null) {
+        for (var info : remainingExpressions) {
+            var expr = matchExpressionInfo(s, info, expectedType, parserState, logger);
+            if (expr.isPresent()) {
                 recentExpressions.acknowledge(info);
                 logger.clearLogs();
                 return expr;
@@ -147,8 +146,9 @@ public class SyntaxParser {
         }
         logger.setContext(ErrorContext.NO_MATCH);
         logger.error("No expression matching ''" + s + "' was found", ErrorType.NO_MATCH);
-        return null;
+        return Optional.empty();
     }
+
 
     /**
      * Parses a {@link Expression boolean expression} from the given {@linkplain String}
@@ -163,43 +163,46 @@ public class SyntaxParser {
      * no match was found
      * or for another reason detailed in an error message.
      */
-    public static Expression<Boolean> parseBooleanExpression(String s, @MagicConstant(intValues = {NOT_CONDITIONAL, MAYBE_CONDITIONAL, CONDITIONAL}) int conditional, ParserState parserState, SkriptLogger logger) {
+    public static Optional<? extends Expression<Boolean>> parseBooleanExpression(String s, @MagicConstant(intValues = {NOT_CONDITIONAL, MAYBE_CONDITIONAL, CONDITIONAL}) int conditional, ParserState parserState, SkriptLogger logger) {
         // I swear this is the cleanest way to do it
         if (s.startsWith("(") && s.endsWith(")") && StringUtils.findClosingIndex(s, '(', ')', 0) == s.length() - 1) {
             s = s.substring(1, s.length() - 1);
         }
         if (s.equalsIgnoreCase("true")) {
-            return new SimpleLiteral<>(Boolean.class, true);
+            return Optional.of(new SimpleLiteral<>(Boolean.class, true));
         } else if (s.equalsIgnoreCase("false")) {
-            return new SimpleLiteral<>(Boolean.class, false);
+            return Optional.of(new SimpleLiteral<>(Boolean.class, false));
         }
-        Variable<Boolean> variable = (Variable<Boolean>) Variables.parseVariable(s, Boolean.class, parserState, logger);
-        if (variable != null) {
-            if (!variable.isSingle()) {
-                logger.error("A single value was expected, but " + s + " represents multiple values.", ErrorType.SEMANTIC_ERROR);
-                return null;
+        var variable = (Optional<? extends Variable<Boolean>>) Variables.parseVariable(s, Boolean.class, parserState, logger);
+        if (variable.isPresent()) {
+            if (variable.filter(v -> !v.isSingle()).isEmpty()) {
+                logger.error("A single value was expected, but " +
+                        s +
+                        " represents multiple values.", ErrorType.SEMANTIC_ERROR);
+                return Optional.empty();
+            } else {
+                return variable;
             }
-            return variable;
         }
-        for (ExpressionInfo<?, ?> info : recentExpressions) {
+        for (var info : recentExpressions) {
             if (info.getReturnType().getType().getTypeClass() != Boolean.class)
                 continue;
-            Expression<Boolean> expr = (Expression<Boolean>) matchExpressionInfo(s, info, BOOLEAN_PATTERN_TYPE, parserState, logger);
-            if (expr != null) {
+            var expr = (Optional<? extends Expression<Boolean>>) matchExpressionInfo(s, info, BOOLEAN_PATTERN_TYPE, parserState, logger);
+            if (expr.isPresent()) {
                 switch (conditional) {
                     case 0: // Can't be conditional
-                        if (ConditionalExpression.class.isAssignableFrom(expr.getClass())) {
+                        if (ConditionalExpression.class.isAssignableFrom(expr.get().getClass())) {
                             logger.error("The boolean expression must not be conditional", ErrorType.SEMANTIC_ERROR);
-                            return null;
+                            return Optional.empty();
                         }
                         break;
                     case 2: // Has to be conditional
-                        if (!ConditionalExpression.class.isAssignableFrom(expr.getClass())) {
+                        if (!ConditionalExpression.class.isAssignableFrom(expr.get().getClass())) {
                             logger.error("The boolean expression must be conditional", ErrorType.SEMANTIC_ERROR);
-                            return null;
+                            return Optional.empty();
                         }
                     case 1: // Can be conditional
-                        if (ConditionalExpression.class.isAssignableFrom(expr.getClass())) {
+                        if (ConditionalExpression.class.isAssignableFrom(expr.get().getClass())) {
                             recentConditions.acknowledge((ExpressionInfo<? extends ConditionalExpression, ? extends Boolean>) info);
                         }
                     default: // You just want me dead, don't you ?
@@ -212,27 +215,27 @@ public class SyntaxParser {
             logger.forgetError();
         }
         // Let's not loop over the same elements again
-        List<ExpressionInfo<?, ?>> remainingExpressions = SyntaxManager.getAllExpressions();
+        var remainingExpressions = SyntaxManager.getAllExpressions();
         recentExpressions.removeFrom(remainingExpressions);
-        for (ExpressionInfo<?, ?> info : remainingExpressions) {
+        for (var info : remainingExpressions) {
             if (info.getReturnType().getType().getTypeClass() != Boolean.class)
                 continue;
-            Expression<Boolean> expr = (Expression<Boolean>) matchExpressionInfo(s, info, BOOLEAN_PATTERN_TYPE, parserState, logger);
-            if (expr != null) {
+            var expr = (Optional<? extends Expression<Boolean>>) matchExpressionInfo(s, info, BOOLEAN_PATTERN_TYPE, parserState, logger);
+            if (expr.isPresent()) {
                 switch (conditional) {
                     case 0: // Can't be conditional
-                        if (ConditionalExpression.class.isAssignableFrom(expr.getClass())) {
+                        if (ConditionalExpression.class.isAssignableFrom(expr.get().getClass())) {
                             logger.error("The boolean expression must not be conditional", ErrorType.SEMANTIC_ERROR);
-                            return null;
+                            return Optional.empty();
                         }
                         break;
                     case 2: // Has to be conditional
-                        if (!ConditionalExpression.class.isAssignableFrom(expr.getClass())) {
+                        if (!ConditionalExpression.class.isAssignableFrom(expr.get().getClass())) {
                             logger.error("The boolean expression must be conditional", ErrorType.SEMANTIC_ERROR);
-                            return null;
+                            return Optional.empty();
                         }
                     case 1: // Can be conditional
-                        if (ConditionalExpression.class.isAssignableFrom(expr.getClass())) {
+                        if (ConditionalExpression.class.isAssignableFrom(expr.get().getClass())) {
                             recentConditions.acknowledge((ExpressionInfo<? extends ConditionalExpression, ? extends Boolean>) info);
                         }
                     default: // You just want me dead, don't you ?
@@ -246,23 +249,25 @@ public class SyntaxParser {
         }
         logger.setContext(ErrorContext.NO_MATCH);
         logger.error("No expression matching '" + s + "' was found", ErrorType.NO_MATCH);
-        return null;
+        return Optional.empty();
     }
 
-    private static <T> Expression<? extends T> matchExpressionInfo(String s, ExpressionInfo<?, ?> info, PatternType<T> expectedType, ParserState parserState, SkriptLogger logger) {
-        List<PatternElement> patterns = info.getPatterns();
-        PatternType<?> infoType = info.getReturnType();
-        Class<?> infoTypeClass = infoType.getType().getTypeClass();
-        Class<T> expectedTypeClass = expectedType.getType().getTypeClass();
+    private static <T> Optional<? extends Expression<? extends T>> matchExpressionInfo(String s, ExpressionInfo<?, ?> info, PatternType<T> expectedType, ParserState parserState, SkriptLogger logger) {
+        var patterns = info.getPatterns();
+        var infoType = info.getReturnType();
+        var infoTypeClass = infoType.getType().getTypeClass();
+        var expectedTypeClass = expectedType.getType().getTypeClass();
         if (!expectedTypeClass.isAssignableFrom(infoTypeClass) && !Converters.converterExists(infoTypeClass, expectedTypeClass))
-            return null;
-        for (int i = 0; i < patterns.size(); i++) {
-            PatternElement element = patterns.get(i);
+            return Optional.empty();
+        for (var i = 0; i < patterns.size(); i++) {
+            var element = patterns.get(i);
             logger.setContext(ErrorContext.MATCHING);
-            MatchContext parser = new MatchContext(element, parserState, logger);
+            var parser = new MatchContext(element, parserState, logger);
             if (element.match(s, 0, parser) != -1) {
                 try {
-                    Expression<? extends T> expression = (Expression<? extends T>) info.getSyntaxClass().newInstance();
+                    var expression = (Expression<? extends T>) info.getSyntaxClass()
+                            .getDeclaredConstructor()
+                            .newInstance();
                     logger.setContext(ErrorContext.INITIALIZATION);
                     if (!expression.init(
                             parser.getParsedExpressions().toArray(new Expression[0]),
@@ -274,17 +279,17 @@ public class SyntaxParser {
                     logger.setContext(ErrorContext.CONSTRAINT_CHECKING);
                     Class<?> expressionReturnType = expression.getReturnType();
                     if (!expectedTypeClass.isAssignableFrom(expressionReturnType)) { // Would only screw up in case of bad dynamic type usage
-                        Expression<?> converted = expression.convertExpression(expectedTypeClass);
-                        if (converted != null) {
-                            return (Expression<? extends T>) converted;
+                        var converted = expression.convertExpression(expectedTypeClass);
+                        if (converted.isPresent()) {
+                            return converted;
                         } else {
-                            Type<?> type = TypeManager.getByClass(expressionReturnType);
-                            assert type != null;
+                            var type = TypeManager.getByClass(expressionReturnType);
+                            assert type.isPresent();
                             logger.error(StringUtils.withIndefiniteArticle(expectedType.toString(), false) +
                                     " was expected, but " +
-                                    StringUtils.withIndefiniteArticle(type.toString(), false) +
+                                    StringUtils.withIndefiniteArticle(type.get().toString(), false) +
                                     " was found", ErrorType.SEMANTIC_ERROR);
-                            return null;
+                            return Optional.empty();
                         }
                     }
                     if (!expression.isSingle() &&
@@ -297,13 +302,13 @@ public class SyntaxParser {
                         logger.error("The enclosing section does not allow the use of this expression : " + expression.toString(null, logger.isDebug()), ErrorType.SEMANTIC_ERROR);
                         continue;
                     }
-                    return expression;
-                } catch (InstantiationException | IllegalAccessException e) {
+                    return Optional.of(expression);
+                } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                     logger.error("Couldn't instantiate class '" + info.getSyntaxClass().getName() + "'", ErrorType.EXCEPTION);
                 }
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     /**
@@ -315,12 +320,10 @@ public class SyntaxParser {
      * no match was found
      * or for another reason detailed in an error message
      */
-    @Nullable
-    public static InlineCondition parseInlineCondition(String s, ParserState parserState, SkriptLogger logger) {
-        if (s.isEmpty())
-            return null;
-        Expression<Boolean> cond = parseBooleanExpression(s, CONDITIONAL, parserState, logger);
-        return cond != null ? new InlineCondition(cond) : null;
+    public static Optional<? extends InlineCondition> parseInlineCondition(String s, ParserState parserState, SkriptLogger logger) {
+        return s.isEmpty()
+                ? Optional.empty()
+                : parseBooleanExpression(s, CONDITIONAL, parserState, logger).map(InlineCondition::new);
     }
 
     /**
@@ -328,52 +331,53 @@ public class SyntaxParser {
      * @param <T> the type of the list literal
      * @param s the string to be parsed as a list literal
      * @param expectedType the expected return type (must be plural)
+     * @param parserState the current parser state
      * @param logger the logger
      * @return a list literal that was successfully parsed, or {@literal null} if the string is empty,
      * no match was found
      * or for another reason detailed in an error message.
      */
-    @SuppressWarnings("rawtypes")
-    public static <T> Expression<? extends T> parseListLiteral(String s, PatternType<T> expectedType, ParserState parserState, SkriptLogger logger) {
+    public static <T> Optional<? extends Expression<? extends T>> parseListLiteral(String s, PatternType<T> expectedType, ParserState parserState, SkriptLogger logger) {
         assert !expectedType.isSingle();
         if (!s.contains(",") && !s.contains("and") && !s.contains("nor") && !s.contains("or"))
-            return null;
+            return Optional.empty();
         List<String> parts = new ArrayList<>();
-        Matcher m = LIST_SPLIT_PATTERN.matcher(s);
-        int lastIndex = 0;
-        for (int i = 0; i < s.length(); i = StringUtils.nextSimpleCharacterIndex(s, i+1)) {
+        var m = LIST_SPLIT_PATTERN.matcher(s);
+        var lastIndex = 0;
+        for (var i = 0; i < s.length(); i = StringUtils.nextSimpleCharacterIndex(s, i+1)) {
             if (i == -1) {
-                return null;
+                return Optional.empty();
             } else if (StringUtils.nextSimpleCharacterIndex(s, i) > i) { // We are currently at the start of something we need to skip over
                 i = StringUtils.nextSimpleCharacterIndex(s, i) - 1;
                 continue;
             }
-            char c = s.charAt(i);
+            var c = s.charAt(i);
             if (c == ' ' || c == ',') {
                 m.region(i, s.length());
                 if (m.lookingAt()) {
                     if (i == lastIndex)
-                        return null;
+                        return Optional.empty();
                     parts.add(s.substring(lastIndex, i));
                     parts.add(m.group());
                     i = m.end() - 1;
                     lastIndex = i;
                 }
             } else if (c == '(') {
-                String closing = StringUtils.getEnclosedText(s, '(', ')', i);
-                if (closing != null) {
-                    i = i + closing.length() + 1;
+                var closing = StringUtils.getEnclosedText(s, '(', ')', i);
+                if (closing.isPresent()) {
+                    var finalI = i; // Lambdas require it
+                    i = closing.map(cl -> finalI + cl.length() + 1).orElse(i);
                 }
             }
         }
         if (lastIndex < s.length() - 1)
             parts.add(s.substring(lastIndex));
         if (parts.size() == 1)
-            return null;
+            return Optional.empty();
         Boolean isAndList = null; // Hello nullable booleans, it had been a pleasure NOT using you
-        for (int i = 0; i < parts.size(); i++) {
+        for (var i = 0; i < parts.size(); i++) {
             if ((i & 1) == 1) { // Odd index == separator
-                String separator = parts.get(i).trim();
+                var separator = parts.get(i).strip();
                 if (separator.equalsIgnoreCase("and") || separator.equalsIgnoreCase("nor")) {
                     isAndList = true;
                 } else if (separator.equalsIgnoreCase("or")) {
@@ -383,47 +387,46 @@ public class SyntaxParser {
         }
         isAndList = isAndList == null || isAndList; // Defaults to true
         List<Expression<? extends T>> expressions = new ArrayList<>();
-        boolean isLiteralList = true;
-        for (int i = 0; i < parts.size(); i++) {
+        var isLiteralList = true;
+        for (var i = 0; i < parts.size(); i++) {
             if ((i & 1) == 0) { // Even index == element
-                String part = parts.get(i).trim();
+                var part = parts.get(i).strip();
                 logger.recurse();
-                Expression<? extends T> expression = parseExpression(part, expectedType, parserState, logger);
+                var expression = parseExpression(part, expectedType, parserState, logger);
                 logger.callback();
-                if (expression == null) {
-                    return null;
-                }
-                isLiteralList &= Literal.isLiteral(expression);
-                expressions.add(expression);
+                if (expression.isEmpty())
+                    return Optional.empty();
+                isLiteralList &= Literal.isLiteral(expression.get());
+                expressions.add(expression.get());
             }
         }
         if (expressions.size() == 1)
-            return expressions.get(0);
+            return Optional.of(expressions.get(0));
         if (isLiteralList) {
-            Literal[] literals = new Literal[expressions.size()];
-            for (int i = 0; i < expressions.size(); i++) {
-                Expression<? extends T> exp = expressions.get(i);
+            Literal<?>[] literals = new Literal[expressions.size()];
+            for (var i = 0; i < expressions.size(); i++) {
+                var exp = expressions.get(i);
                 if (exp instanceof Literal) {
-                    literals[i] = (Literal) exp;
+                    literals[i] = (Literal<?>) exp;
                 } else {
                     assert exp instanceof VariableString;
-                    literals[i] = new SimpleLiteral(String.class, exp.getSingle(TriggerContext.DUMMY));
+                    literals[i] = new SimpleLiteral<>(String.class, (String) exp.getSingle(TriggerContext.DUMMY).orElseThrow(AssertionError::new));
                 }
             }
-            Class<?> returnType = ClassUtils.getCommonSuperclass(Arrays.stream(literals).map(Literal::getReturnType).toArray(Class[]::new));
-            return new LiteralList<>(
-                literals,
-                returnType,
-                isAndList
-            );
+            var returnType = ClassUtils.getCommonSuperclass(Arrays.stream(literals).map(Literal::getReturnType).toArray(Class[]::new));
+            return Optional.of(new LiteralList<>(
+                    (Literal<? extends T>[]) literals,
+                    (Class<T>) returnType,
+                    isAndList
+            ));
         } else {
-            Expression[] exprs = expressions.toArray(new Expression[0]);
-            Class<?> returnType = ClassUtils.getCommonSuperclass(Arrays.stream(exprs).map(Expression::getReturnType).toArray(Class[]::new));
-            return new ExpressionList<>(
-                exprs,
-                returnType,
-                isAndList
-            );
+            Expression<?>[] exprs = expressions.toArray(new Expression[0]);
+            var returnType = ClassUtils.getCommonSuperclass(Arrays.stream(exprs).map(Expression::getReturnType).toArray(Class[]::new));
+            return Optional.of(new ExpressionList<>(
+                    (Literal<? extends T>[]) exprs,
+                    (Class<T>) returnType,
+                    isAndList
+            ));
         }
     }
 
@@ -432,35 +435,37 @@ public class SyntaxParser {
      * @param <T> the type of the literal
      * @param s the string to be parsed as a literal
      * @param expectedType the expected return type
+     * @param parserState the current parser state
      * @param logger the logger
      * @return a literal that was successfully parsed, or {@literal null} if the string is empty,
      * no match was found
      * or for another reason detailed in an error message.
      */
-    public static <T> Expression<? extends T> parseLiteral(String s, PatternType<T> expectedType, ParserState parserState, SkriptLogger logger) {
-        Map<Class<?>, Type<?>> classToTypeMap = TypeManager.getClassToTypeMap();
-        for (Class<?> c : classToTypeMap.keySet()) {
+    public static <T> Optional<? extends Expression<? extends T>> parseLiteral(String s, PatternType<T> expectedType, ParserState parserState, SkriptLogger logger) {
+        var classToTypeMap = TypeManager.getClassToTypeMap();
+        for (var c : classToTypeMap.keySet()) {
             Class<? extends T> expectedClass = expectedType.getType().getTypeClass();
             if (expectedClass.isAssignableFrom(c) || Converters.converterExists(c, expectedClass)) {
-                Function<String, ?> literalParser = classToTypeMap.get(c).getLiteralParser();
-                if (literalParser != null) {
-                    T literal = (T) literalParser.apply(s);
-                    if (literal != null && expectedClass.isAssignableFrom(c)) {
-                        T[] one = (T[]) Array.newInstance(literal.getClass(), 1);
-                        one[0] = literal;
-                        return new SimpleLiteral<>(one);
-                    } else if (literal != null) {
-                        return new SimpleLiteral<>((Class<T>) c, literal).convertExpression(expectedType.getType().getTypeClass());
+                Optional<? extends Function<String, ?>> literalParser = classToTypeMap.get(c).getLiteralParser();
+                if (literalParser.isPresent()) {
+                    var literal = literalParser.map(l -> (T) l.apply(s));
+                    if (literal.isPresent() && expectedClass.isAssignableFrom(c)) {
+                        var one = (T[]) Array.newInstance(literal.get().getClass(), 1);
+                        one[0] = literal.get();
+                        return Optional.of(new SimpleLiteral<>(one));
+                    } else if (literal.isPresent()) {
+                        return new SimpleLiteral<>((Class<T>) c, literal.get()).convertExpression(expectedType.getType().getTypeClass());
                     }
                 } else if (expectedClass == String.class || c == String.class) {
-                    VariableString vs = VariableString.newInstanceWithQuotes(s, parserState, logger);
-                    if (vs != null) {
-                        return (Expression<? extends T>) vs;
+                    var vs = VariableString.newInstanceWithQuotes(s, parserState, logger)
+                            .map(v -> (Expression<? extends T>) v);
+                    if (vs.isPresent()) {
+                        return vs;
                     }
                 }
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     /**
@@ -472,12 +477,12 @@ public class SyntaxParser {
      * no match was found
      * or for another reason detailed in an error message
      */
-    public static Effect parseEffect(String s, ParserState parserState, SkriptLogger logger) {
+    public static Optional<? extends Effect> parseEffect(String s, ParserState parserState, SkriptLogger logger) {
         if (s.isEmpty())
-            return null;
-        for (SyntaxInfo<? extends Effect> recentEffect : recentEffects) {
-            Effect eff = matchEffectInfo(s, recentEffect, parserState, logger);
-            if (eff != null) {
+            return Optional.empty();
+        for (var recentEffect : recentEffects) {
+            var eff = matchEffectInfo(s, recentEffect, parserState, logger);
+            if (eff.isPresent()) {
                 recentEffects.acknowledge(recentEffect);
                 logger.clearLogs();
                 return eff;
@@ -485,11 +490,11 @@ public class SyntaxParser {
             logger.forgetError();
         }
         // Let's not loop over the same elements again
-        List<SyntaxInfo<? extends Effect>> remainingEffects = SyntaxManager.getEffects();
+        var remainingEffects = SyntaxManager.getEffects();
         recentEffects.removeFrom(remainingEffects);
-        for (SyntaxInfo<? extends Effect> remainingEffect : remainingEffects) {
-            Effect eff = matchEffectInfo(s, remainingEffect, parserState, logger);
-            if (eff != null) {
+        for (var remainingEffect : remainingEffects) {
+            var eff = matchEffectInfo(s, remainingEffect, parserState, logger);
+            if (eff.isPresent()) {
                 recentEffects.acknowledge(remainingEffect);
                 logger.clearLogs();
                 return eff;
@@ -498,33 +503,35 @@ public class SyntaxParser {
         }
         logger.setContext(ErrorContext.NO_MATCH);
         logger.error("No effect matching '" + s + "' was found", ErrorType.NO_MATCH);
-        return null;
+        return Optional.empty();
     }
 
-    private static Effect matchEffectInfo(String s, SyntaxInfo<? extends Effect> info, ParserState parserState, SkriptLogger logger) {
-        List<PatternElement> patterns = info.getPatterns();
-        for (int i = 0; i < patterns.size(); i++) {
-            PatternElement element = patterns.get(i);
+    private static Optional<? extends Effect> matchEffectInfo(String s, SyntaxInfo<? extends Effect> info, ParserState parserState, SkriptLogger logger) {
+        var patterns = info.getPatterns();
+        for (var i = 0; i < patterns.size(); i++) {
+            var element = patterns.get(i);
             logger.setContext(ErrorContext.MATCHING);
-            MatchContext parser = new MatchContext(element, parserState, logger);
+            var parser = new MatchContext(element, parserState, logger);
             if (element.match(s, 0, parser) != -1) {
                 try {
-                    Effect eff = info.getSyntaxClass().newInstance();
+                    var eff = info.getSyntaxClass()
+                            .getDeclaredConstructor()
+                            .newInstance();
                     logger.setContext(ErrorContext.INITIALIZATION);
                     if (!eff.init(
-                        parser.getParsedExpressions().toArray(new Expression[0]),
-                        i,
-                        parser.toParseResult()
+                            parser.getParsedExpressions().toArray(new Expression[0]),
+                            i,
+                            parser.toParseResult()
                     )) {
                         continue;
                     }
-                    return eff;
-                } catch (InstantiationException | IllegalAccessException e) {
+                    return Optional.of(eff);
+                } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                     logger.error("Couldn't instantiate class " + info.getSyntaxClass(), ErrorType.EXCEPTION);
                 }
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     /**
@@ -536,27 +543,25 @@ public class SyntaxParser {
      * no match was found
      * or for another reason detailed in an error message
      */
-    @Nullable
-    public static Statement parseStatement(String s, ParserState parserState, SkriptLogger logger) {
+    public static Optional<? extends Statement> parseStatement(String s, ParserState parserState, SkriptLogger logger) {
         if (s.isEmpty())
-            return null;
+            return Optional.empty();
         if (s.regionMatches(true, 0, "continue if ", 0, "continue if ".length())) { // startsWithIgnoreCase
-            InlineCondition cond = parseInlineCondition(s.substring("continue if ".length()), parserState, logger);
-            if (parserState.forbidsSyntax(InlineCondition.class)) {
+            var cond = parseInlineCondition(s.substring("continue if ".length()), parserState, logger)
+                    .filter(__ -> parserState.forbidsSyntax(InlineCondition.class));
+            if (cond.isEmpty()) {
                 logger.setContext(ErrorContext.RESTRICTED_SYNTAXES);
                 logger.error("Inline conditions are not allowed in this section", ErrorType.SEMANTIC_ERROR);
-                return null;
-            } else if (cond != null) {
-                return cond;
             }
+            return cond;
         }
-        Effect eff = parseEffect(s, parserState, logger);
-        if (eff == null) {
-            return null;
-        } else if (parserState.forbidsSyntax(eff.getClass())) {
+        var eff = parseEffect(s, parserState, logger);
+        if (eff.isEmpty()) {
+            return Optional.empty();
+        } else if (parserState.forbidsSyntax(eff.get().getClass())) {
             logger.setContext(ErrorContext.RESTRICTED_SYNTAXES);
-            logger.error("The enclosing section does not allow the use of this effect : " + eff.toString(null, logger.isDebug()), ErrorType.SEMANTIC_ERROR);
-            return null;
+            logger.error("The enclosing section does not allow the use of this effect : " + eff.get().toString(null, logger.isDebug()), ErrorType.SEMANTIC_ERROR);
+            return Optional.empty();
         } else {
             return eff;
         }
@@ -571,23 +576,23 @@ public class SyntaxParser {
      * no match was found
      * or for another reason detailed in an error message
      */
-    public static CodeSection parseSection(FileSection section, ParserState parserState, SkriptLogger logger) {
+    public static Optional<? extends CodeSection> parseSection(FileSection section, ParserState parserState, SkriptLogger logger) {
         if (section.getLineContent().isEmpty())
-            return null;
-        for (SyntaxInfo<? extends CodeSection> recentSection : recentSections) {
-            CodeSection sec = matchSectionInfo(section, recentSection, parserState, logger);
-            if (sec != null) {
+            return Optional.empty();
+        for (var recentSection : recentSections) {
+            var sec = matchSectionInfo(section, recentSection, parserState, logger);
+            if (sec.isPresent()) {
                 recentSections.acknowledge(recentSection);
                 logger.clearLogs();
                 return sec;
             }
             logger.forgetError();
         }
-        List<SyntaxInfo<? extends CodeSection>> remainingSections = SyntaxManager.getSections();
+        var remainingSections = SyntaxManager.getSections();
         recentSections.removeFrom(remainingSections);
-        for (SyntaxInfo<? extends CodeSection> remainingSection : remainingSections) {
-            CodeSection sec = matchSectionInfo(section, remainingSection, parserState, logger);
-            if (sec != null) {
+        for (var remainingSection : remainingSections) {
+            var sec = matchSectionInfo(section, remainingSection, parserState, logger);
+            if (sec.isPresent()) {
                 recentSections.acknowledge(remainingSection);
                 logger.clearLogs();
                 return sec;
@@ -596,18 +601,20 @@ public class SyntaxParser {
         }
         logger.setContext(ErrorContext.NO_MATCH);
         logger.error("No section matching '" + section.getLineContent() + "' was found", ErrorType.NO_MATCH);
-        return null;
+        return Optional.empty();
     }
 
-    private static CodeSection matchSectionInfo(FileSection section, SyntaxInfo<? extends CodeSection> info, ParserState parserState, SkriptLogger logger) {
-        List<PatternElement> patterns = info.getPatterns();
-        for (int i = 0; i < patterns.size(); i++) {
-            PatternElement element = patterns.get(i);
+    private static Optional<? extends CodeSection> matchSectionInfo(FileSection section, SyntaxInfo<? extends CodeSection> info, ParserState parserState, SkriptLogger logger) {
+        var patterns = info.getPatterns();
+        for (var i = 0; i < patterns.size(); i++) {
+            var element = patterns.get(i);
             logger.setContext(ErrorContext.MATCHING);
-            MatchContext parser = new MatchContext(element, parserState, logger);
+            var parser = new MatchContext(element, parserState, logger);
             if (element.match(section.getLineContent(), 0, parser) != -1) {
                 try {
-                    CodeSection sec = info.getSyntaxClass().newInstance();
+                    var sec = info.getSyntaxClass()
+                            .getDeclaredConstructor()
+                            .newInstance();
                     logger.setContext(ErrorContext.INITIALIZATION);
                     if (!sec.init(
                             parser.getParsedExpressions().toArray(new Expression[0]),
@@ -617,13 +624,13 @@ public class SyntaxParser {
                         continue;
                     }
                     sec.loadSection(section, parserState, logger);
-                    return sec;
-                } catch (InstantiationException | IllegalAccessException e) {
+                    return Optional.of(sec);
+                } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                     logger.error("Couldn't instantiate class " + info.getSyntaxClass(), ErrorType.EXCEPTION);
                 }
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     /**
@@ -634,13 +641,12 @@ public class SyntaxParser {
      * no match was found
      * or for another reason detailed in an error message
      */
-    @Nullable
-    public static UnloadedTrigger parseTrigger(FileSection section, SkriptLogger logger) {
+    public static Optional<? extends UnloadedTrigger> parseTrigger(FileSection section, SkriptLogger logger) {
         if (section.getLineContent().isEmpty())
-            return null;
-        for (SkriptEventInfo<?> recentEvent : recentEvents) {
-            UnloadedTrigger trigger = matchEventInfo(section, recentEvent, logger);
-            if (trigger != null) {
+            return Optional.empty();
+        for (var recentEvent : recentEvents) {
+            var trigger = matchEventInfo(section, recentEvent, logger);
+            if (trigger.isPresent()) {
                 recentEvents.acknowledge(recentEvent);
                 logger.clearLogs();
                 return trigger;
@@ -648,11 +654,11 @@ public class SyntaxParser {
             logger.forgetError();
         }
         // Let's not loop over the same elements again
-        List<SkriptEventInfo<?>> remainingEvents = SyntaxManager.getEvents();
+        var remainingEvents = SyntaxManager.getEvents();
         recentEvents.removeFrom(remainingEvents);
-        for (SkriptEventInfo<?> remainingEvent : remainingEvents) {
-            UnloadedTrigger trigger = matchEventInfo(section, remainingEvent, logger);
-            if (trigger != null) {
+        for (var remainingEvent : remainingEvents) {
+            var trigger = matchEventInfo(section, remainingEvent, logger);
+            if (trigger.isPresent()) {
                 recentEvents.acknowledge(remainingEvent);
                 logger.clearLogs();
                 return trigger;
@@ -661,19 +667,21 @@ public class SyntaxParser {
         }
         logger.setContext(ErrorContext.NO_MATCH);
         logger.error("No trigger matching '" + section.getLineContent() + "' was found", ErrorType.NO_MATCH);
-        return null;
+        return Optional.empty();
     }
 
-    private static UnloadedTrigger matchEventInfo(FileSection section, SkriptEventInfo<?> info, SkriptLogger logger) {
-        List<PatternElement> patterns = info.getPatterns();
-        for (int i = 0; i < patterns.size(); i++) {
-            PatternElement element = patterns.get(i);
-            ParserState parserState = new ParserState();
+    private static Optional<? extends UnloadedTrigger> matchEventInfo(FileSection section, SkriptEventInfo<?> info, SkriptLogger logger) {
+        var patterns = info.getPatterns();
+        for (var i = 0; i < patterns.size(); i++) {
+            var element = patterns.get(i);
+            var parserState = new ParserState();
             logger.setContext(ErrorContext.MATCHING);
-            MatchContext parser = new MatchContext(element, parserState, logger);
+            var parser = new MatchContext(element, parserState, logger);
             if (element.match(section.getLineContent(), 0, parser) != -1) {
                 try {
-                    SkriptEvent event = info.getSyntaxClass().newInstance();
+                    var event = info.getSyntaxClass()
+                            .getDeclaredConstructor()
+                            .newInstance();
                     logger.setContext(ErrorContext.INITIALIZATION);
                     if (!event.init(
                             parser.getParsedExpressions().toArray(new Expression[0]),
@@ -682,18 +690,17 @@ public class SyntaxParser {
                     )) {
                         continue;
                     }
-                    Trigger trig = new Trigger(event);
+                    var trig = new Trigger(event);
                     parserState.setCurrentContexts(info.getContexts());
-                    // trig.loadSection(section, parserState, logger);
                     /*
-                     * We don't actually load the trigger, that will be left to the loading priority system
+                     * We don't actually load the trigger here, that will be left to the loading priority system
                      */
-                    return new UnloadedTrigger(trig, section, logger.getLine(), info, parserState);
-                } catch (InstantiationException | IllegalAccessException e) {
+                    return Optional.of(new UnloadedTrigger(trig, section, logger.getLine(), info, parserState));
+                } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                     logger.error("Couldn't instantiate class " + info.getSyntaxClass(), ErrorType.EXCEPTION);
                 }
             }
         }
-        return null;
+        return Optional.empty();
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/ChoiceElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/ChoiceElement.java
@@ -29,7 +29,7 @@ public class ChoiceElement {
         if (!(obj instanceof ChoiceElement)) {
             return false;
         } else {
-            ChoiceElement other = (ChoiceElement) obj;
+            var other = (ChoiceElement) obj;
             return element.equals(other.element) && parseMark == other.parseMark;
         }
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/ChoiceGroup.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/ChoiceGroup.java
@@ -34,16 +34,16 @@ public class ChoiceGroup implements PatternElement {
         if (!(obj instanceof ChoiceGroup)) {
             return false;
         } else {
-            List<ChoiceElement> choiceElements = ((ChoiceGroup) obj).choices;
+            var choiceElements = ((ChoiceGroup) obj).choices;
             return choices.size() == choiceElements.size() && choices.equals(choiceElements);
         }
     }
 
     @Override
     public int match(String s, int index, MatchContext context) {
-        for (ChoiceElement choice : choices) {
-            MatchContext branch = context.branch(choice.getElement());
-            int m = choice.getElement().match(s, index, branch);
+        for (var choice : choices) {
+            var branch = context.branch(choice.getElement());
+            var m = choice.getElement().match(s, index, branch);
             if (m != -1) {
                 context.merge(branch);
                 context.addMark(choice.getParseMark());
@@ -55,8 +55,8 @@ public class ChoiceGroup implements PatternElement {
 
     @Override
     public String toString() {
-        StringJoiner joiner = new StringJoiner("|", "(", ")");
-        for (ChoiceElement choice : choices) {
+        var joiner = new StringJoiner("|", "(", ")");
+        for (var choice : choices) {
             if (choice.getParseMark() != 0) {
                 joiner.add(choice.getParseMark() + ":" + choice.getElement().toString());
             } else {

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/CompoundElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/CompoundElement.java
@@ -33,31 +33,31 @@ public class CompoundElement implements PatternElement {
         if (!(obj instanceof CompoundElement)) {
             return false;
         } else {
-            List<PatternElement> elems = ((CompoundElement) obj).elements;
+            var elems = ((CompoundElement) obj).elements;
             return elements.size() == elems.size() && elements.equals(elems);
         }
     }
 
     @Override
     public int match(String s, int index, MatchContext context) {
-        int i = index;
-        for (PatternElement element : elements) {
+        var i = index;
+        for (var element : elements) {
             context.advanceInPattern();
-            int m = element.match(s, i, context);
+            var m = element.match(s, i, context);
             if (m == -1) {
                 return -1;
             }
             i = m;
         }
-        if (context.getSource() == null && i < s.length() - 1)
+        if (context.getSource().isEmpty() && i < s.length() - 1)
             return -1;
         return i;
     }
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        for (PatternElement element : elements) {
+        var builder = new StringBuilder();
+        for (var element : elements) {
             builder.append(element);
         }
         return builder.toString();

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/ExpressionElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/ExpressionElement.java
@@ -50,12 +50,13 @@ public class ExpressionElement implements PatternElement {
         }
         var logger = context.getLogger();
         logger.recurse();
+        var source = context.getSource();
         var possibilityIndex = context.getPatternIndex();
         var flattened = PatternElement.flatten(context.getOriginalElement());
-        var source = context.getSource();
-        if (source.isPresent() && possibilityIndex >= flattened.size()) {
+        while (source.isPresent() && possibilityIndex >= flattened.size()) {
             flattened = PatternElement.flatten(source.get().getOriginalElement());
             possibilityIndex = source.get().getPatternIndex();
+            source = source.get().getSource();
         }
         // We look at what could possibly be after the expression in the current syntax
         var possibleInputs = PatternElement.getPossibleInputs(flattened.subList(possibilityIndex, flattened.size()));
@@ -68,7 +69,7 @@ public class ExpressionElement implements PatternElement {
                     if (index == 0) {
                         return -1;
                     }
-                    var toParse = s.substring(index).trim();
+                    var toParse = s.substring(index).strip();
                     var expression = parse(toParse, typeArray, context.getParserState(), logger);
                     if (expression.isPresent()) {
                         context.addExpression(expression.get());
@@ -78,7 +79,7 @@ public class ExpressionElement implements PatternElement {
                 }
                 var i = StringUtils.indexOfIgnoreCase(s, text, index);
                 while (i != -1) {
-                    var toParse = s.substring(index, i).trim();
+                    var toParse = s.substring(index, i).strip();
                     var expression = parse(toParse, typeArray, context.getParserState(), logger);
                     if (expression.isPresent()) {
                         context.addExpression(expression.get());

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/ExpressionElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/ExpressionElement.java
@@ -14,6 +14,7 @@ import io.github.syst3ms.skriptparser.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 
 /**
@@ -44,99 +45,101 @@ public class ExpressionElement implements PatternElement {
 
     @Override
     public int match(String s, int index, MatchContext context) {
-        PatternType<?>[] typeArray = types.toArray(new PatternType<?>[0]);
+        var typeArray = types.toArray(new PatternType<?>[0]);
         if (index >= s.length()) {
             return -1;
         }
-        SkriptLogger logger = context.getLogger();
-        int possibilityIndex = context.getPatternIndex();
-        List<PatternElement> flattened = PatternElement.flatten(context.getOriginalElement());
-        if (context.getSource() != null && possibilityIndex >= flattened.size()) {
-            flattened = PatternElement.flatten(context.getSource().getOriginalElement());
-            possibilityIndex = context.getSource().getPatternIndex();
+        var logger = context.getLogger();
+        logger.recurse();
+        var possibilityIndex = context.getPatternIndex();
+        var flattened = PatternElement.flatten(context.getOriginalElement());
+        var source = context.getSource();
+        if (source.isPresent() && possibilityIndex >= flattened.size()) {
+            flattened = PatternElement.flatten(source.get().getOriginalElement());
+            possibilityIndex = source.get().getPatternIndex();
         }
         // We look at what could possibly be after the expression in the current syntax
-        List<PatternElement> possibleInputs = PatternElement.getPossibleInputs(flattened.subList(possibilityIndex, flattened.size()));
-        for (PatternElement possibleInput : possibleInputs) {  // We iterate over those possibilities
+        var possibleInputs = PatternElement.getPossibleInputs(flattened.subList(possibilityIndex, flattened.size()));
+        for (var possibleInput : possibleInputs) {  // We iterate over those possibilities
             if (possibleInput instanceof TextElement) {
-                String text = ((TextElement) possibleInput).getText();
+                var text = ((TextElement) possibleInput).getText();
                 if (text.isEmpty())
                     continue;
                 if (text.equals("\0")) { // End of line
                     if (index == 0) {
                         return -1;
                     }
-                    String toParse = s.substring(index).trim();
-                    Expression<?> expression = parse(toParse, typeArray, context.getParserState(), logger);
-                    if (expression != null) {
-                        context.addExpression(expression);
+                    var toParse = s.substring(index).trim();
+                    var expression = parse(toParse, typeArray, context.getParserState(), logger);
+                    if (expression.isPresent()) {
+                        context.addExpression(expression.get());
                         return index + toParse.length();
                     }
                     return -1;
                 }
-                int i = StringUtils.indexOfIgnoreCase(s, text, index);
+                var i = StringUtils.indexOfIgnoreCase(s, text, index);
                 while (i != -1) {
-                    String toParse = s.substring(index, i).trim();
-                    Expression<?> expression = parse(toParse, typeArray, context.getParserState(), logger);
-                    if (expression != null) {
-                        context.addExpression(expression);
+                    var toParse = s.substring(index, i).trim();
+                    var expression = parse(toParse, typeArray, context.getParserState(), logger);
+                    if (expression.isPresent()) {
+                        context.addExpression(expression.get());
                         return index + toParse.length();
                     }
                     i = StringUtils.indexOfIgnoreCase(s, text, i + 1);
                 }
             } else if (possibleInput instanceof RegexGroup) {
-                Matcher m = ((RegexGroup) possibleInput).getPattern().matcher(s).region(index, s.length());
+                var m = ((RegexGroup) possibleInput).getPattern().matcher(s).region(index, s.length());
                 while (m.lookingAt()) {
-                    int i = m.start();
+                    var i = m.start();
                     if (i == -1) {
                         continue;
                     }
-                    String toParse = s.substring(index, i);
+                    var toParse = s.substring(index, i);
                     if (toParse.length() == context.getOriginalPattern().length())
                         continue;
-                    Expression<?> expression = parse(toParse, typeArray, context.getParserState(), logger);
-                    if (expression != null) {
-                        context.addExpression(expression);
+                    var expression = parse(toParse, typeArray, context.getParserState(), logger);
+                    if (expression.isPresent()) {
+                        context.addExpression(expression.get());
                         return index + toParse.length();
                     }
                 }
             } else {
                 assert possibleInput instanceof ExpressionElement;
-                List<PatternElement> nextPossibleInputs = PatternElement.getPossibleInputs(flattened.subList(context.getPatternIndex() + 1, flattened.size()));
+                var nextPossibleInputs = PatternElement.getPossibleInputs(flattened.subList(context.getPatternIndex() + 1, flattened.size()));
                 if (nextPossibleInputs.stream().anyMatch(pe -> !(pe instanceof TextElement))) {
                     continue;
                 }
-                for (PatternElement nextPossibleInput : nextPossibleInputs) {
-                    String text = ((TextElement) nextPossibleInput).getText();
+                for (var nextPossibleInput : nextPossibleInputs) {
+                    var text = ((TextElement) nextPossibleInput).getText();
                     if (text.equals("")) {
-                        String rest = s.substring(index);
-                        List<String> splits = splitAtSpaces(rest);
-                        for (String split : splits) {
-                            int i = StringUtils.indexOfIgnoreCase(s, split, index);
+                        var rest = s.substring(index);
+                        var splits = splitAtSpaces(rest);
+                        for (var split : splits) {
+                            var i = StringUtils.indexOfIgnoreCase(s, split, index);
                             if (i != -1) {
-                                String toParse = s.substring(index, i);
-                                Expression<?> expression = parse(toParse, typeArray, context.getParserState(), logger);
-                                if (expression != null) {
-                                    context.addExpression(expression);
+                                var toParse = s.substring(index, i);
+                                var expression = parse(toParse, typeArray, context.getParserState(), logger);
+                                if (expression.isPresent()) {
+                                    context.addExpression(expression.get());
                                     return index + toParse.length();
                                 }
                             }
                         }
                         return -1;
                     } else {
-                        int bound = StringUtils.indexOfIgnoreCase(s, text, index);
+                        var bound = StringUtils.indexOfIgnoreCase(s, text, index);
                         if (bound == -1) {
                             continue;
                         }
-                        String rest = s.substring(index, bound);
-                        List<String> splits = splitAtSpaces(rest);
-                        for (String split : splits) {
-                            int i = StringUtils.indexOfIgnoreCase(s, split, index);
+                        var rest = s.substring(index, bound);
+                        var splits = splitAtSpaces(rest);
+                        for (var split : splits) {
+                            var i = StringUtils.indexOfIgnoreCase(s, split, index);
                             if (i != -1) {
-                                String toParse = s.substring(index, i);
-                                Expression<?> expression = parse(toParse, typeArray, context.getParserState(), logger);
-                                if (expression != null) {
-                                    context.addExpression(expression);
+                                var toParse = s.substring(index, i);
+                                var expression = parse(toParse, typeArray, context.getParserState(), logger);
+                                if (expression.isPresent()) {
+                                    context.addExpression(expression.get());
                                     return index + toParse.length();
                                 }
                             }
@@ -150,23 +153,20 @@ public class ExpressionElement implements PatternElement {
 
     private List<String> splitAtSpaces(String s) {
         List<String> split = new ArrayList<>();
-        StringBuilder sb = new StringBuilder();
-        char[] charArray = s.toCharArray();
-        for (int i = 0; i < charArray.length; i++) {
-            char c = charArray[i];
+        var sb = new StringBuilder();
+        var charArray = s.toCharArray();
+        for (var i = 0; i < charArray.length; i++) {
+            var c = charArray[i];
             if (c == ' ') {
                 if (sb.length() > 0) {
                     split.add(sb.toString());
                     sb.setLength(0);
                 }
             } else if (c == '(') {
-                String enclosed = StringUtils.getEnclosedText(s, '(', ')', i);
-                if (enclosed == null) {
-                    sb.append('(');
-                    continue;
-                }
-                sb.append('(').append(enclosed).append(')');
-                i += enclosed.length() + 1;
+                var enclosed = StringUtils.getEnclosedText(s, '(', ')', i)
+                        .map(en -> "(" + en + ")");
+                sb.append(enclosed.orElse("("));
+                i += enclosed.map(s1 -> s1.length() + 1).orElse(0);
             } else {
                 sb.append(c);
             }
@@ -178,48 +178,52 @@ public class ExpressionElement implements PatternElement {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> Expression<? extends T> parse(String s, PatternType<?>[] types, ParserState parserState, SkriptLogger logger) {
-        for (PatternType<?> type : types) {
-            Expression<? extends T> expression;
+    private <T> Optional<? extends Expression<? extends T>> parse(String s, PatternType<?>[] types, ParserState parserState, SkriptLogger logger) {
+        for (var type : types) {
+            Optional<? extends Expression<? extends T>> expression;
             logger.recurse();
             if (type.equals(SyntaxParser.BOOLEAN_PATTERN_TYPE)) {
                 // NOTE : conditions call parseBooleanExpression straight away
-                expression = (Expression<? extends T>) SyntaxParser.parseBooleanExpression(
+                expression = (Optional<? extends Expression<? extends T>>) SyntaxParser.parseBooleanExpression(
                         s,
                         acceptsConditional ? SyntaxParser.MAYBE_CONDITIONAL : SyntaxParser.NOT_CONDITIONAL,
                         parserState,
-                        logger);
+                        logger
+                );
             } else {
                 expression = SyntaxParser.parseExpression(s, (PatternType<T>) type, parserState, logger);
             }
             logger.callback();
-            if (expression == null)
+            if (expression.isEmpty())
                 continue;
-            switch (acceptance) {
-                case ALL:
-                    break;
-                case EXPRESSIONS_ONLY:
-                    if (Literal.isLiteral(expression)) {
-                        logger.error("Only expressions are allowed, found literal " + s, ErrorType.SEMANTIC_ERROR);
-                        return null;
-                    }
-                    break;
-                case LITERALS_ONLY:
-                    if (!Literal.isLiteral(expression)) {
-                        logger.error("Only literals are allowed, found expression " + s, ErrorType.SEMANTIC_ERROR);
-                        return null;
-                    }
-                    break;
-                case VARIABLES_ONLY:
-                    if (!(expression instanceof Variable)) {
-                        logger.error("Only variables are allowed, found " + s, ErrorType.SEMANTIC_ERROR);
-                        return null;
-                    }
-                    break;
-            }
+            expression = expression.filter(e -> {
+                switch (acceptance) {
+                    case ALL:
+                        break;
+                    case EXPRESSIONS_ONLY:
+                        if (Literal.isLiteral(e)) {
+                            logger.error("Only expressions are allowed, found literal " + s, ErrorType.SEMANTIC_ERROR);
+                            return false;
+                        }
+                        break;
+                    case LITERALS_ONLY:
+                        if (!Literal.isLiteral(e)) {
+                            logger.error("Only literals are allowed, found expression " + s, ErrorType.SEMANTIC_ERROR);
+                            return false;
+                        }
+                        break;
+                    case VARIABLES_ONLY:
+                        if (!(e instanceof Variable)) {
+                            logger.error("Only variables are allowed, found " + s, ErrorType.SEMANTIC_ERROR);
+                            return false;
+                        }
+                        break;
+                }
+                return true;
+            });
             return expression;
         }
-        return null;
+        return Optional.empty();
     }
 
     @Override
@@ -229,14 +233,14 @@ public class ExpressionElement implements PatternElement {
         if (!(obj instanceof ExpressionElement)) {
             return false;
         } else {
-            ExpressionElement e = (ExpressionElement) obj;
+            var e = (ExpressionElement) obj;
             return types.equals(e.types) && acceptance == e.acceptance && acceptsConditional == e.acceptsConditional;
         }
     }
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("%");
+        var sb = new StringBuilder("%");
         if (nullable)
             sb.append('-');
         switch (acceptance) {

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/ExpressionElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/ExpressionElement.java
@@ -15,7 +15,6 @@ import io.github.syst3ms.skriptparser.util.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
 
 /**
  * A variable/expression, declared in syntax using {@literal %type%}

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/OptionalGroup.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/OptionalGroup.java
@@ -23,15 +23,15 @@ public class OptionalGroup implements PatternElement {
         if (!(obj instanceof OptionalGroup)) {
             return false;
         } else {
-            OptionalGroup other = (OptionalGroup) obj;
+            var other = (OptionalGroup) obj;
             return element.equals(other.element);
         }
     }
 
     @Override
     public int match(String s, int index, MatchContext context) {
-        MatchContext branch = context.branch(element);
-        int m = element.match(s, index, branch);
+        var branch = context.branch(element);
+        var m = element.match(s, index, branch);
         context.merge(branch);
         return m != -1 ? m : index;
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/PatternElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/PatternElement.java
@@ -32,13 +32,13 @@ public interface PatternElement {
     static List<PatternElement> getPossibleInputs(List<PatternElement> elements) {
         List<PatternElement> optionalPossibilities = new ArrayList<>(); // We generally want to get the non-optional ones out of the way first
         List<PatternElement> possibilities = new ArrayList<>();
-        for (PatternElement element : elements) {
+        for (var element : elements) {
             if (element instanceof TextElement || element instanceof RegexGroup) {
                 if (element instanceof TextElement) {
-                    String text = ((TextElement) element).getText();
-                    if (text.isEmpty() || text.matches("\\s*") && elements.size() == 1) {
-                        return Collections.emptyList();
-                    } else if (text.matches("\\s*")) {
+                    var text = ((TextElement) element).getText();
+                    if (text.isEmpty() || text.isBlank() && elements.size() == 1) {
+                        return possibilities;
+                    } else if (text.isBlank()) {
                         continue;
                     }
                 }
@@ -46,8 +46,8 @@ public interface PatternElement {
                 possibilities.addAll(optionalPossibilities);
                 return possibilities;
             } else if (element instanceof ChoiceGroup) {
-                for (ChoiceElement choice : ((ChoiceGroup) element).getChoices()) {
-                    List<PatternElement> possibleInputs = getPossibleInputs(flatten(choice.getElement()));
+                for (var choice : ((ChoiceGroup) element).getChoices()) {
+                    var possibleInputs = getPossibleInputs(flatten(choice.getElement()));
                     possibilities.addAll(possibleInputs);
                 }
                 possibilities.addAll(optionalPossibilities);

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/PatternParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/PatternParser.java
@@ -46,7 +46,7 @@ public class PatternParser {
                     logger.error("Unmatched square bracket (index " + initialPos + ") : '" + pattern.substring(initialPos) + "'", ErrorType.MALFORMED_INPUT);
                     return Optional.empty();
                 } else if (s.get().isEmpty()) {
-                    logger.warn("There is an empty optional group. Place a backslash before a square bracket for it to be interpreted literally : [" + s + "]");
+                    logger.warn("There is an empty optional group. Place a backslash before a square bracket for it to be interpreted literally : [" + s.get() + "]");
                 }
                 if (textBuilder.length() != 0) {
                     elements.add(new TextElement(textBuilder.toString()));
@@ -110,7 +110,7 @@ public class PatternParser {
                 List<ChoiceElement> choiceElements = new ArrayList<>();
                 for (var choice : choices.get()) {
                     if (choice.isEmpty()) {
-                        logger.warn("There is an empty choice in the choice group. Place a backslash before the vertical bar for it to be interpreted literally : (" + s + ")");
+                        logger.warn("There is an empty choice in the choice group. Place a backslash before the vertical bar for it to be interpreted literally : (" + s.get() + ")");
                     }
                     Optional<ChoiceElement> choiceElement;
                     var matcher = PARSE_MARK_PATTERN.matcher(choice);
@@ -153,7 +153,7 @@ public class PatternParser {
                     logger.error("Unmatched angle bracket (index " + initialPos + ") : '" + pattern.substring(initialPos) + "'", ErrorType.MALFORMED_INPUT);
                     return Optional.empty();
                 } else if (s.get().isEmpty()) {
-                    logger.warn("There is an empty regex group. Place a backslash before an angle bracket for it to be interpreted literally : [" + s + "]");
+                    logger.warn("There is an empty regex group. Place a backslash before an angle bracket for it to be interpreted literally : [" + s.get() + "]");
                 }
                 if (textBuilder.length() != 0) {
                     elements.add(new TextElement(textBuilder.toString()));
@@ -164,7 +164,7 @@ public class PatternParser {
                 try {
                     pat = Pattern.compile(s.get());
                 } catch (PatternSyntaxException e) {
-                    logger.error("Invalid regex pattern (index " + initialPos + ") : '" + s + "'", ErrorType.MALFORMED_INPUT);
+                    logger.error("Invalid regex pattern (index " + initialPos + ") : '" + s.get() + "'", ErrorType.MALFORMED_INPUT);
                     return Optional.empty();
                 }
                 elements.add(new RegexGroup(pat));

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/PatternParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/PatternParser.java
@@ -5,13 +5,11 @@ import io.github.syst3ms.skriptparser.log.SkriptLogger;
 import io.github.syst3ms.skriptparser.types.PatternType;
 import io.github.syst3ms.skriptparser.types.TypeManager;
 import io.github.syst3ms.skriptparser.util.StringUtils;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/PatternParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/PatternParser.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -26,44 +27,43 @@ public class PatternParser {
      * @param pattern the pattern to be parsed
      * @return the parsed PatternElement, or {@literal null} if something went wrong.
      */
-    @Nullable
-    public PatternElement parsePattern(String pattern, SkriptLogger logger) {
+    public Optional<? extends PatternElement> parsePattern(String pattern, SkriptLogger logger) {
         if (pattern.isEmpty())
-            return new TextElement("");
+            return Optional.of(new TextElement(""));
         List<PatternElement> elements = new ArrayList<>();
-        StringBuilder textBuilder = new StringBuilder();
-        String[] parts = StringUtils.splitVerticalBars(pattern, logger);
-        if (parts == null) {
-            return null;
-        } else if (parts.length > 1) {
+        var textBuilder = new StringBuilder();
+        var parts = StringUtils.splitVerticalBars(pattern, logger);
+        if (parts.isEmpty()) {
+            return Optional.empty();
+        } else if (parts.get().length > 1) {
             pattern = "(" + pattern + ")";
         }
-        char[] chars = pattern.toCharArray();
-        for (int i = 0; i < chars.length; i++) {
-            char c = chars[i];
-            int initialPos = i;
+        var chars = pattern.toCharArray();
+        for (var i = 0; i < chars.length; i++) {
+            var c = chars[i];
+            var initialPos = i;
             if (c == '[') {
-                String s = StringUtils.getEnclosedText(pattern, '[', ']', i);
-                if (s == null) {
+                var s = StringUtils.getEnclosedText(pattern, '[', ']', i);
+                if (s.isEmpty()) {
                     logger.error("Unmatched square bracket (index " + initialPos + ") : '" + pattern.substring(initialPos) + "'", ErrorType.MALFORMED_INPUT);
-                    return null;
-                } else if (s.isEmpty()) {
+                    return Optional.empty();
+                } else if (s.get().isEmpty()) {
                     logger.warn("There is an empty optional group. Place a backslash before a square bracket for it to be interpreted literally : [" + s + "]");
                 }
                 if (textBuilder.length() != 0) {
                     elements.add(new TextElement(textBuilder.toString()));
                     textBuilder = new StringBuilder();
                 }
-                i += s.length() + 1; // sets i to the closing bracket, for loop does the rest
-                Matcher matcher = PARSE_MARK_PATTERN.matcher(s);
-                PatternElement content;
-                String[] vertParts = StringUtils.splitVerticalBars(s, logger);
-                if (vertParts == null) {
-                    return null; // The content is malformed anyway
+                i += s.get().length() + 1; // sets i to the closing bracket, for loop does the rest
+                Optional<OptionalGroup> o;
+                var matcher = PARSE_MARK_PATTERN.matcher(s.get());
+                var vertParts = StringUtils.splitVerticalBars(pattern, logger);
+                if (vertParts.isEmpty()) {
+                    return Optional.empty(); // The content is malformed anyway
                 }
-                if (matcher.matches() && vertParts.length == 1) {
-                    String base = matcher.group(1);
-                    String mark = matcher.group(2);
+                if (matcher.matches() && vertParts.get().length == 1) {
+                    var base = matcher.group(1);
+                    var mark = matcher.group(2);
                     int markNumber;
                     try {
                         if (base == null) {
@@ -74,48 +74,51 @@ public class PatternParser {
                             markNumber = Integer.parseInt(mark, 16);
                         } else {
                             logger.error("Invalid parse mark (index " + initialPos + ") : '" + base + mark + "'", ErrorType.MALFORMED_INPUT);
-                            return null;
+                            return Optional.empty();
                         }
                     } catch (NumberFormatException e) {
-                        return null;
+                        logger.error("Couldn't parse the parser mark (index " + initialPos + ") : '" + mark + "'", ErrorType.MALFORMED_INPUT);
+                        return Optional.empty();
                     }
-                    String rest = matcher.group(3);
-                    PatternElement e = parsePattern(rest, logger);
-                    if (e == null) {
-                        return null;
-                    }
-                    content = new ChoiceGroup(Collections.singletonList(new ChoiceElement(e, markNumber))); // I said I would keep the other constructor for unit tests
+                    var rest = matcher.group(3);
+                    o = parsePattern(rest, logger)
+                            .map(e -> new ChoiceGroup(Collections.singletonList(new ChoiceElement(e, markNumber))))
+                            .map(OptionalGroup::new);
+
                 } else {
-                    content = parsePattern(s, logger);
-                    if (content == null) {
-                        return null;
-                    }
+                    o = s.flatMap(st -> parsePattern(st, logger))
+                            .map(OptionalGroup::new);
                 }
-                elements.add(new OptionalGroup(content));
+                if (o.isEmpty()) {
+                    return Optional.empty();
+                } else {
+                    elements.add(o.get());
+                }
             } else if (c == '(') {
-                String s = StringUtils.getEnclosedText(pattern, '(', ')', i);
-                if (s == null) {
+                var s = StringUtils.getEnclosedText(pattern, '(', ')', i);
+                if (s.isEmpty()) {
                     logger.error("Unmatched parenthesis (index " + initialPos + ") : '" + pattern.substring(initialPos) + "'", ErrorType.MALFORMED_INPUT);
-                    return null;
+                    return Optional.empty();
                 }
                 if (textBuilder.length() != 0) {
                     elements.add(new TextElement(textBuilder.toString()));
                     textBuilder = new StringBuilder();
                 }
-                i += s.length() + 1;
-                String[] choices = StringUtils.splitVerticalBars(s, logger);
-                if (choices == null) {
-                    return null;
+                i += s.get().length() + 1;
+                var choices = StringUtils.splitVerticalBars(s.get(), logger);
+                if (choices.isEmpty()) {
+                    return Optional.empty();
                 }
                 List<ChoiceElement> choiceElements = new ArrayList<>();
-                for (String choice : choices) {
+                for (var choice : choices.get()) {
                     if (choice.isEmpty()) {
                         logger.warn("There is an empty choice in the choice group. Place a backslash before the vertical bar for it to be interpreted literally : (" + s + ")");
                     }
-                    Matcher matcher = PARSE_MARK_PATTERN.matcher(choice);
+                    Optional<ChoiceElement> choiceElement;
+                    var matcher = PARSE_MARK_PATTERN.matcher(choice);
                     if (matcher.matches()) {
-                        String base = matcher.group(1);
-                        String mark = matcher.group(2);
+                        var base = matcher.group(1);
+                        var mark = matcher.group(2);
                         int markNumber;
                         try {
                             if (base == null) {
@@ -126,45 +129,45 @@ public class PatternParser {
                                 markNumber = Integer.parseInt(mark, 16);
                             } else {
                                 logger.error("Invalid parse mark (index " + initialPos + ") : '" + base + mark + "'", ErrorType.MALFORMED_INPUT);
-                                return null;
+                                return Optional.empty();
                             }
                         } catch (NumberFormatException e) {
-                            return null;
+                            logger.error("Couldn't parse the parser mark (index " + initialPos + ") : '" + mark + "'", ErrorType.MALFORMED_INPUT);
+                            return Optional.empty();
                         }
-                        String rest = matcher.group(3);
-                        PatternElement choiceContent = parsePattern(rest, logger);
-                        if (choiceContent == null) {
-                            return null;
-                        }
-                        choiceElements.add(new ChoiceElement(choiceContent, markNumber));
+                        var rest = matcher.group(3);
+                        choiceElement = parsePattern(rest, logger)
+                                .map(p -> new ChoiceElement(p, markNumber));
                     } else {
-                        PatternElement choiceContent = parsePattern(choice, logger);
-                        if (choiceContent == null) {
-                            return null;
-                        }
-                        choiceElements.add(new ChoiceElement(choiceContent, 0));
+                        choiceElement = parsePattern(choice, logger)
+                                .map(p -> new ChoiceElement(p, 0));
+                    }
+                    if (choiceElement.isEmpty()) {
+                        return Optional.empty();
+                    } else {
+                        choiceElements.add(choiceElement.get());
                     }
                 }
                 elements.add(new ChoiceGroup(choiceElements));
             } else if (c == '<') {
-                String s = StringUtils.getEnclosedText(pattern, '<', '>', i);
-                if (s == null) {
+                var s = StringUtils.getEnclosedText(pattern, '<', '>', i);
+                if (s.isEmpty()) {
                     logger.error("Unmatched angle bracket (index " + initialPos + ") : '" + pattern.substring(initialPos) + "'", ErrorType.MALFORMED_INPUT);
-                    return null;
-                } else if (s.isEmpty()) {
+                    return Optional.empty();
+                } else if (s.get().isEmpty()) {
                     logger.warn("There is an empty regex group. Place a backslash before an angle bracket for it to be interpreted literally : [" + s + "]");
                 }
                 if (textBuilder.length() != 0) {
                     elements.add(new TextElement(textBuilder.toString()));
                     textBuilder = new StringBuilder();
                 }
-                i += s.length() + 1;
+                i += s.get().length() + 1;
                 Pattern pat;
                 try {
-                    pat = Pattern.compile(s);
+                    pat = Pattern.compile(s.get());
                 } catch (PatternSyntaxException e) {
                     logger.error("Invalid regex pattern (index " + initialPos + ") : '" + s + "'", ErrorType.MALFORMED_INPUT);
-                    return null;
+                    return Optional.empty();
                 }
                 elements.add(new RegexGroup(pat));
             } else if (c == '%') {
@@ -172,26 +175,26 @@ public class PatternParser {
                  * Can't use getEnclosedText as % acts for both opening and closing,
                  * and there's no need of checking for nested stuff
                  */
-                int nextIndex = pattern.indexOf('%', i + 1);
+                var nextIndex = pattern.indexOf('%', i + 1);
                 if (nextIndex == -1) {
                     logger.error("Unmatched percent (index " + initialPos + ") : '" + pattern.substring(initialPos) + "'", ErrorType.MALFORMED_INPUT);
-                    return null;
+                    return Optional.empty();
                 }
                 if (textBuilder.length() != 0) {
                     elements.add(new TextElement(textBuilder.toString()));
                     textBuilder.setLength(0);
                 }
-                String s = pattern.substring(i + 1, nextIndex);
+                var s = pattern.substring(i + 1, nextIndex);
                 i = nextIndex;
-                Matcher m = VARIABLE_PATTERN.matcher(s);
+                var m = VARIABLE_PATTERN.matcher(s);
                 if (!m.matches()) {
                     logger.error("Invalid expression element (index " + initialPos + ") : '" + s + "'", ErrorType.MALFORMED_INPUT);
-                    return null;
+                    return Optional.empty();
                 } else {
-                    boolean nullable = m.group(1) != null;
-                    ExpressionElement.Acceptance acceptance = ExpressionElement.Acceptance.ALL;
+                    var nullable = m.group(1) != null;
+                    var acceptance = ExpressionElement.Acceptance.ALL;
                     if (m.group(2) != null) {
-                        String acc = m.group(2);
+                        var acc = m.group(2);
                         if (acc.equals("~")) {
                             acceptance = ExpressionElement.Acceptance.EXPRESSIONS_ONLY;
                         } else if (acc.equals("^")) {
@@ -200,34 +203,34 @@ public class PatternParser {
                             acceptance = ExpressionElement.Acceptance.LITERALS_ONLY;
                         }
                     }
-                    String typeString = m.group("types");
-                    String[] types = typeString.split("/");
+                    var typeString = m.group("types");
+                    var types = typeString.split("/");
                     List<PatternType<?>> patternTypes = new ArrayList<>();
-                    for (String type : types) {
-                        PatternType<?> t = TypeManager.getPatternType(type);
-                        if (t == null) {
+                    for (var type : types) {
+                        var t = TypeManager.getPatternType(type);
+                        if (t.isEmpty()) {
                             logger.error("Unknown type (index " + initialPos + ") : '" + type + "'", ErrorType.NO_MATCH);
-                            return null;
+                            return Optional.empty();
                         }
-                        patternTypes.add(t);
+                        patternTypes.add(t.get());
                     }
-                    boolean acceptConditional = m.group(3) != null;
+                    var acceptConditional = m.group(3) != null;
                     if (acceptConditional && patternTypes.stream().noneMatch(t -> t.getType().getTypeClass() == Boolean.class)) {
                         logger.error("Can't use the '=' flag on non-boolean types (index " + initialPos + ")", ErrorType.SEMANTIC_ERROR);
-                        return null;
+                        return Optional.empty();
                     }
                     elements.add(new ExpressionElement(patternTypes, acceptance, nullable, acceptConditional));
                 }
             } else if (c == '\\') {
                 if (i == pattern.length() - 1) {
                     logger.error("Invalid backslash at the end of the string", ErrorType.MALFORMED_INPUT);
-                    return null;
+                    return Optional.empty();
                 } else {
                     textBuilder.append(chars[++i]);
                 }
             } else if (c == ']' || c == ')' || c == '>') { // Closing brackets are skipped over, so this marks an error
                 logger.error("Unmatched closing bracket (index " + initialPos + ") : '" + pattern.substring(0, initialPos + 1) + "'", ErrorType.MALFORMED_INPUT);
-                return null;
+                return Optional.empty();
             } else {
                 textBuilder.append(c);
             }
@@ -237,9 +240,9 @@ public class PatternParser {
             textBuilder.setLength(0);
         }
         if (elements.size() == 1) {
-            return elements.get(0);
+            return Optional.of(elements.get(0));
         } else {
-            return new CompoundElement(elements);
+            return Optional.of(new CompoundElement(elements));
         }
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/RegexGroup.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/RegexGroup.java
@@ -27,28 +27,28 @@ public class RegexGroup implements PatternElement {
         if (!(obj instanceof RegexGroup)) {
             return false;
         } else  {
-            RegexGroup other = (RegexGroup) obj;
+            var other = (RegexGroup) obj;
             return pattern.pattern().equals(other.pattern.pattern());
         }
     }
 
     @Override
     public int match(String s, int index, MatchContext context) {
-        List<PatternElement> flattened = PatternElement.flatten(context.getOriginalElement());
-        int possibilityIndex = context.getPatternIndex();
-        if (context.getSource() != null && possibilityIndex >= flattened.size()) {
-            flattened = PatternElement.flatten(context.getSource().getOriginalElement());
-            possibilityIndex = context.getSource().getPatternIndex();
+        var flattened = PatternElement.flatten(context.getOriginalElement());
+        var possibilityIndex = context.getPatternIndex();
+        if (context.getSource().isPresent() && possibilityIndex >= flattened.size()) {
+            flattened = PatternElement.flatten(context.getSource().get().getOriginalElement());
+            possibilityIndex = context.getSource().get().getPatternIndex();
         }
-        List<PatternElement> possibleInputs = PatternElement.getPossibleInputs(flattened.subList(possibilityIndex, flattened.size()));
+        var possibleInputs = PatternElement.getPossibleInputs(flattened.subList(possibilityIndex, flattened.size()));
         for (PatternElement possibleInput : possibleInputs) {
             if (possibleInput instanceof TextElement) {
-                String text = ((TextElement) possibleInput).getText();
+                var text = ((TextElement) possibleInput).getText();
                 Matcher m;
                 if (text.equals("\0")) { // End of line
                     m = pattern.matcher(s).region(index, s.length());
                 } else {
-                    int i = s.indexOf(text, index);
+                    var i = s.indexOf(text, index);
                     if (i == -1)
                         continue;
                     m = pattern.matcher(s).region(index, i);
@@ -59,22 +59,22 @@ public class RegexGroup implements PatternElement {
                 if (!m.matches())
                     continue;
                 context.addRegexMatch(m.toMatchResult());
-                String content = m.group();
+                var content = m.group();
                 return index + content.length();
             } else {
                 assert possibleInput instanceof RegexGroup;
-                Matcher boundMatcher = ((RegexGroup) possibleInput).getPattern().matcher(s).region(index, s.length());
+                var boundMatcher = ((RegexGroup) possibleInput).getPattern().matcher(s).region(index, s.length());
                 while (boundMatcher.lookingAt()) {
-                    int i = boundMatcher.start();
+                    var i = boundMatcher.start();
                     if (i == -1)
                         continue;
-                    Matcher m = pattern.matcher(s).region(index, i + 1);
+                    var m = pattern.matcher(s).region(index, i + 1);
                     /*
                      * matches() tries to match against the whole region, and that's what we want
                      */
                     if (m.matches()) {
                         context.addRegexMatch(m.toMatchResult());
-                        String content = m.group();
+                        var content = m.group();
                         return index + content.length();
                     }
                 }

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/RegexGroup.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/RegexGroup.java
@@ -2,7 +2,6 @@ package io.github.syst3ms.skriptparser.pattern;
 
 import io.github.syst3ms.skriptparser.parsing.MatchContext;
 
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/RegexGroup.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/RegexGroup.java
@@ -2,6 +2,7 @@ package io.github.syst3ms.skriptparser.pattern;
 
 import io.github.syst3ms.skriptparser.parsing.MatchContext;
 
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -33,14 +34,16 @@ public class RegexGroup implements PatternElement {
 
     @Override
     public int match(String s, int index, MatchContext context) {
+        var source = context.getSource();
         var flattened = PatternElement.flatten(context.getOriginalElement());
         var possibilityIndex = context.getPatternIndex();
-        if (context.getSource().isPresent() && possibilityIndex >= flattened.size()) {
-            flattened = PatternElement.flatten(context.getSource().get().getOriginalElement());
-            possibilityIndex = context.getSource().get().getPatternIndex();
+        while (source.isPresent() && possibilityIndex >= flattened.size()) {
+            flattened = PatternElement.flatten(source.get().getOriginalElement());
+            possibilityIndex = source.get().getPatternIndex();
+            source = source.get().getSource();
         }
         var possibleInputs = PatternElement.getPossibleInputs(flattened.subList(possibilityIndex, flattened.size()));
-        for (PatternElement possibleInput : possibleInputs) {
+        for (var possibleInput : possibleInputs) {
             if (possibleInput instanceof TextElement) {
                 var text = ((TextElement) possibleInput).getText();
                 Matcher m;

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/TextElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/TextElement.java
@@ -26,13 +26,14 @@ public class TextElement implements PatternElement {
     public int match(String s, int index, MatchContext context) {
         if (text.isEmpty())
             return index;
-        int start = 0;
-        int end = 0;
+        var start = 0;
+        var end = 0;
         if (Character.isWhitespace(text.charAt(0))) {
             while (index + start < s.length() && Character.isWhitespace(s.charAt(index + start)))
                 start++;
         }
-        String trimmed = text.trim();
+        var trimmed = text.trim();
+        // We advance until we reach the first non-whitespace character in s
         if (index + start + trimmed.length() > s.length()) {
             return -1;
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/TextElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/TextElement.java
@@ -28,12 +28,10 @@ public class TextElement implements PatternElement {
             return index;
         var start = 0;
         if (Character.isWhitespace(text.charAt(0))) {
-            start = s.length() - s.stripLeading().length();
+            while (index + start < s.length() && Character.isWhitespace(s.charAt(index + start)))
+                start++;
         }
         var end = 0;
-        if (Character.isWhitespace(text.charAt(text.length() - 1))) {
-            end = s.length() - s.stripTrailing().length();
-        }
         var stripped = text.strip();
         // We advance until we reach the first non-whitespace character in s
         if (index + start + stripped.length() > s.length()) {
@@ -42,6 +40,10 @@ public class TextElement implements PatternElement {
         if (stripped.isEmpty()) {
             return index + start;
         } else if (s.regionMatches(true, index + start, stripped, 0, stripped.length())) {
+            if (Character.isWhitespace(text.charAt(text.length() - 1))) {
+                while (end < s.length() && Character.isWhitespace(s.charAt(index + start + stripped.length() - end)))
+                    end++;
+            }
             return index + start + stripped.length() + end; // Adjusting for some of the whitespace we ignored
         } else {
             return -1;

--- a/src/main/java/io/github/syst3ms/skriptparser/pattern/TextElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/pattern/TextElement.java
@@ -27,24 +27,22 @@ public class TextElement implements PatternElement {
         if (text.isEmpty())
             return index;
         var start = 0;
-        var end = 0;
         if (Character.isWhitespace(text.charAt(0))) {
-            while (index + start < s.length() && Character.isWhitespace(s.charAt(index + start)))
-                start++;
+            start = s.length() - s.stripLeading().length();
         }
-        var trimmed = text.trim();
+        var end = 0;
+        if (Character.isWhitespace(text.charAt(text.length() - 1))) {
+            end = s.length() - s.stripTrailing().length();
+        }
+        var stripped = text.strip();
         // We advance until we reach the first non-whitespace character in s
-        if (index + start + trimmed.length() > s.length()) {
+        if (index + start + stripped.length() > s.length()) {
             return -1;
         }
-        if (trimmed.isEmpty()) {
+        if (stripped.isEmpty()) {
             return index + start;
-        } else if (s.regionMatches(true, index + start, trimmed, 0, trimmed.length())) {
-            if (Character.isWhitespace(text.charAt(text.length() - 1))) {
-                while (index + start + trimmed.length() - end < s.length() && Character.isWhitespace(s.charAt(index + start + trimmed.length() - end)))
-                    end++;
-            }
-            return index + start + trimmed.length() + end; // Adjusting for some of the whitespace we ignored
+        } else if (s.regionMatches(true, index + start, stripped, 0, stripped.length())) {
+            return index + start + stripped.length() + end; // Adjusting for some of the whitespace we ignored
         } else {
             return -1;
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
@@ -17,6 +17,7 @@ import java.math.RoundingMode;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
@@ -365,14 +366,14 @@ public class DefaultRegistration {
         /*
          * Converters
          */
-        Converters.registerConverter(Number.class, Long.class, n -> n instanceof Long ? (Long) n : n.longValue());
+        Converters.registerConverter(Number.class, Long.class, n -> Optional.of(n instanceof Long ? (Long) n : n.longValue()));
         Converters.registerConverter(Number.class, BigInteger.class, n -> {
             if (n instanceof BigInteger) {
-                return (BigInteger) n;
+                return Optional.of((BigInteger) n);
             } else if (n instanceof Long) {
-                return BigInteger.valueOf((Long) n);
+                return Optional.of(BigInteger.valueOf((Long) n));
             } else {
-                return BigInteger.valueOf(n.longValue());
+                return Optional.of(BigInteger.valueOf(n.longValue()));
             }
         });
         registration.register(); // Ignoring logs here, we control the input

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
@@ -291,7 +291,7 @@ public class DefaultRegistration {
         Comparators.registerComparator(
                 Number.class,
                 Number.class,
-                new Comparator<Number, Number>(true) {
+                new Comparator<>(true) {
                     @SuppressWarnings("unchecked")
                     @Override
                     public Relation apply(Number number, Number number2) {
@@ -301,12 +301,13 @@ public class DefaultRegistration {
                             BigDecimal bd = BigDecimalMath.getBigDecimal(number);
                             BigDecimal bd2 = BigDecimalMath.getBigDecimal(number2);
                             return Relation.get(bd.compareTo(bd2));
-                        } else if ((number instanceof BigInteger || number2 instanceof BigInteger) && (number instanceof Long || number2 instanceof Long)) {
+                        } else if ((number instanceof BigInteger || number2 instanceof BigInteger) &&
+                                (number instanceof Long || number2 instanceof Long)) {
                             BigInteger bi = BigDecimalMath.getBigInteger(number);
                             BigInteger bi2 = BigDecimalMath.getBigInteger(number2);
                             return Relation.get(bi.compareTo(bi2));
                         } else if ((number instanceof Double || number instanceof Long) &&
-                                   (number2 instanceof Double || number2 instanceof Long)) {
+                                (number2 instanceof Double || number2 instanceof Long)) {
                             double d = number.doubleValue() - number2.doubleValue();
                             return Double.isNaN(d) ? Relation.NOT_EQUAL : Relation.get(d);
                         } else {

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/PatternInfos.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/PatternInfos.java
@@ -17,8 +17,8 @@ public class PatternInfos<T> {
     public PatternInfos(Object[][] infos) {
         patterns = new String[infos.length];
         data = new Object[infos.length];
-        for (int i = 0; i < infos.length; i++) {
-            Object[] info = infos[i];
+        for (var i = 0; i < infos.length; i++) {
+            var info = infos[i];
             if (info.length != 2 || !(info[0] instanceof String))
                 throw new SkriptParserException("Arrays inside of PatternInfos must be of the form {String, T}");
             patterns[i] = (String) info[0];

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
@@ -148,7 +148,7 @@ public class SkriptRegistration {
     }
 
     /**
-     * Starts a registration process for an {@link PropertyExpression}
+     * Starts a registration process for a {@link PropertyExpression}
      * @param c the Expression's class
      * @param returnType the Expression's return type
      * @param isSingle whether the Expression is a single value
@@ -156,7 +156,7 @@ public class SkriptRegistration {
      * @param property the property that is used
      * @param <C> the Expression
      * @param <T> the Expression's return type
-     * @return an {@link ExpressionRegistrar}
+     * @return an {@link ExpressionRegistrar} to continue the registration process
      */
     public <C extends Expression<T>, T> ExpressionRegistrar<C, T> newPropertyExpression(Class<C> c, Class<T> returnType, boolean isSingle, String ownerType, String property) {
         return new ExpressionRegistrar<>(c, returnType, isSingle,
@@ -182,7 +182,7 @@ public class SkriptRegistration {
     }
 
     /**
-     * Registers {@link PropertyExpression}
+     * Registers a {@link PropertyExpression}
      * @param c the Expression's class
      * @param returnType the Expression's return type
      * @param isSingle whether the Expression is a single value
@@ -205,7 +205,7 @@ public class SkriptRegistration {
      * @param c the Effect's class
      * @param patterns the Effect's patterns
      * @param <C> the Effect
-     * @return an {@link EffectRegistrar}
+     * @return an {@link EffectRegistrar} to continue the registration process
      */
     public <C extends Effect> EffectRegistrar<C> newEffect(Class<C> c, String... patterns) {
         return new EffectRegistrar<>(c, patterns);
@@ -257,7 +257,7 @@ public class SkriptRegistration {
      * @param c the SkriptEvent's class
      * @param patterns the SkriptEvent's patterns
      * @param <E> the SkriptEvent
-     * @return a {@link EventRegistrar}
+     * @return an {@link EventRegistrar} to continue the registration process
      */
     public <E extends SkriptEvent> EventRegistrar<E> newEvent(Class<E> c, String... patterns) {
         return new EventRegistrar<>(c, patterns);
@@ -471,6 +471,7 @@ public class SkriptRegistration {
         /**
          * Adds this expression to the list of currently registered syntaxes
          */
+        @Override
         public void register() {
             List<PatternElement> elements = new ArrayList<>();
             super.patterns.forEach(s -> patternParser.parsePattern(s, logger).ifPresent(elements::add));
@@ -494,6 +495,7 @@ public class SkriptRegistration {
         /**
          * Adds this effect to the list of currently registered syntaxes
          */
+        @Override
         public void register() {
             List<PatternElement> elements = new ArrayList<>();
             super.patterns.forEach(s -> patternParser.parsePattern(s, logger).ifPresent(elements::add));

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
@@ -1,8 +1,6 @@
 package io.github.syst3ms.skriptparser.registration;
 
-import io.github.syst3ms.skriptparser.pattern.OptionalGroup;
 import io.github.syst3ms.skriptparser.registration.contextvalues.ContextValue;
-import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.lang.*;
 import io.github.syst3ms.skriptparser.lang.base.PropertyExpression;
 import io.github.syst3ms.skriptparser.log.ErrorType;
@@ -481,7 +479,7 @@ public class SkriptRegistration {
                 logger.error("Couldn't find a type corresponding to the class '" + returnType.getName() + "'", ErrorType.NO_MATCH);
                 return;
             }
-            var info = new ExpressionInfo<C, T>(super.c, elements, registerer, type.get(), isSingle, super.priority);
+            var info = new ExpressionInfo<>(super.c, elements, registerer, type.get(), isSingle, super.priority);
             expressions.putOne(super.c, info);
         }
     }
@@ -499,7 +497,7 @@ public class SkriptRegistration {
         public void register() {
             List<PatternElement> elements = new ArrayList<>();
             super.patterns.forEach(s -> patternParser.parsePattern(s, logger).ifPresent(elements::add));
-            var info = new SyntaxInfo<C>(super.c, elements, super.priority, registerer);
+            var info = new SyntaxInfo<>(super.c, elements, super.priority, registerer);
             effects.add(info);
         }
     }
@@ -518,7 +516,7 @@ public class SkriptRegistration {
         public void register() {
             List<PatternElement> elements = new ArrayList<>();
             super.patterns.forEach(s -> patternParser.parsePattern(s, logger).ifPresent(elements::add));
-            var info = new SyntaxInfo<C>(super.c, elements, super.priority, registerer);
+            var info = new SyntaxInfo<>(super.c, elements, super.priority, registerer);
             sections.add(info);
         }
     }
@@ -546,7 +544,7 @@ public class SkriptRegistration {
                 }
                 patternParser.parsePattern(s, logger).ifPresent(elements::add);
             }
-            var info = new SkriptEventInfo<T>(super.c, handledContexts, elements, super.priority, registerer);
+            var info = new SkriptEventInfo<>(super.c, handledContexts, elements, super.priority, registerer);
             events.add(info);
             registerer.addHandledEvent(this.c);
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SyntaxManager.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SyntaxManager.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 public class SyntaxManager {
     /**
@@ -58,15 +59,14 @@ public class SyntaxManager {
      * @return the {@link ExpressionInfo} corresponding to the given {@link Expression} instance
      */
     @SuppressWarnings("unchecked")
-    @Nullable
-    public static <E extends Expression<T>, T> ExpressionInfo<E, T> getExpressionExact(Expression<T> expr) {
+    public static <E extends Expression<T>, T> Optional<? extends ExpressionInfo<E, T>> getExpressionExact(Expression<T> expr) {
         Class<?> c = expr.getSource().getClass();
         for (var info : SyntaxManager.getAllExpressions()) {
             if (info.getSyntaxClass() == c) {
-                return (ExpressionInfo<E, T>) info;
+                return Optional.of((ExpressionInfo<E, T>) info);
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SyntaxManager.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SyntaxManager.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 
 public class SyntaxManager {
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SyntaxManager.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SyntaxManager.java
@@ -34,10 +34,10 @@ public class SyntaxManager {
         sections.sort(INFO_COMPARATOR);
         triggers.addAll(reg.getEvents());
         triggers.sort(INFO_COMPARATOR);
-        for (Map.Entry<Class<?>, List<ExpressionInfo<?, ?>>> entry : reg.getExpressions().entrySet()) {
-            Class<?> key = entry.getKey();
-            List<ExpressionInfo<?, ?>> infos = entry.getValue();
-            for (ExpressionInfo<?, ?> info : infos) {
+        for (var entry : reg.getExpressions().entrySet()) {
+            var key = entry.getKey();
+            var infos = entry.getValue();
+            for (var info : infos) {
                 expressions.putOne(key, info);
             }
         }
@@ -47,7 +47,7 @@ public class SyntaxManager {
      * @return a list of all currently registered expressions
      */
     public static List<ExpressionInfo<?, ?>> getAllExpressions() {
-        List<ExpressionInfo<?, ?>> expressionInfos = expressions.getAllValues();
+        var expressionInfos = expressions.getAllValues();
         expressionInfos.sort(INFO_COMPARATOR);
         return expressionInfos;
     }
@@ -62,7 +62,7 @@ public class SyntaxManager {
     @Nullable
     public static <E extends Expression<T>, T> ExpressionInfo<E, T> getExpressionExact(Expression<T> expr) {
         Class<?> c = expr.getSource().getClass();
-        for (ExpressionInfo<?, ?> info : SyntaxManager.getAllExpressions()) {
+        for (var info : SyntaxManager.getAllExpressions()) {
             if (info.getSyntaxClass() == c) {
                 return (ExpressionInfo<E, T>) info;
             }

--- a/src/main/java/io/github/syst3ms/skriptparser/sections/SecAsync.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/sections/SecAsync.java
@@ -13,6 +13,8 @@ import io.github.syst3ms.skriptparser.util.ThreadUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * Executes the code in the section asynchronously, meaning in another thread.
  * Note that the next code that isn't part of the section (intended the same amount of times) will be executed in the current thread again.
@@ -44,13 +46,13 @@ public class SecAsync extends CodeSection {
         return true;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public Statement walk(TriggerContext ctx) {
-        final Statement[] item = {getFirst()};
-
+    public Optional<? extends Statement> walk(TriggerContext ctx) {
+        Optional<? extends Statement>[] item = new Optional[]{getFirst()};
         ThreadUtils.runAsync(() -> {
-            while (!item[0].equals(getNext()))
-                item[0] = item[0].walk(ctx);
+            while (!item[0].equals(getNext())) // Calling equals() on optionals calls equals() on their values
+                item[0] = item[0].flatMap(i -> i.walk(ctx));
         });
         return getNext();
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/sections/SecLoop.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/sections/SecLoop.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.WeakHashMap;
 
 /**
@@ -47,7 +48,7 @@ public class SecLoop extends CodeSection {
 	}
 
 	@Override
-	public Statement walk(TriggerContext ctx) {
+	public Optional<? extends Statement> walk(TriggerContext ctx) {
 		Iterator<?> iter = currentIter.get(ctx);
 		if (iter == null) {
 			iter = expr instanceof Variable ? ((Variable<?>) expr).variablesIterator(ctx) : expr.iterator(ctx);
@@ -61,7 +62,7 @@ public class SecLoop extends CodeSection {
 		if (iter == null || !iter.hasNext()) {
 			if (iter != null)
 				currentIter.remove(ctx); // a loop inside another loop can be called multiple times in the same event
-			return actualNext;
+			return Optional.ofNullable(actualNext);
 		} else {
 			current.put(ctx, iter.next());
 			return getFirst();

--- a/src/main/java/io/github/syst3ms/skriptparser/sections/SecWhile.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/sections/SecWhile.java
@@ -11,6 +11,8 @@ import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.parsing.ParserState;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * A section that keeps executing its contents while a given condition is met.
  */
@@ -40,10 +42,10 @@ public class SecWhile extends CodeSection {
     }
 
     @Override
-    public Statement walk(TriggerContext ctx) {
-        Boolean cond = condition.getSingle(ctx);
-        if (cond == null || !cond) {
-            return actualNext;
+    public Optional<? extends Statement> walk(TriggerContext ctx) {
+        Optional<? extends Boolean> cond = condition.getSingle(ctx);
+        if (cond.isEmpty() || !cond.get()) {
+            return Optional.ofNullable(actualNext);
         } else {
             return getFirst();
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/types/PatternType.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/PatternType.java
@@ -28,14 +28,14 @@ public class PatternType<T> {
         if (!(obj instanceof PatternType)) {
             return false;
         } else {
-            PatternType<?> o = (PatternType<?>) obj;
+            var o = (PatternType<?>) obj;
             return type.equals(o.type) && single == o.single;
         }
     }
 
     @Override
     public String toString() {
-        String[] forms = type.getPluralForms();
+        var forms = type.getPluralForms();
         return forms[single ? 0 : 1];
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/types/Type.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/Type.java
@@ -108,7 +108,7 @@ public class Type<T> {
         this.baseName = baseName;
         this.literalParser = literalParser;
         this.toStringFunction = (Function<Object, String>) toStringFunction;
-        this.pluralForms = StringUtils.getForms(pattern.trim());
+        this.pluralForms = StringUtils.getForms(pattern.strip());
         this.defaultChanger = defaultChanger;
         this.arithmetic = arithmetic;
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/types/Type.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/Type.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -112,9 +113,8 @@ public class Type<T> {
         this.arithmetic = arithmetic;
     }
 
-    @Nullable
-    public Function<String, ? extends T> getLiteralParser() {
-        return literalParser;
+    public Optional<Function<String, ? extends T>> getLiteralParser() {
+        return Optional.ofNullable(literalParser);
     }
 
     public String[] getPluralForms() {
@@ -137,7 +137,7 @@ public class Type<T> {
         if (!(obj instanceof Type)) {
             return false;
         } else {
-            Type<?> o = (Type<?>) obj;
+            var o = (Type<?>) obj;
             return typeClass.equals(o.typeClass) && baseName.equals(o.baseName) &&
                    Arrays.equals(pluralForms, o.pluralForms);
         }
@@ -156,13 +156,11 @@ public class Type<T> {
         return toStringFunction;
     }
 
-    @Nullable
-    public Changer<? super T> getDefaultChanger() {
-        return defaultChanger;
+    public Optional<? extends Changer<? super T>> getDefaultChanger() {
+        return Optional.ofNullable(defaultChanger);
     }
 
-    @Nullable
-    public Arithmetic<T, ?> getArithmetic() {
-        return arithmetic;
+    public Optional<? extends Arithmetic<T, ?>> getArithmetic() {
+        return Optional.ofNullable(arithmetic);
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/types/TypeManager.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/TypeManager.java
@@ -33,9 +33,8 @@ public class TypeManager {
      * @param name the name to get the Type from
      * @return the corresponding Type, or {@literal null} if nothing matched
      */
-    @Nullable
-    public static Type<?> getByExactName(String name) {
-        return nameToType.get(name);
+    public static Optional<? extends Type<?>> getByExactName(String name) {
+        return Optional.ofNullable(nameToType.get(name));
     }
 
     /**
@@ -43,7 +42,7 @@ public class TypeManager {
      * @param name the name to get a Type from
      * @return the matching Type, or {@literal null} if nothing matched
      */
-    public static Optional<Type<?>> getByName(String name) {
+    public static Optional<? extends Type<?>> getByName(String name) {
         for (var t : nameToType.values()) {
             var forms = t.getPluralForms();
             if (name.equalsIgnoreCase(forms[0]) || name.equalsIgnoreCase(forms[1])) {

--- a/src/main/java/io/github/syst3ms/skriptparser/types/comparisons/Comparators.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/comparisons/Comparators.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
  * A class handling registration and usage of {@link Comparator}s
  */
 public class Comparators {
-    public static final Comparator<Object, Object> EQUALS_COMPARATOR = new Comparator<Object, Object>(false) {
+    public static final Comparator<Object, Object> EQUALS_COMPARATOR = new Comparator<>(false) {
         @Override
         public Relation apply(@Nullable Object o, @Nullable Object o2) {
             return Relation.get(Objects.equals(o, o2));

--- a/src/main/java/io/github/syst3ms/skriptparser/types/comparisons/Comparators.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/comparisons/Comparators.java
@@ -87,8 +87,8 @@ public class Comparators {
                     c2 = (Optional<? extends Function<? super S, Optional<?>>>) Converters.getConverter(s, info.getType(!first));
                     if (c2.isPresent()) {
                         return Optional.of(first
-                                        ? new ConvertedComparator<>(info.getComparator(), c2.get())
-                                        : new InverseComparator<>(
+                                ? new ConvertedComparator<>(info.getComparator(), c2.get())
+                                : new InverseComparator<>(
                                         new ConvertedComparator<>(c2.get(), info.getComparator())
                                 )
                         );
@@ -98,11 +98,11 @@ public class Comparators {
                     c1 = (Optional<? extends Function<? super F, Optional<?>>>) Converters.getConverter(f, info.getType(!first));
                     if (c1.isPresent()) {
                         return Optional.of(!first
-                                        ? new ConvertedComparator<>(
+                                ? new ConvertedComparator<>(
                                         (Comparator<? super F, ?>) c1.get(),
                                         (Function<? super S, Optional<?>>) info.getComparator()
                                 )
-                                        : new InverseComparator<>(
+                                : new InverseComparator<>(
                                         new ConvertedComparator<>(info.getComparator(), c1.get())
                                 )
                         );
@@ -161,7 +161,7 @@ public class Comparators {
             var t2 = c2 == null ? Optional.ofNullable(o2) : (Optional<?>) c2.apply(o2);
             if (t1.isEmpty() || t2.isEmpty())
                 return Relation.NOT_EQUAL;
-            return c.apply(t1, t2);
+            return c.apply(t1.get(), t2.get());
         }
 
         @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ChainedConverter.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ChainedConverter.java
@@ -29,8 +29,7 @@ public final class ChainedConverter<F, M, T> implements Function<F, Optional<? e
 
     @Override
     public Optional<? extends T> apply(@Nullable F f) {
-        return first.apply(f)
-                .flatMap(second::apply);
+        return first.apply(f).flatMap(second::apply);
     }
 
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ChainedConverter.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ChainedConverter.java
@@ -2,6 +2,7 @@ package io.github.syst3ms.skriptparser.types.conversions;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -13,26 +14,23 @@ import java.util.function.Function;
  * @param <T> same as Converter's <T> (to)
  * @see Converters#registerConverter(Class, Class, Function)
  */
-public final class ChainedConverter<F, M, T> implements Function<F, T> {
-    private final Function<? super F, ? extends M> first;
-    private final Function<? super M, ? extends T> second;
+public final class ChainedConverter<F, M, T> implements Function<F, Optional<? extends T>> {
+    private final Function<? super F, Optional<? extends M>> first;
+    private final Function<? super M, Optional<? extends T>> second;
 
-    public ChainedConverter(Function<? super F, ? extends M> first, Function<? super M, ? extends T> second) {
+    public ChainedConverter(Function<? super F, Optional<? extends M>> first, Function<? super M, Optional<? extends T>> second) {
         this.first = first;
         this.second = second;
     }
 
-    public static <F, M, T> ChainedConverter<F, M, T> newInstance(Function<? super F, ? extends M> first, Function<? super M, ? extends T> second) {
+    public static <F, M, T> ChainedConverter<F, M, T> newInstance(Function<? super F, Optional<? extends M>> first, Function<? super M, Optional<? extends T>> second) {
         return new ChainedConverter<>(first, second);
     }
 
     @Override
-    @Nullable
-    public T apply(@Nullable F f) {
-        M m = first.apply(f);
-        if (m == null)
-            return null;
-        return second.apply(m);
+    public Optional<? extends T> apply(@Nullable F f) {
+        return first.apply(f)
+                .flatMap(second::apply);
     }
 
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ConverterInfo.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ConverterInfo.java
@@ -1,0 +1,40 @@
+package io.github.syst3ms.skriptparser.types.conversions;
+
+import org.intellij.lang.annotations.MagicConstant;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class ConverterInfo<F, T> {
+    private final Class<F> from;
+    private final Class<T> to;
+    private final Function<? super F, Optional<? extends T>> converter;
+    private final int flags;
+
+    public ConverterInfo(Class<F> from, Class<T> to, Function<? super F, Optional<? extends T>> converter) {
+        this(from, to, converter, Converters.ALL_CHAINING);
+    }
+
+    public ConverterInfo(Class<F> from, Class<T> to, Function<? super F, Optional<? extends T>> converter, @MagicConstant(intValues = {Converters.ALL_CHAINING, Converters.NO_LEFT_CHAINING, Converters.NO_RIGHT_CHAINING, Converters.NO_CHAINING}) int flags) {
+        this.from = from;
+        this.to = to;
+        this.converter = converter;
+        this.flags = flags;
+    }
+
+    public Class<F> getFrom() {
+        return from;
+    }
+
+    public Class<T> getTo() {
+        return to;
+    }
+
+    public Function<? super F, Optional<? extends T>> getConverter() {
+        return converter;
+    }
+
+    public int getFlags() {
+        return flags;
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ConverterUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ConverterUtils.java
@@ -8,7 +8,7 @@ import java.util.function.Function;
 @SuppressWarnings("unchecked")
 public class ConverterUtils {
 
-    public static <F, T> Function<?, ? extends T> createInstanceofConverter(Converters.ConverterInfo<F, T> conv) {
+    public static <F, T> Function<?, ? extends T> createInstanceofConverter(ConverterInfo<F, T> conv) {
         return createInstanceofConverter(conv.getFrom(), (Function<F, T>) conv.getConverter());
     }
 
@@ -22,14 +22,14 @@ public class ConverterUtils {
 
     public static <F, T> Function<? super F, ? extends T> createInstanceofConverter(Function<F, ?> conv, Class<T> to) {
         return f -> {
-            Object o = conv.apply(f);
+            var o = conv.apply(f);
             if (to.isInstance(o))
                 return (T) o;
             return null;
         };
     }
 
-    public static <F, T> Function<?, ? extends T> createDoubleInstanceofConverter(Converters.ConverterInfo<F, ?> conv, Class<T> to) {
+    public static <F, T> Function<?, ? extends T> createDoubleInstanceofConverter(ConverterInfo<F, ?> conv, Class<T> to) {
         return createDoubleInstanceofConverter(conv.getFrom(), (Function<F, ?>) conv.getConverter(), to);
     }
 
@@ -37,7 +37,7 @@ public class ConverterUtils {
         return o -> {
             if (!from.isInstance(o))
                 return null;
-            Object o2 = conv.apply((F) o);
+            var o2 = conv.apply((F) o);
             if (to.isInstance(o2))
                 return (T) o2;
             return null;

--- a/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ConverterUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ConverterUtils.java
@@ -1,5 +1,6 @@
 package io.github.syst3ms.skriptparser.types.conversions;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -8,40 +9,32 @@ import java.util.function.Function;
 @SuppressWarnings("unchecked")
 public class ConverterUtils {
 
-    public static <F, T> Function<?, ? extends T> createInstanceofConverter(ConverterInfo<F, T> conv) {
-        return createInstanceofConverter(conv.getFrom(), (Function<F, T>) conv.getConverter());
+    public static <F, T> Function<?, Optional<? extends T>> createInstanceofConverter(ConverterInfo<F, T> conv) {
+        return createInstanceofConverter(conv.getFrom(), conv.getConverter());
     }
 
-    public static <F, T> Function<?, ? extends T> createInstanceofConverter(Class<F> from, Function<F, T> conv) {
-        return o -> {
-            if (!from.isInstance(o))
-                return null;
-            return conv.apply((F) o);
-        };
+    public static <F, T> Function<?, Optional<? extends T>> createInstanceofConverter(Class<F> from, Function<? super F, Optional<? extends T>> conv) {
+        return p -> Optional.ofNullable(p)
+                .filter(from::isInstance)
+                .flatMap(f -> conv.apply((F) f));
     }
 
-    public static <F, T> Function<? super F, ? extends T> createInstanceofConverter(Function<F, ?> conv, Class<T> to) {
-        return f -> {
-            var o = conv.apply(f);
-            if (to.isInstance(o))
-                return (T) o;
-            return null;
-        };
+    public static <F, T> Function<? super F, Optional<? extends T>> createInstanceofConverter(Function<? super F, Optional<? extends T>> conv, Class<T> to) {
+        return p -> conv.apply(p)
+                .filter(to::isInstance)
+                .map(t -> (T) t);
     }
 
-    public static <F, T> Function<?, ? extends T> createDoubleInstanceofConverter(ConverterInfo<F, ?> conv, Class<T> to) {
-        return createDoubleInstanceofConverter(conv.getFrom(), (Function<F, ?>) conv.getConverter(), to);
+    public static <F, T> Function<?, Optional<? extends T>> createDoubleInstanceofConverter(ConverterInfo<F, ?> conv, Class<T> to) {
+        return createDoubleInstanceofConverter(conv.getFrom(), (Function<F, Optional<?>>) conv.getConverter(), to);
     }
 
-    public static <F, T> Function<?, ? extends T> createDoubleInstanceofConverter(Class<F> from, Function<F, ?> conv, Class<T> to) {
-        return o -> {
-            if (!from.isInstance(o))
-                return null;
-            var o2 = conv.apply((F) o);
-            if (to.isInstance(o2))
-                return (T) o2;
-            return null;
-        };
+    public static <F, T> Function<?, Optional<? extends T>> createDoubleInstanceofConverter(Class<F> from, Function<? super F, Optional<?>> conv, Class<T> to) {
+        return p -> Optional.ofNullable(p)
+                .filter(from::isInstance)
+                .flatMap(f -> conv.apply((F) f))
+                .filter(to::isInstance)
+                .map(t -> (T) t);
     }
 
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/types/conversions/Converters.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/conversions/Converters.java
@@ -60,12 +60,11 @@ public abstract class Converters {
     public static <F, T> void registerConverters(SkriptRegistration registration) {
         for (var info : registration.getConverters()) {
             var inf = (ConverterInfo<F, T>) info;
-            // Well, this is... fun
-            Converters.registerConverter(
+            registerConverter(
                     inf.getFrom(),
                     inf.getTo(),
                     inf.getConverter(),
-                    info.getFlags()
+                    inf.getFlags()
             );
         }
     }
@@ -273,9 +272,11 @@ public abstract class Converters {
         }
         for (var conv : converters) {
             if (conv.getFrom().isAssignableFrom(from) && conv.getTo().isAssignableFrom(to)) {
-                return Optional.of((Function<? super F, Optional<? extends T>>) ConverterUtils.createInstanceofConverter(conv.getConverter(), to));
+                var inf = (ConverterInfo<F, T>) conv;
+                return Optional.of(ConverterUtils.createInstanceofConverter(inf.getConverter(), to));
             } else if (from.isAssignableFrom(conv.getFrom()) && to.isAssignableFrom(conv.getTo())) {
-                return Optional.of((Function<? super F, Optional<? extends T>>) ConverterUtils.createInstanceofConverter(conv));
+                var inf = (ConverterInfo<F, T>) conv;
+                return Optional.of((Function<? super F, Optional<? extends T>>) ConverterUtils.createInstanceofConverter(inf));
             }
         }
         for (var conv : converters) {

--- a/src/main/java/io/github/syst3ms/skriptparser/types/conversions/Converters.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/conversions/Converters.java
@@ -20,7 +20,6 @@
 package io.github.syst3ms.skriptparser.types.conversions;
 
 import io.github.syst3ms.skriptparser.registration.SkriptRegistration;
-import io.github.syst3ms.skriptparser.types.comparisons.Comparator;
 import io.github.syst3ms.skriptparser.util.Pair;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/io/github/syst3ms/skriptparser/types/ranges/Ranges.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/ranges/Ranges.java
@@ -2,6 +2,7 @@ package io.github.syst3ms.skriptparser.types.ranges;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
 
 /**
@@ -18,12 +19,12 @@ public class Ranges {
     }
 
     @SuppressWarnings("unchecked")
-    public static <B, T> RangeInfo<B, T> getRange(Class<B> bound) {
-        for (Class<?> c : rangeMap.keySet()) {
+    public static <B, T> Optional<? extends RangeInfo<B, T>> getRange(Class<B> bound) {
+        for (var c : rangeMap.keySet()) {
             if (c == bound || c.isAssignableFrom(bound)) {
-                return (RangeInfo<B, T>) rangeMap.get(c);
+                return Optional.ofNullable((RangeInfo<B, T>) rangeMap.get(c));
             }
         }
-        return null;
+        return Optional.empty();
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/util/ClassUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/ClassUtils.java
@@ -10,22 +10,22 @@ public class ClassUtils {
      * @return the nearest common superclass of the provided classes, accounting for interfaces
      */
     public static Class<?> getCommonSuperclass(Class<?>... cs) {
-        Class<?> r = cs[0];
+        var r = cs[0];
         outer:
-        for (Class<?> c : cs) {
+        for (var c : cs) {
             if (c.isAssignableFrom(r)) {
                 r = c;
                 continue;
             }
             if (!r.isAssignableFrom(c)) {
-                Class<?> s = c;
+                var s = c;
                 while ((s = s.getSuperclass()) != null) {
                     if (s != Object.class && s.isAssignableFrom(r)) {
                         r = s;
                         continue outer;
                     }
                 }
-                for (Class<?> i : c.getInterfaces()) {
+                for (var i : c.getInterfaces()) {
                     s = getCommonSuperclass(i, r);
                     if (s != Object.class) {
                         r = s;
@@ -45,7 +45,7 @@ public class ClassUtils {
      * @return whether the first argument contains a superclass of the second argument
      */
     public static boolean containsSuperclass(Class<?>[] haystack, Class<?> needle) {
-        for (Class<?> c : haystack) {
+        for (var c : haystack) {
             if (c.isArray())
                 c = c.getComponentType();
             if (c.isAssignableFrom(needle))

--- a/src/main/java/io/github/syst3ms/skriptparser/util/ClassUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/ClassUtils.java
@@ -40,7 +40,7 @@ public class ClassUtils {
 
     /**
      * Checks whether an array of classes contains a superclass of the second class argument
-     * @param haystack the array of classes to checl
+     * @param haystack the array of classes to check
      * @param needle the class which may have a superclass inside of the array
      * @return whether the first argument contains a superclass of the second argument
      */

--- a/src/main/java/io/github/syst3ms/skriptparser/util/CollectionUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/CollectionUtils.java
@@ -20,8 +20,8 @@ public class CollectionUtils {
     }
 
     public static <T> T[] reverseArray(T[] array) {
-        for (int i = 0; i < array.length / 2; i++) {
-            T temp = array[i];
+        for (var i = 0; i < array.length / 2; i++) {
+            var temp = array[i];
             array[i] = array[array.length - 1 - i];
             array[array.length - 1 - i] = temp;
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/util/DoubleOptional.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/DoubleOptional.java
@@ -1,0 +1,363 @@
+package io.github.syst3ms.skriptparser.util;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.*;
+
+/**
+ * A double-valued version of an {@link Optional}, containing very similar methods.
+ *
+ * Note that the two values aren't really independent : either both are set, or both are empty.
+ * @param <T1> the type of the first value
+ * @param <T2> the type of the second value
+ */
+public class DoubleOptional<T1, T2> {
+    /**
+     * Common instance for {@code empty()}
+     */
+    private static final DoubleOptional<?, ?> EMPTY = new DoubleOptional<>();
+
+    /**
+     * If non-null, the first value is present ; if null, it is absent.
+     */
+    @Nullable
+    private final T1 first;
+    /**
+     * If non-null, the second value is present ; if null, it is absent.
+     */
+    @Nullable
+    private final T2 second;
+
+    /**
+     * Constructs an empty instance.
+     */
+    private DoubleOptional() {
+        this.first = null;
+        this.second = null;
+    }
+
+    /**
+     * Constructs a non-empty instance.
+     *
+     * @param first the first value
+     * @param second the second value
+     * @throws NullPointerException if either parameters are {@literal null}.
+     */
+    private DoubleOptional(T1 first, T2 second) {
+        this.first = Objects.requireNonNull(first);
+        this.second = Objects.requireNonNull(second);
+    }
+
+    /**
+     * Returns an empty {@code DoubleOptional} instance.
+     *
+     * @param <T1> the type of the first non-existent value
+     * @param <T2> the type of the second non-existent value
+     * @return an empty {@code DoubleOptional}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1, T2> DoubleOptional<T1, T2> empty() {
+        return (DoubleOptional<T1, T2>) EMPTY;
+    }
+
+    /**
+     * Returns an {@code Optional} describing the given non-{@code null}
+     * value.
+     *
+     * @param first the first value to describe, which must be non-{@code null}
+     * @param second the second value to describe, which must be non-{@code null}
+     * @param <T1> the type of the first value
+     * @param <T2> the type fo the second value
+     * @return a {@code DoubleOptional} with the value present
+     * @throws NullPointerException if either first or second are {@code null}
+     */
+    public static <T1, T2> DoubleOptional<T1, T2> of(T1 first, T2 second) {
+        return new DoubleOptional<>(first, second);
+    }
+
+    /**
+     * Returns a {@code DoubleOptional} describing the given values, if
+     * both non-{@code null}, otherwise returns an empty {@code DoubleOptional}.
+     *
+     * @param first the first possibly {@code null} value to describe
+     * @param second the secpond possibly {@code null} value to describe
+     * @param <T1> the type of the first value
+     * @param <T2> the type of the second value
+     * @return a {@code DoubleOptional} with both values present if the specified values
+     *         are both non-{@code null}, otherwise an empty {@code DoubleOptional}
+     */
+    public static <T1, T2> DoubleOptional<T1, T2> ofNullable(@Nullable T1 first, @Nullable T2 second) {
+        return first == null || second == null ? empty() : new DoubleOptional<>(first, second);
+    }
+
+    /**
+     * Returns a {@code DoubleOptional} describing the values represented by two {@link Optional}s if both
+     * are present, otherwise returns an empty {@code DoubleOptional}.
+     *
+     * @param first a possibly empty {@link Optional} describing the first value
+     * @param second a possibly empty {@link Optional} describing the second value
+     * @param <T1> the type of the first value
+     * @param <T2> the type of the second value
+     * @return a {@code DoubleOptional} describing the two values described by the two {@link Optional}s,
+     *         if both are present, otherwise an empty {@code DoubleOptional}
+     */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public static <T1, T2> DoubleOptional<T1, T2> ofOptional(Optional<T1> first, Optional<T2> second) {
+        return first.isEmpty() || second.isEmpty() ? empty() : new DoubleOptional<>(first.get(), second.get());
+    }
+
+    /**
+     * If the first value is present, returns the value, otherwise throws a {@link NoSuchElementException}.
+     *
+     * @return the non-null first value of this {@code DoubleOptional}
+     * @throws NoSuchElementException if no first value is present
+     */
+    public T1 getFirst() {
+        if (first == null) {
+            throw new NoSuchElementException("No first value present");
+        }
+        return first;
+    }
+
+    /**
+     * If the second value is present, returns the value, otherwise throws a {@link NoSuchElementException}.
+     *
+     * @return the non-null second value of this {@code DoubleOptional}
+     * @throws NoSuchElementException if no second value is present
+     */
+    public T2 getSecond() {
+        if (second == null) {
+            throw new NoSuchElementException("No second value present");
+        }
+        return second;
+    }
+
+    /**
+     * If both values are present, returns {@code true}, otherwise {@code false}.
+     *
+     * @return {@code true} if both values are present, otherwise {@code false}.
+     */
+    public boolean isPresent() {
+        return first != null && second != null;
+    }
+
+    /**
+     * If either values are absent, returns {@code true}, otherwise {@code false}.
+     *
+     * @return {@code true} if either values are absent, otherwise {@code false}
+     */
+    public boolean isEmpty() {
+        return first == null || second == null;
+    }
+
+    /**
+     * If both values are present, does the given action using both values, otherwise does nothing.
+     *
+     * @param action the action to be performed if both values are present
+     */
+    public void ifPresent(BiConsumer<? super T1, ? super T2> action) {
+        if (first != null && second != null) {
+            action.accept(first, second);
+        }
+    }
+
+    /**
+     * If both values are present, does the first action using both values, otherwise does the second action.
+     *
+     * @param action the action to be performed if both values are present
+     * @param emptyAction the action to be performed if either values are absent
+     */
+    public void ifPresentOrElse(BiConsumer<? super T1, ? super T2> action, Runnable emptyAction) {
+        if (isPresent()) {
+            action.accept(first, second);
+        } else {
+            emptyAction.run();
+        }
+    }
+
+    /**
+     * If both values are present and match the given predicate, returns a {@code DoubleOptional} describing
+     * these values, otherwise returns an empty {@code DoubleOptional}.
+     *
+     * @param predicate the predicate to test both values against, if present
+     * @return a {@code DoubleOptional} describing these values, if they are present and match the given predicate,
+     *         otherwise an empty {@code DoubleOptional}
+     */
+    public DoubleOptional<T1, T2> filter(BiPredicate<? super T1, ? super T2> predicate) {
+        if (isEmpty()) {
+            return this;
+        } else {
+            return predicate.test(first, second) ? this : empty();
+        }
+    }
+
+    /**
+     * If both values are present, returns a {@code DoubleOptional} describing the result
+     * (as if by {@link #ofNullable(Object, Object)}) of applying each given mapping function
+     * to its respective value, and otherwise returns an empty {@code DoubleOptional}.
+     *
+     * If either mapping function returns {@code null}, the result will be an empty {@code DoubleOptional}.
+     *
+     * @param firstMapper the mapping function to apply to the first value, if present
+     * @param secondMapper the mapping function to apply to the second value, if present
+     * @param <U> the new type of the first value
+     * @param <V> the new type of the second value
+     * @return a {@code DoubleOptional} describing the result of applying mapping functions
+     *         to each of the values if present, and an empty {@code DoubleOptional} otherwise.
+     */
+    public <U, V> DoubleOptional<U, V> map(
+            Function<? super T1, ? extends U> firstMapper,
+            Function<? super T2, ? extends V> secondMapper) {
+        if (isEmpty()) {
+            return empty();
+        } else {
+            return DoubleOptional.ofNullable(firstMapper.apply(first), secondMapper.apply(second));
+        }
+    }
+
+    /**
+     * If both values are present, returns an {@link Optional} constructed from the result of the given mapping
+     * function applied to both values, otherwise returns an empty {@link Optional}.
+     *
+     * If the mapping function returns {@code null}, an empty {@link Optional} is returned.
+     *
+     * @param mapper the mapping function taking both values as inputs
+     * @param <U> the type of the resulting {@link Optional}
+     * @return an {@link Optional} describing the result of applying the mapping function to both values if present,
+     *         and an empty {@link Optional} otherwise
+     */
+    public <U> Optional<U> mapToOptional(BiFunction<? super T1, ? super T2, ? extends U> mapper) {
+        if (isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.ofNullable(mapper.apply(first, second));
+        }
+    }
+
+    /**
+     * If both values are present, returns the result of applying the given {@code DoubleOptional}-returning
+     * mapping function to both values, and otherwise returns an empty {@code DoubleOptional}.
+     *
+     * This is similar to {@link #map(Function, Function)}, but it doesn't wrap the result in an additional
+     * {@code DoubleOptional}.
+     *
+     * @param mapper the mapping function taking in both values (if present) and returning a {@code DoubleOptional}
+     * @param <U> the type of the first value of the new {@code DoubleOptional}
+     * @param <V> the type of the second value of the new {@code DoubleOptional}
+     * @return the result of applying the mapping function to both values if present, and an empty {@code DoubleOptional}
+     *         otherwise
+     * @throws NullPointerException if the mapping function returns {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    public <U, V> DoubleOptional<U, V> flatMap(BiFunction<? super T1, ? super T2, DoubleOptional<? extends U, ? extends V>> mapper) {
+        if (isEmpty()) {
+            return empty();
+        } else {
+            DoubleOptional<U, V> opt = (DoubleOptional<U, V>) mapper.apply(first, second);
+            return Objects.requireNonNull(opt);
+        }
+    }
+
+    /**
+     * If both values are present, returns the result of applying the given {@link Optional}-returning
+     * mapping function to both values, and otherwise returns an empty {@link Optional}.
+     *
+     * This is similar to {@link #mapToOptional(BiFunction)}, but it doesn't wrap the result in an additional
+     * {@link Optional}.
+     *
+     * @param mapper the mapping function taking in both values (if present) and returning an {@link Optional}
+     * @param <U> the type of the new {@link Optional}
+     * @return the result of applying the mapping function to both values if present, and an empty {@link Optional}
+     *         otherwise
+     * @throws NullPointerException if the mapping function returns {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    public <U> Optional<U> flatMapToOptional(BiFunction<? super T1, ? super T2, Optional<? extends U>> mapper) {
+        if (isEmpty()) {
+            return Optional.empty();
+        } else {
+            Optional<U> opt = (Optional<U>) mapper.apply(first, second);
+            return Objects.requireNonNull(opt);
+        }
+    }
+
+    /**
+     * If both values are present, returns a {@code DoubleOptional} describing them, otherwise returns
+     * a {@code DoubleOptional} obtained from the given supplier function.
+     *
+     * @param supplier the supplier producing the {@code DoubleOptional} returned if this one is empty
+     * @return a {@code DoubleOptional} describing the two values if present, and otherwise the {@code DoubleOptional}
+     *         produced by the given supplier function
+     */
+    @SuppressWarnings("unchecked")
+    public DoubleOptional<T1, T2> or(Supplier<? extends DoubleOptional<? extends T1, ? extends T2>> supplier) {
+        if (isPresent()) {
+            return this;
+        } else {
+            DoubleOptional<T1, T2> opt = (DoubleOptional<T1, T2>) supplier.get();
+            return Objects.requireNonNull(opt);
+        }
+    }
+
+    /**
+     * If the first value is present, returns it, otherwise returns {@code other}.
+     *
+     * @param other the value to be returned if the first value is not present (may be {@code null})
+     * @return the first value if present, otherwise {@code other}
+     */
+    @Contract("!null -> !null")
+    @Nullable
+    public T1 firstOrElse(@Nullable T1 other) {
+        return first != null ? first : other;
+    }
+
+    /**
+     * If the second value is present, returns it, otherwise returns {@code other}.
+     *
+     * @param other the value to be returned if the second value is not present (may be {@code null})
+     * @return the second value if present, otherwise {@code other}
+     */
+    @Contract("!null -> !null")
+    @Nullable
+    public T2 secondOrElse(@Nullable T2 other) {
+        return second != null ? second : other;
+    }
+
+    /**
+     * If the first value is present, returns it, otherwise throws an exception produced by the given
+     * exception-supplying function.
+     *
+     * @param exceptionSupplier the function producing the exception to be thrown if the first value is not present
+     * @param <X> the type of exception that may be thrown
+     * @return the first value if present
+     * @throws X if the first value is not present
+     */
+    public <X extends Throwable> T1 firstOrElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
+        if (first != null) {
+            return first;
+        } else {
+            throw exceptionSupplier.get();
+        }
+    }
+
+    /**
+     * If the second value is present, returns it, otherwise throws an exception produced by the given
+     * exception-supplying function.
+     *
+     * @param exceptionSupplier the function producing the exception to be thrown if the second value is not present
+     * @param <X> the type of exception that may be thrown
+     * @return the second value if present
+     * @throws X if the second value is not present
+     */
+    public <X extends Throwable> T2 secondOrElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
+        if (second != null) {
+            return second;
+        } else {
+            throw exceptionSupplier.get();
+        }
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
@@ -7,11 +7,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Enumeration;
 import java.util.List;
-import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**

--- a/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
@@ -126,7 +126,7 @@ public class FileUtils {
                             break;
                         }
                     }
-                    if (load && !e.getName().matches(".+\\$\\d+\\.class$")) { // It's of very little use to load anonymous classes
+                    if (load && !e.getName().matches(".+\\$\\d+\\.class")) { // It's of very little use to load anonymous classes
                         final var c = e.getName().replace('/', '.').substring(0, e.getName().length() - ".class".length());
                         try {
                             Class.forName(c, true, FileUtils.class.getClassLoader());

--- a/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
@@ -43,8 +43,8 @@ public class FileUtils {
      */
     public static List<String> readAllLines(Path filePath) throws IOException {
         List<String> lines = new ArrayList<>();
-        StringBuilder multilineBuilder = new StringBuilder();
-        for (String line : Files.readAllLines(filePath, StandardCharsets.UTF_8)) {
+        var multilineBuilder = new StringBuilder();
+        for (var line : Files.readAllLines(filePath, StandardCharsets.UTF_8)) {
             line = line.replaceAll("\\s*$", "");
             if (line.replace("\\" + MULTILINE_SYNTAX_TOKEN, "\0")
                     .endsWith(MULTILINE_SYNTAX_TOKEN)) {
@@ -72,9 +72,9 @@ public class FileUtils {
      * @return the indentation level
      */
     public static int getIndentationLevel(String line, boolean countAllSpaces) {
-        Matcher m = LEADING_WHITESPACE_PATTERN.matcher(line);
+        var m = LEADING_WHITESPACE_PATTERN.matcher(line);
         if (m.matches()) {
-            String space = m.group(1);
+            var space = m.group(1);
             if (countAllSpaces) {
                 return 4 * StringUtils.count(space, "\t") + StringUtils.count(space, " ");
             } else {
@@ -86,20 +86,20 @@ public class FileUtils {
     }
 
     private static String trimMultilineIndent(String multilineText) {
-        String[] lines = multilineText.split("\0");
+        var lines = multilineText.split("\0");
         // Inspired from Kotlin's trimIndent() function
-        int baseIndent = Arrays.stream(lines)
+        var baseIndent = Arrays.stream(lines)
                                .skip(1) // First line's indent should be ignored
                                .mapToInt(l -> getIndentationLevel(l, true))
                                .min()
                                .orElse(0);
         if (baseIndent == 0)
             return multilineText.replace("\0", "");
-        Pattern pat = Pattern.compile("\\s");
-        StringBuilder sb = new StringBuilder(lines[0]);
-        for (String line : Arrays.copyOfRange(lines, 1, lines.length)) {
-            Matcher m = pat.matcher(line);
-            for (int i = 0; i < baseIndent && m.find(); i++) {
+        var pat = Pattern.compile("\\s");
+        var sb = new StringBuilder(lines[0]);
+        for (var line : Arrays.copyOfRange(lines, 1, lines.length)) {
+            var m = pat.matcher(line);
+            for (var i = 0; i < baseIndent && m.find(); i++) {
                 line = line.replaceFirst(m.group(), "");
             }
             sb.append(line);
@@ -110,26 +110,27 @@ public class FileUtils {
     /**
      * Loads all classes of selected packages of the skript-parser JAR.
      * @param basePackage a root package
-     * @param subPackages a list of all subpackages of the root package, in which classes will be loaded
+     * @param subPackages a list of all subpackages of the root package, in which classes will be leadied
+     * @throws IOException
      */
     public static void loadClasses(File jarFile, String basePackage, String... subPackages) throws IOException {
-        for (int i = 0; i < subPackages.length; i++)
+        for (var i = 0; i < subPackages.length; i++)
             subPackages[i] = subPackages[i].replace('.', '/') + "/";
         basePackage = basePackage.replace('.', '/') + "/";
-        try (JarFile jar = new JarFile(jarFile)) {
-            Enumeration<JarEntry> entries = jar.entries();
+        try (var jar = new JarFile(jarFile)) {
+            var entries = jar.entries();
             while (entries.hasMoreElements()) {
-                JarEntry e = entries.nextElement();
+                var e = entries.nextElement();
                 if (e.getName().startsWith(basePackage) && e.getName().endsWith(".class")) {
-                    boolean load = subPackages.length == 0;
-                    for (final String sub : subPackages) {
+                    var load = subPackages.length == 0;
+                    for (final var sub : subPackages) {
                         if (e.getName().startsWith(sub, basePackage.length())) {
                             load = true;
                             break;
                         }
                     }
-                    if (load) {
-                        final String c = e.getName().replace('/', '.').substring(0, e.getName().length() - ".class".length());
+                    if (load && !e.getName().matches(".+\\$\\d+\\.class$")) { // It's of very little use to load anonymous classes
+                        final var c = e.getName().replace('/', '.').substring(0, e.getName().length() - ".class".length());
                         try {
                             Class.forName(c, true, FileUtils.class.getClassLoader());
                         } catch (final ClassNotFoundException | ExceptionInInitializerError ex) {

--- a/src/main/java/io/github/syst3ms/skriptparser/util/MultiMap.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/MultiMap.java
@@ -34,7 +34,7 @@ public class MultiMap<K, V> extends HashMap<K, List<V>> {
     public List<V> getAllValues() {
         List<V> values = new ArrayList<>();
         for (Iterable<V> v : values()) {
-            for (V val : v) {
+            for (var val : v) {
                 values.add(val);
             }
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/util/Pair.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/Pair.java
@@ -36,7 +36,7 @@ public class Pair<T, U> {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        Pair<?, ?> pair = (Pair<?, ?>) o;
+        var pair = (Pair<?, ?>) o;
         return first.equals(pair.first) &&
                 second.equals(pair.second);
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/util/RecentElementList.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/RecentElementList.java
@@ -45,8 +45,8 @@ public class RecentElementList<T> implements Iterable<T> {
             occurrences.add(element);
             backing.add(new AbstractMap.SimpleEntry<>(element, 1));
         } else {
-            for (int i = 0; i < backing.size(); i++) {
-                Map.Entry<T, Integer> freq = backing.get(i);
+            for (var i = 0; i < backing.size(); i++) {
+                var freq = backing.get(i);
                 if (freq.getKey().equals(element)) {
                     freq.setValue(freq.getValue() + 1);
                     backing.set(i, freq);

--- a/src/main/java/io/github/syst3ms/skriptparser/util/RecentElementList.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/RecentElementList.java
@@ -76,7 +76,7 @@ public class RecentElementList<T> implements Iterable<T> {
          * care about here. This shouldn't cause issues even if parallel parsing is implemented, because any reasonable
          * implementation would not use one RecentElementList across multiple threads. At least I hope so...
          */
-        return new Iterator<T>() {
+        return new Iterator<>() {
             private final List<Map.Entry<T, Integer>> b = backing;
             private int index = 0;
 

--- a/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
@@ -3,12 +3,10 @@ package io.github.syst3ms.skriptparser.util;
 import io.github.syst3ms.skriptparser.log.ErrorType;
 import io.github.syst3ms.skriptparser.log.SkriptLogger;
 import io.github.syst3ms.skriptparser.parsing.SkriptParserException;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**

--- a/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,26 +24,12 @@ public class StringUtils {
      * @return the amount of total occurences
      */
     public static int count(String s, String... toFind) {
-        int count = 0;
-        for (String sequence : toFind) {
-            int occurrences = s.length() - s.replace(sequence, "").length();
+        var count = 0;
+        for (var sequence : toFind) {
+            var occurrences = s.length() - s.replace(sequence, "").length();
             count += occurrences / sequence.length();
         }
         return count;
-    }
-
-    /**
-     * Simply repeats the given string the given amount of times
-     * @param str the string
-     * @param times the amount of times to be repeated
-     * @return the repeated string
-     */
-    public static String repeat(String str, int times) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < times; i++) {
-            sb.append(str);
-        }
-        return sb.toString();
     }
 
     /**
@@ -54,9 +41,9 @@ public class StringUtils {
      * @return the index at which the brace pair closes
      */
     public static int findClosingIndex(String pattern, char opening, char closing, int start) {
-        int n = 0;
-        for (int i = start; i < pattern.length(); i++) {
-            char c = pattern.charAt(i);
+        var n = 0;
+        for (var i = start; i < pattern.length(); i++) {
+            var c = pattern.charAt(i);
             if (c == '\\') {
                 i++;
             } else if (c == closing) {
@@ -79,13 +66,12 @@ public class StringUtils {
      * @param start where the brace pair starts
      * @return the enclosed text
      */
-    @Nullable
-    public static String getEnclosedText(String pattern, char opening, char closing, int start) {
-        int closingBracket = findClosingIndex(pattern, opening, closing, start);
+    public static Optional<String> getEnclosedText(String pattern, char opening, char closing, int start) {
+        var closingBracket = findClosingIndex(pattern, opening, closing, start);
         if (closingBracket == -1) {
-            return null;
+            return Optional.empty();
         } else {
-            return pattern.substring(start + 1, closingBracket);
+            return Optional.of(pattern.substring(start + 1, closingBracket));
         }
     }
 
@@ -99,30 +85,30 @@ public class StringUtils {
     public static int nextSimpleCharacterIndex(String s, int index) {
         if (index < 0)
             throw new StringIndexOutOfBoundsException(index);
-        char[] chars = s.toCharArray();
-        for (int i = index; i < chars.length; i++) {
-            char c = chars[i];
+        var chars = s.toCharArray();
+        for (var i = index; i < chars.length; i++) {
+            var c = chars[i];
             if (c == '\\') {
                 if (i == chars.length - 1)
                     return -1;
                 return i + 1;
             } else if (c == '{') {
-                int closing = findClosingIndex(s, '{', '}', i);
+                var closing = findClosingIndex(s, '{', '}', i);
                 if (closing == -1)
                     return -1;
                 i = closing;
             } else if (c == '"') {
-                int closing = s.indexOf('"', i + 1);
+                var closing = s.indexOf('"', i + 1);
                 if (closing == -1)
                     return -1;
                 i = closing;
             } else if (c == '\'') {
-                int closing = s.indexOf('\'', i + 1);
+                var closing = s.indexOf('\'', i + 1);
                 if (closing == -1)
                     return -1;
                 i = closing;
             } else if (c == 'R' && i < s.length() - 2 && chars[i + 1] == '"') {
-                Matcher m = R_LITERAL_CONTENT_PATTERN.matcher(s).region(i + 2, s.length());
+                var m = R_LITERAL_CONTENT_PATTERN.matcher(s).region(i + 2, s.length());
                 if (!m.lookingAt())
                     return -1;
                 i = m.end() + 1;
@@ -139,24 +125,23 @@ public class StringUtils {
      * @param start where the pair begins
      * @return the content between %%
      */
-    @Nullable
-    public static String getPercentContent(String s, int start) {
-        for (int i = start; i < s.length(); i++) {
-            char c = s.charAt(i);
+    public static Optional<String> getPercentContent(String s, int start) {
+        for (var i = start; i < s.length(); i++) {
+            var c = s.charAt(i);
             if (c == '\\') {
                 i++;
             } else if (c == '{') { // We must ignore variable content
-                int closing = findClosingIndex(s, '{', '}', i);
+                var closing = findClosingIndex(s, '{', '}', i);
                 if (closing == -1)
-                    return null;
+                    return Optional.empty();
                 i = closing;
             } else if (c == '%') {
-                return s.substring(start, i);
+                return Optional.of(s.substring(start, i));
             } else if (c == '}') { // We normally skip over these, this must be an error
-                return null;
+                return Optional.empty();
             }
         }
-        return null; // There were no percents (unclosed percent is handled by VariableString already)
+        return Optional.empty(); // There were no percents (unclosed percent is handled by VariableString already)
     }
 
     /**
@@ -173,23 +158,23 @@ public class StringUtils {
             // Fallback to legacy behavior.
             return haystack.indexOf(needle);
         }
-        for (int i = start; i < haystack.length(); ++i) {
+        for (var i = start; i < haystack.length(); ++i) {
             // Early out, if possible.
             if (i + needle.length() > haystack.length()) {
                 return -1;
             }
 
             // Attempt to match substring starting at position i of haystack.
-            int j = 0;
-            int ii = i;
-            while (ii < haystack.length() && j < needle.length()) {
-                char c = Character.toLowerCase(haystack.charAt(ii));
-                char c2 = Character.toLowerCase(needle.charAt(j));
+            var j = 0;
+            var k = i;
+            while (k < haystack.length() && j < needle.length()) {
+                var c = Character.toLowerCase(haystack.charAt(k));
+                var c2 = Character.toLowerCase(needle.charAt(j));
                 if (c != c2) {
                     break;
                 }
                 j++;
-                ii++;
+                k++;
             }
             // Walked all the way to the end of the needle, return the start
             // position that this was found.
@@ -206,26 +191,27 @@ public class StringUtils {
      * @param logger the logger
      * @return the split string
      */
-    public static String[] splitVerticalBars(String s, SkriptLogger logger) {
+    public static Optional<String[]> splitVerticalBars(String s, SkriptLogger logger) {
         List<String> split = new ArrayList<>();
-        StringBuilder sb = new StringBuilder();
-        char[] chars = s.toCharArray();
-        for (int i = 0; i < chars.length; i++) {
-            char c = chars[i];
+        var sb = new StringBuilder();
+        var chars = s.toCharArray();
+        for (var i = 0; i < chars.length; i++) {
+            var c = chars[i];
             if (c == '\\') {
                 sb.append(c);
                 if (i + 1 < s.length()) {
                     sb.append(chars[++i]);
                 }
             } else if (c == '(' || c == '[') {
-                char closing = c == '(' ? ')' : ']';
-                String text = getEnclosedText(s, c, closing, i);
-                if (text == null) {
+                var closing = c == '(' ? ')' : ']';
+                var text = getEnclosedText(s, c, closing, i);
+                text.ifPresent(st -> sb.append(c).append(st).append(closing));
+                if (text.isPresent()) {
+                    i += text.get().length() + 1;
+                } else {
                     logger.error("Unmatched bracket : '" + s.substring(i) + "'", ErrorType.MALFORMED_INPUT);
-                    return null;
+                    return Optional.empty();
                 }
-                sb.append(c).append(text).append(closing);
-                i += text.length() + 1;
             } else if (c == '|') {
                 split.add(sb.toString());
                 sb.setLength(0);
@@ -234,7 +220,7 @@ public class StringUtils {
             }
         }
         split.add(sb.toString());
-        return split.toArray(new String[0]);
+        return Optional.of(split.toArray(new String[0]));
     }
 
     /**
@@ -243,8 +229,8 @@ public class StringUtils {
      */
     public static String[] getForms(String pluralizable) {
         List<String[]> words = new ArrayList<>();
-        for (String s : pluralizable.split("\\s+")) {
-            String[] split = s.split("@");
+        for (var s : pluralizable.split("\\s+")) {
+            var split = s.split("@");
             switch (split.length) {
                 case 1:
                     words.add(new String[]{s, s});
@@ -259,8 +245,8 @@ public class StringUtils {
                     throw new SkriptParserException("Invalid pluralized word : " + s);
             }
         }
-        String[] pluralized = new String[]{"", ""};
-        for (String[] word : words) {
+        var pluralized = new String[]{"", ""};
+        for (var word : words) {
             pluralized[0] += word[0] + " ";
             pluralized[1] += word[1] + " ";
         }
@@ -273,7 +259,7 @@ public class StringUtils {
      * @return the array with all of its contents trimmed
      */
     private static String[] trimAll(String[] strings) {
-        for (int i = 0; i < strings.length; i++)
+        for (var i = 0; i < strings.length; i++)
             strings[i] = strings[i].trim();
         return strings;
     }
@@ -290,7 +276,7 @@ public class StringUtils {
             return "";
         else if (plural)
             return noun;
-        char first = Character.toLowerCase(noun.charAt(0));
+        var first = Character.toLowerCase(noun.charAt(0));
         switch (first) {
             case 'a':
             case 'e':

--- a/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
@@ -16,10 +16,10 @@ public class StringUtils {
     public static final Pattern R_LITERAL_CONTENT_PATTERN = Pattern.compile("(.+?)\\((.+)\\)\\1"); // It's actually rare to be able to use '.+' raw like this
 
     /**
-     * Counts combined occurences of one or more strings in another
-     * @param s the string to find occurences in
-     * @param toFind the strings to find occurences of
-     * @return the amount of total occurences
+     * Counts combined occurrences of one or more strings in another
+     * @param s the string to find occurrences in
+     * @param toFind the strings to find occurrences of
+     * @return the amount of total occurrences
      */
     public static int count(String s, String... toFind) {
         var count = 0;
@@ -147,11 +147,9 @@ public class StringUtils {
      * @param haystack the string to look in
      * @param needle the string to look for
      * @param start where to look from
-     * @return the index of the first occurence
+     * @return the index of the first occurrence
      */
-    public static int indexOfIgnoreCase(String haystack,
-                                        String needle,
-                                        int start) {
+    public static int indexOfIgnoreCase(String haystack, String needle, int start) {
         if (needle.isEmpty() || haystack.isEmpty()) {
             // Fallback to legacy behavior.
             return haystack.indexOf(needle);
@@ -175,7 +173,7 @@ public class StringUtils {
                 k++;
             }
             // Walked all the way to the end of the needle, return the start
-            // position that this was found.
+            // position that this was found at.
             if (j == needle.length()) {
                 return i;
             }
@@ -248,7 +246,7 @@ public class StringUtils {
             pluralized[0] += word[0] + " ";
             pluralized[1] += word[1] + " ";
         }
-        return trimAll(pluralized);
+        return stripAll(pluralized);
     }
 
     /**
@@ -256,9 +254,9 @@ public class StringUtils {
      * @param strings the strings
      * @return the array with all of its contents trimmed
      */
-    private static String[] trimAll(String[] strings) {
+    private static String[] stripAll(String[] strings) {
         for (var i = 0; i < strings.length; i++)
-            strings[i] = strings[i].trim();
+            strings[i] = strings[i].strip();
         return strings;
     }
 
@@ -269,7 +267,7 @@ public class StringUtils {
      * @return the string with its proper indefinite article
      */
     public static String withIndefiniteArticle(String noun, boolean plural) {
-        noun = noun.trim();
+        noun = noun.strip();
         if (noun.isEmpty())
             return "";
         else if (plural)

--- a/src/main/java/io/github/syst3ms/skriptparser/util/math/BigDecimalMath.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/math/BigDecimalMath.java
@@ -42,9 +42,9 @@ public class BigDecimalMath {
     private static BigDecimal eCache;
 
     static {
-        BigDecimal result = ONE;
+        var result = ONE;
         factorialCache[0] = result;
-        for (int i = 1; i < factorialCache.length; i++) {
+        for (var i = 1; i < factorialCache.length; i++) {
             result = result.multiply(valueOf(i));
             factorialCache[i] = result;
         }
@@ -109,7 +109,7 @@ public class BigDecimalMath {
      * @see #exponent(BigDecimal)
      */
     public static BigDecimal mantissa(BigDecimal value) {
-        int exponent = exponent(value);
+        var exponent = exponent(value);
         if (exponent == 0) {
             return value;
         }
@@ -199,14 +199,14 @@ public class BigDecimalMath {
             return factorialCache[n];
         }
 
-        BigDecimal result = factorialCache[factorialCache.length - 1];
+        var result = factorialCache[factorialCache.length - 1];
         return result.multiply(factorialRecursion(factorialCache.length, n));
     }
 
     private static BigDecimal factorialLoop(int n1, final int n2) {
-        final long limit = Long.MAX_VALUE / n2;
+        final var limit = Long.MAX_VALUE / n2;
         long accu = 1;
-        BigDecimal result = BigDecimal.ONE;
+        var result = BigDecimal.ONE;
         while (n1 <= n2) {
             if (accu <= limit) {
                 accu *= n1;
@@ -220,11 +220,11 @@ public class BigDecimalMath {
     }
 
     private static BigDecimal factorialRecursion(final int n1, final int n2) {
-        int threshold = n1 > 200 ? 80 : 150;
+        var threshold = n1 > 200 ? 80 : 150;
         if (n2 - n1 < threshold) {
             return factorialLoop(n1, n2);
         }
-        final int mid = (n1 + n2) >> 1;
+        final var mid = (n1 + n2) >> 1;
         return factorialRecursion(mid + 1, n2).multiply(factorialRecursion(n1, mid));
     }
 
@@ -259,22 +259,22 @@ public class BigDecimalMath {
 
         // https://en.wikipedia.org/wiki/Spouge%27s_approximation
         checkMathContext(mathContext);
-        MathContext mc = new MathContext(mathContext.getPrecision() * 2, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() * 2, mathContext.getRoundingMode());
 
-        int a = mathContext.getPrecision() * 13 / 10;
-        List<BigDecimal> constants = getSpougeFactorialConstants(a);
+        var a = mathContext.getPrecision() * 13 / 10;
+        var constants = getSpougeFactorialConstants(a);
 
-        BigDecimal bigA = BigDecimal.valueOf(a);
+        var bigA = BigDecimal.valueOf(a);
 
-        boolean negative = false;
-        BigDecimal factor = constants.get(0);
-        for (int k = 1; k < a; k++) {
-            BigDecimal bigK = BigDecimal.valueOf(k);
+        var negative = false;
+        var factor = constants.get(0);
+        for (var k = 1; k < a; k++) {
+            var bigK = BigDecimal.valueOf(k);
             factor = factor.add(constants.get(k).divide(x.add(bigK), mc), mc);
             negative = !negative;
         }
 
-        BigDecimal result = pow(x.add(bigA, mc), x.add(BigDecimal.valueOf(0.5), mc), mc);
+        var result = pow(x.add(bigA, mc), x.add(BigDecimal.valueOf(0.5), mc), mc);
         result = result.multiply(exp(x.negate().subtract(bigA, mc), mc), mc);
         result = result.multiply(factor, mc);
 
@@ -285,15 +285,15 @@ public class BigDecimalMath {
         synchronized (spougeFactorialConstantsCacheLock) {
             return spougeFactorialConstantsCache.computeIfAbsent(a, key -> {
                 List<BigDecimal> constants = new ArrayList<>(a);
-                MathContext mc = new MathContext(a * 15 / 10);
+                var mc = new MathContext(a * 15 / 10);
 
-                BigDecimal c0 = sqrt(pi(mc).multiply(TWO, mc), mc);
+                var c0 = sqrt(pi(mc).multiply(TWO, mc), mc);
                 constants.add(c0);
 
-                boolean negative = false;
-                for (int k = 1; k < a; k++) {
-                    BigDecimal bigK = BigDecimal.valueOf(k);
-                    BigDecimal ck = pow(BigDecimal.valueOf(a - k), bigK.subtract(ONE_HALF, mc), mc);
+                var negative = false;
+                for (var k = 1; k < a; k++) {
+                    var bigK = BigDecimal.valueOf(k);
+                    var ck = pow(BigDecimal.valueOf(a - k), bigK.subtract(ONE_HALF, mc), mc);
                     ck = ck.multiply(exp(BigDecimal.valueOf(a - k), mc), mc);
                     ck = ck.divide(factorial(k - 1), mc);
                     if (negative) {
@@ -333,7 +333,7 @@ public class BigDecimalMath {
         // TODO optimize y=0, y=1, y=10^k, y=-1, y=-10^k
 
         try {
-            long longValue = y.longValueExact();
+            var longValue = y.longValueExact();
             return pow(x, longValue, mathContext);
         } catch (ArithmeticException ex) {
             // ignored
@@ -344,8 +344,8 @@ public class BigDecimalMath {
         }
 
         // x^y = exp(y*log(x))
-        MathContext mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
-        BigDecimal result = exp(y.multiply(log(x, mc), mc), mc);
+        var mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
+        var result = exp(y.multiply(log(x, mc), mc), mc);
 
         return round(result, mathContext);
     }
@@ -370,18 +370,18 @@ public class BigDecimalMath {
      *                             {@code BigDecimal}  operation would require rounding.
      */
     public static BigDecimal pow(BigDecimal x, long y, MathContext mathContext) {
-        MathContext mc = mathContext.getPrecision() == 0
+        var mc = mathContext.getPrecision() == 0
                 ? mathContext
                 : new MathContext(mathContext.getPrecision() + 10, mathContext.getRoundingMode());
 
         // TODO optimize y=0, y=1, y=10^k, y=-1, y=-10^k
 
         if (y < 0) {
-            BigDecimal value = reciprocal(pow(x, -y, mc), mc);
+            var value = reciprocal(pow(x, -y, mc), mc);
             return round(value, mathContext);
         }
 
-        BigDecimal result = ONE;
+        var result = ONE;
         while (y > 0) {
             if ((y & 1) == 1) {
                 // odd exponent -> multiply result with x
@@ -420,13 +420,13 @@ public class BigDecimalMath {
             return ONE.divide(powInteger(x, integerY.negate(), mathContext), mathContext);
         }
 
-        MathContext mc = new MathContext(Math.max(mathContext.getPrecision(), -integerY.scale()) + 30,
+        var mc = new MathContext(Math.max(mathContext.getPrecision(), -integerY.scale()) + 30,
                 mathContext.getRoundingMode()
         );
 
-        BigDecimal result = ONE;
+        var result = ONE;
         while (integerY.signum() > 0) {
-            BigDecimal halfY = integerY.divide(TWO, mc);
+            var halfY = integerY.divide(TWO, mc);
 
             if (fractionalPart(halfY).signum() != 0) {
                 // odd exponent -> multiply result with x
@@ -466,8 +466,8 @@ public class BigDecimalMath {
                 throw new ArithmeticException("Illegal sqrt(x) for x < 0: x = " + x);
         }
 
-        int maxPrecision = mathContext.getPrecision() + 6;
-        BigDecimal acceptableError = ONE.movePointLeft(mathContext.getPrecision() + 1);
+        var maxPrecision = mathContext.getPrecision() + 6;
+        var acceptableError = ONE.movePointLeft(mathContext.getPrecision() + 1);
 
         BigDecimal result;
         int adaptivePrecision;
@@ -492,7 +492,7 @@ public class BigDecimalMath {
                 if (adaptivePrecision > maxPrecision) {
                     adaptivePrecision = maxPrecision;
                 }
-                MathContext mc = new MathContext(adaptivePrecision, mathContext.getRoundingMode());
+                var mc = new MathContext(adaptivePrecision, mathContext.getRoundingMode());
                 result = x.divide(result, mc).add(last, mc).multiply(ONE_HALF, mc);
             }
             while (adaptivePrecision < maxPrecision || result.subtract(last).abs().compareTo(acceptableError) > 0);
@@ -547,9 +547,9 @@ public class BigDecimalMath {
      */
     public static BigDecimal log2(BigDecimal x, MathContext mathContext) {
         checkMathContext(mathContext);
-        MathContext mc = new MathContext(mathContext.getPrecision() + 4, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 4, mathContext.getRoundingMode());
 
-        BigDecimal result = log(x, mc).divide(logTwo(mc), mc);
+        var result = log(x, mc).divide(logTwo(mc), mc);
         return round(result, mathContext);
     }
 
@@ -564,9 +564,9 @@ public class BigDecimalMath {
      */
     public static BigDecimal log10(BigDecimal x, MathContext mathContext) {
         checkMathContext(mathContext);
-        MathContext mc = new MathContext(mathContext.getPrecision() + 2, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 2, mathContext.getRoundingMode());
 
-        BigDecimal result = log(x, mc).divide(logTen(mc), mc);
+        var result = log(x, mc).divide(logTen(mc), mc);
         return round(result, mathContext);
     }
 
@@ -574,13 +574,13 @@ public class BigDecimalMath {
         // https://en.wikipedia.org/wiki/Natural_logarithm in chapter 'High Precision'
         // y = y + 2 * (x-exp(y)) / (x+exp(y))
 
-        int maxPrecision = mathContext.getPrecision() + 20;
-        BigDecimal acceptableError = ONE.movePointLeft(mathContext.getPrecision() + 1);
+        var maxPrecision = mathContext.getPrecision() + 20;
+        var acceptableError = ONE.movePointLeft(mathContext.getPrecision() + 1);
         //System.out.println("logUsingNewton(" + x + " " + mathContext + ") precision " + maxPrecision);
 
         BigDecimal result;
         int adaptivePrecision;
-        double doubleX = x.doubleValue();
+        var doubleX = x.doubleValue();
         if (doubleX > 0.0 && isDoubleValue(x)) {
             result = BigDecimal.valueOf(Math.log(doubleX));
             adaptivePrecision = EXPECTED_INITIAL_PRECISION;
@@ -596,9 +596,9 @@ public class BigDecimalMath {
             if (adaptivePrecision > maxPrecision) {
                 adaptivePrecision = maxPrecision;
             }
-            MathContext mc = new MathContext(adaptivePrecision, mathContext.getRoundingMode());
+            var mc = new MathContext(adaptivePrecision, mathContext.getRoundingMode());
 
-            BigDecimal expY = BigDecimalMath.exp(result, mc);
+            var expY = BigDecimalMath.exp(result, mc);
             step = TWO.multiply(x.subtract(expY, mc), mc).divide(x.add(expY, mc), mc);
             //System.out.println("  step " + step + " adaptivePrecision=" + adaptivePrecision);
             result = result.add(step);
@@ -609,14 +609,14 @@ public class BigDecimalMath {
     }
 
     private static BigDecimal logUsingExponent(BigDecimal x, MathContext mathContext) {
-        MathContext mcDouble = new MathContext(mathContext.getPrecision() * 2, mathContext.getRoundingMode());
-        MathContext mc = new MathContext(mathContext.getPrecision() + 4, mathContext.getRoundingMode());
+        var mcDouble = new MathContext(mathContext.getPrecision() * 2, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 4, mathContext.getRoundingMode());
         //System.out.println("logUsingExponent(" + x + " " + mathContext + ") precision " + mc);
 
-        int exponent = exponent(x);
-        BigDecimal mantissa = mantissa(x);
+        var exponent = exponent(x);
+        var mantissa = mantissa(x);
 
-        BigDecimal result = logUsingTwoThree(mantissa, mc);
+        var result = logUsingTwoThree(mantissa, mc);
         if (exponent != 0) {
             result = result.add(valueOf(exponent).multiply(logTen(mcDouble), mc), mc);
         }
@@ -624,16 +624,16 @@ public class BigDecimalMath {
     }
 
     private static BigDecimal logUsingTwoThree(BigDecimal x, MathContext mathContext) {
-        MathContext mcDouble = new MathContext(mathContext.getPrecision() * 2, mathContext.getRoundingMode());
-        MathContext mc = new MathContext(mathContext.getPrecision() + 4, mathContext.getRoundingMode());
+        var mcDouble = new MathContext(mathContext.getPrecision() * 2, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 4, mathContext.getRoundingMode());
         //System.out.println("logUsingTwoThree(" + x + " " + mathContext + ") precision " + mc);
 
-        int factorOfTwo = 0;
-        int powerOfTwo = 1;
-        int factorOfThree = 0;
-        int powerOfThree = 1;
+        var factorOfTwo = 0;
+        var powerOfTwo = 1;
+        var factorOfThree = 0;
+        var powerOfThree = 1;
 
-        double value = x.doubleValue();
+        var value = x.doubleValue();
         if (value < 0.01) {
             // do nothing
         } else if (value < 0.1) { // never happens when called by logUsingExponent()
@@ -692,8 +692,8 @@ public class BigDecimalMath {
             }
         }
 
-        BigDecimal correctedX = x;
-        BigDecimal result = ZERO;
+        var correctedX = x;
+        var result = ZERO;
 
         if (factorOfTwo > 0) {
             correctedX = correctedX.divide(valueOf(powerOfTwo), mc);
@@ -771,18 +771,18 @@ public class BigDecimalMath {
     }
 
     private static BigDecimal piChudnovski(MathContext mathContext) {
-        MathContext mc = new MathContext(mathContext.getPrecision() + 10, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 10, mathContext.getRoundingMode());
 
-        final BigDecimal value24 = BigDecimal.valueOf(24);
-        final BigDecimal value640320 = BigDecimal.valueOf(640320);
-        final BigDecimal value13591409 = BigDecimal.valueOf(13591409);
-        final BigDecimal value545140134 = BigDecimal.valueOf(545140134);
-        final BigDecimal valueDivisor = value640320.pow(3).divide(value24, mc);
+        final var value24 = BigDecimal.valueOf(24);
+        final var value640320 = BigDecimal.valueOf(640320);
+        final var value13591409 = BigDecimal.valueOf(13591409);
+        final var value545140134 = BigDecimal.valueOf(545140134);
+        final var valueDivisor = value640320.pow(3).divide(value24, mc);
 
-        BigDecimal sumA = BigDecimal.ONE;
-        BigDecimal sumB = BigDecimal.ZERO;
+        var sumA = BigDecimal.ONE;
+        var sumB = BigDecimal.ZERO;
 
-        BigDecimal a = BigDecimal.ONE;
+        var a = BigDecimal.ONE;
         long dividendTerm1 = 5; // -(6*k - 5)
         long dividendTerm2 = -1; // 2*k - 1
         long dividendTerm3 = -1; // 6*k - 1
@@ -790,25 +790,25 @@ public class BigDecimalMath {
 
         long iterationCount = (mc.getPrecision() + 13) / 14;
         for (long k = 1; k <= iterationCount; k++) {
-            BigDecimal valueK = BigDecimal.valueOf(k);
+            var valueK = BigDecimal.valueOf(k);
             dividendTerm1 += -6;
             dividendTerm2 += 2;
             dividendTerm3 += 6;
-            BigDecimal dividend = BigDecimal.valueOf(dividendTerm1).multiply(BigDecimal.valueOf(dividendTerm2))
+            var dividend = BigDecimal.valueOf(dividendTerm1).multiply(BigDecimal.valueOf(dividendTerm2))
                                             .multiply(BigDecimal.valueOf(dividendTerm3));
             kPower3 = valueK.pow(3);
-            BigDecimal divisor = kPower3.multiply(valueDivisor, mc);
+            var divisor = kPower3.multiply(valueDivisor, mc);
             a = a.multiply(dividend).divide(divisor, mc);
-            BigDecimal b = valueK.multiply(a, mc);
+            var b = valueK.multiply(a, mc);
 
             sumA = sumA.add(a);
             sumB = sumB.add(b);
         }
 
-        final BigDecimal value426880 = BigDecimal.valueOf(426880);
-        final BigDecimal value10005 = BigDecimal.valueOf(10005);
-        final BigDecimal factor = value426880.multiply(sqrt(value10005, mc));
-        BigDecimal pi = factor.divide(value13591409.multiply(sumA, mc).add(value545140134.multiply(sumB, mc)), mc);
+        final var value426880 = BigDecimal.valueOf(426880);
+        final var value10005 = BigDecimal.valueOf(10005);
+        final var factor = value426880.multiply(sqrt(value10005, mc));
+        var pi = factor.divide(value13591409.multiply(sumA, mc).add(value545140134.multiply(sumB, mc)), mc);
 
         return round(pi, mathContext);
     }
@@ -877,30 +877,30 @@ public class BigDecimalMath {
     }
 
     private static BigDecimal expIntegralFractional(BigDecimal x, MathContext mathContext) {
-        BigDecimal integralPart = integralPart(x);
+        var integralPart = integralPart(x);
 
         if (integralPart.signum() == 0) {
             return expTaylor(x, mathContext);
         }
 
-        BigDecimal fractionalPart = x.subtract(integralPart);
+        var fractionalPart = x.subtract(integralPart);
 
-        MathContext mc = new MathContext(mathContext.getPrecision() + 10, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 10, mathContext.getRoundingMode());
 
-        BigDecimal z = ONE.add(fractionalPart.divide(integralPart, mc));
-        BigDecimal t = expTaylor(z, mc);
+        var z = ONE.add(fractionalPart.divide(integralPart, mc));
+        var t = expTaylor(z, mc);
 
-        BigDecimal result = pow(t, integralPart.intValueExact(), mc);
+        var result = pow(t, integralPart.intValueExact(), mc);
 
         return round(result, mathContext);
     }
 
     private static BigDecimal expTaylor(BigDecimal x, MathContext mathContext) {
-        MathContext mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
 
         x = x.divide(valueOf(256), mc);
 
-        BigDecimal result = ExpCalculator.INSTANCE.calculate(x, mc);
+        var result = ExpCalculator.INSTANCE.calculate(x, mc);
         result = BigDecimalMath.pow(result, 256, mc);
         return round(result, mathContext);
     }
@@ -917,15 +917,15 @@ public class BigDecimalMath {
      */
     public static BigDecimal sin(BigDecimal x, MathContext mathContext) {
         checkMathContext(mathContext);
-        MathContext mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
 
         if (x.abs().compareTo(ROUGHLY_TWO_PI) > 0) {
-            MathContext mc2 = new MathContext(mc.getPrecision() + 4, mathContext.getRoundingMode());
-            BigDecimal twoPi = TWO.multiply(pi(mc2), mc2);
+            var mc2 = new MathContext(mc.getPrecision() + 4, mathContext.getRoundingMode());
+            var twoPi = TWO.multiply(pi(mc2), mc2);
             x = x.remainder(twoPi, mc2);
         }
 
-        BigDecimal result = SinCalculator.INSTANCE.calculate(x, mc);
+        var result = SinCalculator.INSTANCE.calculate(x, mc);
         return round(result, mathContext);
     }
 
@@ -953,14 +953,14 @@ public class BigDecimalMath {
             return asin(x.negate(), mathContext).negate();
         }
 
-        MathContext mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
 
         if (x.compareTo(BigDecimal.valueOf(0.707107)) >= 0) {
-            BigDecimal xTransformed = sqrt(ONE.subtract(x.multiply(x, mc), mc), mc);
+            var xTransformed = sqrt(ONE.subtract(x.multiply(x, mc), mc), mc);
             return acos(xTransformed, mathContext);
         }
 
-        BigDecimal result = AsinCalculator.INSTANCE.calculate(x, mc);
+        var result = AsinCalculator.INSTANCE.calculate(x, mc);
         return round(result, mathContext);
     }
 
@@ -976,15 +976,15 @@ public class BigDecimalMath {
      */
     public static BigDecimal cos(BigDecimal x, MathContext mathContext) {
         checkMathContext(mathContext);
-        MathContext mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
 
         if (x.abs().compareTo(ROUGHLY_TWO_PI) > 0) {
-            MathContext mc2 = new MathContext(mc.getPrecision() + 4, mathContext.getRoundingMode());
-            BigDecimal twoPi = TWO.multiply(pi(mc2), mc2);
+            var mc2 = new MathContext(mc.getPrecision() + 4, mathContext.getRoundingMode());
+            var twoPi = TWO.multiply(pi(mc2), mc2);
             x = x.remainder(twoPi, mc2);
         }
 
-        BigDecimal result = CosCalculator.INSTANCE.calculate(x, mc);
+        var result = CosCalculator.INSTANCE.calculate(x, mc);
         return round(result, mathContext);
     }
 
@@ -1008,9 +1008,9 @@ public class BigDecimalMath {
             throw new ArithmeticException("Illegal acos(x) for x < -1: x = " + x);
         }
 
-        MathContext mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
 
-        BigDecimal result = pi(mc).divide(TWO, mc).subtract(asin(x, mc), mc);
+        var result = pi(mc).divide(TWO, mc).subtract(asin(x, mc), mc);
         return round(result, mathContext);
     }
 
@@ -1030,8 +1030,8 @@ public class BigDecimalMath {
             return ZERO;
         }
 
-        MathContext mc = new MathContext(mathContext.getPrecision() + 4, mathContext.getRoundingMode());
-        BigDecimal result = sin(x, mc).divide(cos(x, mc), mc);
+        var mc = new MathContext(mathContext.getPrecision() + 4, mathContext.getRoundingMode());
+        var result = sin(x, mc).divide(cos(x, mc), mc);
         return round(result, mathContext);
     }
 
@@ -1047,11 +1047,11 @@ public class BigDecimalMath {
      */
     public static BigDecimal atan(BigDecimal x, MathContext mathContext) {
         checkMathContext(mathContext);
-        MathContext mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
+        var mc = new MathContext(mathContext.getPrecision() + 6, mathContext.getRoundingMode());
 
         x = x.divide(sqrt(ONE.add(x.multiply(x, mc), mc), mc), mc);
 
-        BigDecimal result = asin(x, mc);
+        var result = asin(x, mc);
         return round(result, mathContext);
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/util/math/BigDecimalMath.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/math/BigDecimalMath.java
@@ -138,7 +138,7 @@ public class BigDecimalMath {
      * @see #fractionalPart(BigDecimal)
      */
     public static BigDecimal integralPart(BigDecimal value) {
-        return value.setScale(0, BigDecimal.ROUND_DOWN);
+        return value.setScale(0, RoundingMode.DOWN);
     }
 
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/util/math/BigRational.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/math/BigRational.java
@@ -53,8 +53,8 @@ public class BigRational implements Comparable<BigRational> {
 	}
 
 	private BigRational(BigDecimal num, BigDecimal denom) {
-		BigDecimal n = num;
-		BigDecimal d = denom;
+		var n = num;
+		var d = denom;
 
 		if (d.signum() == 0) {
 			throw new ArithmeticException("Divide by zero");
@@ -106,6 +106,7 @@ public class BigRational implements Comparable<BigRational> {
 		if (isZero()) {
 			return this;
 		}
+
 		return of(numerator.negate(), denominator);
 	}
 
@@ -140,8 +141,8 @@ public class BigRational implements Comparable<BigRational> {
 			return of(numerator.add(value.numerator), denominator);
 		}
 
-		BigDecimal n = numerator.multiply(value.denominator).add(value.numerator.multiply(denominator));
-		BigDecimal d = denominator.multiply(value.denominator);
+		var n = numerator.multiply(value.denominator).add(value.numerator.multiply(denominator));
+		var d = denominator.multiply(value.denominator);
 		return of(n, d);
 	}
 
@@ -181,8 +182,8 @@ public class BigRational implements Comparable<BigRational> {
 			return of(numerator.subtract(value.numerator), denominator);
 		}
 
-		BigDecimal n = numerator.multiply(value.denominator).subtract(value.numerator.multiply(denominator));
-		BigDecimal d = denominator.multiply(value.denominator);
+		var n = numerator.multiply(value.denominator).subtract(value.numerator.multiply(denominator));
+		var d = denominator.multiply(value.denominator);
 		return of(n, d);
 	}
 
@@ -205,14 +206,16 @@ public class BigRational implements Comparable<BigRational> {
 			return this;
 		}
 
-		BigDecimal n = numerator.multiply(value.numerator);
-		BigDecimal d = denominator.multiply(value.denominator);
+		var n = numerator.multiply(value.numerator);
+		var d = denominator.multiply(value.denominator);
 		return of(n, d);
 	}
 
 	// private, because we want to hide that we use BigDecimal internally
 	private BigRational multiply(BigDecimal value) {
-		return of(numerator.multiply(value), denominator);
+		var n = numerator.multiply(value);
+		var d = denominator;
+		return of(n, d);
 	}
 	
 	/**
@@ -270,10 +273,7 @@ public class BigRational implements Comparable<BigRational> {
 		if (value.equals(ONE)) {
 			return this;
 		}
-
-		BigDecimal n = numerator.multiply(value.denominator);
-		BigDecimal d = denominator.multiply(value.numerator);
-		return of(n, d);
+		return of(numerator.multiply(value.denominator), denominator.multiply(value.numerator));
 	}
 
 	private BigRational divide(BigDecimal value) {
@@ -297,7 +297,6 @@ public class BigRational implements Comparable<BigRational> {
 		if (value.equals(BigInteger.ONE)) {
 			return this;
 		}
-
 		return divide(new BigDecimal(value));
 	}
 
@@ -372,8 +371,8 @@ public class BigRational implements Comparable<BigRational> {
 	}
 
     private static int countDigits(BigInteger number) {
-		double factor = Math.log(2) / Math.log(10);
-		int digitCount = (int) (factor * number.bitLength() + 1);
+		var factor = Math.log(2) / Math.log(10);
+		var digitCount = (int) (factor * number.bitLength() + 1);
 		if (BigInteger.TEN.pow(digitCount - 1).compareTo(number) > 0) {
 			return digitCount - 1;
 		}
@@ -391,7 +390,7 @@ public class BigRational implements Comparable<BigRational> {
 	 * @return the {@link BigDecimal} value
 	 */
 	public BigDecimal toBigDecimal() {
-		int precision = Math.max(precision(), MathContext.DECIMAL128.getPrecision());
+		var precision = Math.max(precision(), MathContext.DECIMAL128.getPrecision());
 		return toBigDecimal(new MathContext(precision));
 	}
 
@@ -431,7 +430,7 @@ public class BigRational implements Comparable<BigRational> {
 			return false;
 		}
 
-		BigRational other = (BigRational) obj;
+		var other = (BigRational) obj;
 		if (!numerator.equals(other.numerator)) {
 			return false;
 		}
@@ -519,16 +518,16 @@ public class BigRational implements Comparable<BigRational> {
 			return ONE;
 		}
 
-		int scale = value.scale();
+		var scale = value.scale();
 		if (scale == 0) {
 			return new BigRational(value, BigDecimal.ONE);
 		} else if (scale < 0) {
-			BigDecimal n = new BigDecimal(value.unscaledValue()).multiply(BigDecimal.ONE.movePointLeft(value.scale()));
+			var n = new BigDecimal(value.unscaledValue()).multiply(BigDecimal.ONE.movePointLeft(value.scale()));
 			return new BigRational(n, BigDecimal.ONE);
 		}
 		else {
-			BigDecimal n = new BigDecimal(value.unscaledValue());
-			BigDecimal d = BigDecimal.ONE.movePointRight(value.scale());
+			var n = new BigDecimal(value.unscaledValue());
+			var d = BigDecimal.ONE.movePointRight(value.scale());
 			return new BigRational(n, d);
 		}
 	}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/math/BigRational.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/math/BigRational.java
@@ -206,16 +206,12 @@ public class BigRational implements Comparable<BigRational> {
 			return this;
 		}
 
-		var n = numerator.multiply(value.numerator);
-		var d = denominator.multiply(value.denominator);
-		return of(n, d);
+		return of(numerator.multiply(value.numerator), denominator.multiply(value.denominator));
 	}
 
 	// private, because we want to hide that we use BigDecimal internally
 	private BigRational multiply(BigDecimal value) {
-		var n = numerator.multiply(value);
-		var d = denominator;
-		return of(n, d);
+		return of(numerator.multiply(value), denominator);
 	}
 	
 	/**
@@ -326,11 +322,7 @@ public class BigRational implements Comparable<BigRational> {
 		return numerator.signum() == 0;
 	}
 
-	private boolean isPositive() {
-		return numerator.signum() > 0;
-	}
-
-    /**
+	/**
 	 * Returns whether this rational number is an integer number without fraction part.
 	 *
 	 * <p>Will return <code>false</code> if this number is not reduced to the integer representation yet (e.g. 4/4 or 4/2)</p>

--- a/src/main/java/io/github/syst3ms/skriptparser/util/math/CosCalculator.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/math/CosCalculator.java
@@ -28,7 +28,7 @@ public class CosCalculator extends SeriesCalculator {
 	
 	@Override
 	protected BigRational getCurrentFactor() {
-		BigRational factor = factorial2n.reciprocal();
+		var factor = factorial2n.reciprocal();
 		if (negative) {
 			factor = factor.negate();
 		}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/math/NumberMath.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/math/NumberMath.java
@@ -48,8 +48,8 @@ public class NumberMath {
         if ((n instanceof Long || n instanceof Double) && (base instanceof Long || base instanceof Double)) {
             return Math.log(n.doubleValue()) / Math.log(base.doubleValue());
         } else {
-            BigDecimal bd = bigToBigDecimal(n);
-            BigDecimal bdBase = bigToBigDecimal(base);
+            var bd = bigToBigDecimal(n);
+            var bdBase = bigToBigDecimal(base);
             if (bdBase.compareTo(BigDecimal.valueOf(2)) == 0) {
                 return BigDecimalMath.log2(bd, BigDecimalMath.DEFAULT_CONTEXT);
             } else if (bdBase.compareTo(BigDecimal.TEN) == 0) {
@@ -64,7 +64,7 @@ public class NumberMath {
     public static Number factorial(Number n) {
         if (n instanceof Long && n.longValue() < 13)
             return BigDecimalMath.factorial(n.intValue()).longValue();
-        BigDecimal fac = BigDecimalMath.factorial(new BigDecimal(n.toString()), BigDecimalMath.DEFAULT_CONTEXT);
+        var fac = BigDecimalMath.factorial(new BigDecimal(n.toString()), BigDecimalMath.DEFAULT_CONTEXT);
         if (n instanceof Long || n instanceof BigInteger) {
             return fac.toBigInteger();
         } else {

--- a/src/main/java/io/github/syst3ms/skriptparser/util/math/SeriesCalculator.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/math/SeriesCalculator.java
@@ -49,16 +49,16 @@ public abstract class SeriesCalculator {
 	 * @return the calculated result
 	 */
 	public BigDecimal calculate(BigDecimal x, MathContext mathContext) {
-		BigDecimal acceptableError = ONE.movePointLeft(mathContext.getPrecision() + 1);
+		var acceptableError = ONE.movePointLeft(mathContext.getPrecision() + 1);
 
-		PowerIterator powerIterator = createPowerIterator(x, mathContext);
-		
-		BigDecimal sum = BigDecimal.ZERO;
+		var powerIterator = createPowerIterator(x, mathContext);
+
+		var sum = BigDecimal.ZERO;
 		BigDecimal step;
-		int i = 0;
+		var i = 0;
 		do {
-			BigRational factor = getFactor(i);
-			BigDecimal xToThePower  = powerIterator.getCurrentPower();
+			var factor = getFactor(i);
+			var xToThePower  = powerIterator.getCurrentPower();
 			powerIterator.calculateNextPower();
 			step = factor.getNumerator().multiply(xToThePower, mathContext).divide(factor.getDenominator(), mathContext);
 			i++;
@@ -67,7 +67,7 @@ public abstract class SeriesCalculator {
 				xToThePower  = powerIterator.getCurrentPower();
 				powerIterator.calculateNextPower();
 				factor = getFactor(i);
-				BigDecimal step2 = factor.getNumerator().multiply(xToThePower, mathContext).divide(factor.getDenominator(), mathContext);
+				var step2 = factor.getNumerator().multiply(xToThePower, mathContext).divide(factor.getDenominator(), mathContext);
 				step = step.add(step2, mathContext);
 				i++;
 			}
@@ -96,7 +96,7 @@ public abstract class SeriesCalculator {
 	 */
 	protected BigRational getFactor(int index) {
 		while (factors.size() <= index) {
-			BigRational factor = getCurrentFactor();
+			var factor = getCurrentFactor();
 			factors.add(factor);
 			calculateNextFactor();
 		}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/math/SinCalculator.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/math/SinCalculator.java
@@ -28,7 +28,7 @@ public class SinCalculator extends SeriesCalculator {
 	
 	@Override
 	protected BigRational getCurrentFactor() {
-		BigRational factor = factorial2nPlus1.reciprocal();
+		var factor = factorial2nPlus1.reciprocal();
 		if (negative) {
 			factor = factor.negate();
 		}

--- a/src/main/java/io/github/syst3ms/skriptparser/variables/VariableMap.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/variables/VariableMap.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 class VariableMap {
@@ -30,11 +31,11 @@ class VariableMap {
                 map.put(name, value);
             }
         }
-        String[] split = splitList(name);
-        Map<String, Object> parent = map;
-        for (int i = 0; i < split.length; i++) {
-            String n = split[i];
-            Object current = parent.get(n);
+        var split = splitList(name);
+        var parent = map;
+        for (var i = 0; i < split.length; i++) {
+            var n = split[i];
+            var current = parent.get(n);
             if (current == null) {
                 if (i == split.length - 1) {
                     if (value != null) {
@@ -59,7 +60,7 @@ class VariableMap {
                     assert value == null;
                     deleteFromHashMap(String
                         .join(Variables.LIST_SEPARATOR, Arrays.copyOfRange(split, 0, i + 1)), (Map<String, Object>) current);
-                    Object v = ((Map<String, Object>) current).get(null);
+                    var v = ((Map<String, Object>) current).get(null);
                     if (v == null) {
                         parent.remove(n);
                     } else {
@@ -91,12 +92,12 @@ class VariableMap {
 
     @SuppressWarnings("unchecked")
     private void deleteFromHashMap(String parent, Map<String, Object> current) {
-        for (Map.Entry<String, Object> e : current.entrySet()) {
+        for (var e : current.entrySet()) {
             if (e.getKey() == null) {
                 continue;
             }
             map.remove(parent + Variables.LIST_SEPARATOR + e.getKey());
-            Object val = e.getValue();
+            var val = e.getValue();
             if (val instanceof Map) {
                 deleteFromHashMap(parent + Variables.LIST_SEPARATOR + e.getKey(), (Map<String, Object>) val);
             }
@@ -112,31 +113,30 @@ class VariableMap {
 	 * @return an Object for a normal Variable or a Map<String, Object> for a list variable, or null if the variable is not set.
 	 */
     @SuppressWarnings("unchecked")
-    @Nullable
-    public Object getVariable(String name) {
+    public Optional<Object> getVariable(String name) {
         if (!name.endsWith("*")) {
-            return map.get(name);
+            return Optional.ofNullable(map.get(name));
         } else {
-            String[] split = splitList(name);
-            Map<String, Object> current = map;
-            for (int i = 0; i < split.length; i++) {
-                String n = split[i];
+            var split = splitList(name);
+            var current = map;
+            for (var i = 0; i < split.length; i++) {
+                var n = split[i];
                 if (n.equals("*")) {
                     assert i == split.length - 1;
-                    return current;
+                    return Optional.of(current);
                 }
-                Object o = current.get(n);
+                var o = current.get(n);
                 if (o == null) {
-                    return null;
+                    return Optional.empty();
                 }
                 if (o instanceof Map) {
                     current = (Map<String, Object>) o;
                     assert i != split.length - 1;
                 } else {
-                    return null;
+                    return Optional.empty();
                 }
             }
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/variables/Variables.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/variables/Variables.java
@@ -53,8 +53,8 @@ public class Variables {
      * @return true if the name is valid, false otherwise.
      */
     public static boolean isValidVariableName(String name, boolean printErrors, SkriptLogger logger) {
-        name = name.startsWith(LOCAL_VARIABLE_TOKEN) ? name.substring(LOCAL_VARIABLE_TOKEN.length()).trim()
-			: name.trim();
+        name = name.startsWith(LOCAL_VARIABLE_TOKEN) ? name.substring(LOCAL_VARIABLE_TOKEN.length()).strip()
+			: name.strip();
         if (name.startsWith(LIST_SEPARATOR) || name.endsWith(LIST_SEPARATOR)) {
             if (printErrors) {
                 logger.error("A variable name cannot start nor end with the list separator " + LIST_SEPARATOR, ErrorType.MALFORMED_INPUT);

--- a/src/main/java/io/github/syst3ms/skriptparser/variables/Variables.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/variables/Variables.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
@@ -24,27 +25,23 @@ public class Variables {
     // Yes, I know it should be trigger-specific, but I haven't got to that part yet, ok ? TODO make the change
     private static final Map<TriggerContext, VariableMap> localVariables = new HashMap<>();
 
-    @Nullable
-    public static <T> Expression<T> parseVariable(String s, Class<? extends T> types, ParserState parserState, SkriptLogger logger) {
-        s = s.trim();
+    public static <T> Optional<? extends Expression<T>> parseVariable(String s, Class<? extends T> types, ParserState parserState, SkriptLogger logger) {
+        s = s.strip();
         if (REGEX_PATTERN.matcher(s).matches()) {
             s = s.substring(1, s.length() - 1);
         } else {
-            return null;
+            return Optional.empty();
         }
         if (!isValidVariableName(s, true, logger)) {
-            return null;
+            return Optional.empty();
         }
-        VariableString vs = VariableString.newInstance(
-                s.startsWith(LOCAL_VARIABLE_TOKEN) ? s.substring(LOCAL_VARIABLE_TOKEN.length()).trim() : s,
+        var vs = VariableString.newInstance(
+                s.startsWith(LOCAL_VARIABLE_TOKEN) ? s.substring(LOCAL_VARIABLE_TOKEN.length()).strip() : s,
                 parserState,
                 logger
         );
-        if (vs == null) {
-            return null;
-        }
-        return new Variable<>(vs, s.startsWith(LOCAL_VARIABLE_TOKEN), s.endsWith(
-                LIST_SEPARATOR + "*"), types);
+        var finalS = s;
+        return vs.map(v -> new Variable<>(v, finalS.startsWith(LOCAL_VARIABLE_TOKEN), finalS.endsWith(LIST_SEPARATOR + "*"), types));
     }
 
     /**
@@ -85,12 +82,11 @@ public class Variables {
 	 * @param name the name of the variable
 	 * @return an Object for a normal Variable or a Map<String, Object> for a list variable, or null if the variable is not set.
 	 */
-    @Nullable
-    public static Object getVariable(String name, TriggerContext e, boolean local) {
+    public static Optional<Object> getVariable(String name, TriggerContext e, boolean local) {
         if (local) {
-            VariableMap map = localVariables.get(e);
+            var map = localVariables.get(e);
             if (map == null)
-                return null;
+                return Optional.empty();
             return map.getVariable(name);
         } else {
             return variableMap.getVariable(name);
@@ -106,7 +102,7 @@ public class Variables {
     public static void setVariable(String name, @Nullable Object value, @Nullable TriggerContext e, boolean local) {
         if (local) {
             assert e != null : name;
-            VariableMap map = localVariables.get(e);
+            var map = localVariables.get(e);
             if (map == null)
                 localVariables.put(e, map = new VariableMap());
             map.setVariable(name, value);

--- a/src/test/java/io/github/syst3ms/skriptparser/file/FileParserTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/file/FileParserTest.java
@@ -26,7 +26,7 @@ public class FileParserTest {
     }
 
     @Test
-    public void parseFileLines() throws Exception {
+    public void parseFileLines() {
         FileParser parser = new FileParser();
         assertEquals(
                 Collections.singletonList(simpleFileLine("line", 0, 1)),

--- a/src/test/java/io/github/syst3ms/skriptparser/log/SkriptLoggerTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/log/SkriptLoggerTest.java
@@ -6,6 +6,8 @@ import io.github.syst3ms.skriptparser.parsing.ParserState;
 import io.github.syst3ms.skriptparser.parsing.SyntaxParser;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertTrue;
 
 public class SkriptLoggerTest {
@@ -18,16 +20,16 @@ public class SkriptLoggerTest {
     public void skriptLoggerTest() throws Exception {
         SkriptLogger logger = new SkriptLogger();
         ParserState parserState = new ParserState();
-        Expression<?> noMatchFound = SyntaxParser.parseExpression("an expression that doesn't match anything", SyntaxParser.OBJECT_PATTERN_TYPE, parserState, logger);
+        Optional<? extends Expression<?>> noMatchFound = SyntaxParser.parseExpression("an expression that doesn't match anything", SyntaxParser.OBJECT_PATTERN_TYPE, parserState, logger);
         logger.logOutput();
-        assertTrue(noMatchFound == null && logger.close().get(0).getMessage().startsWith("No expression"));
+        assertTrue(noMatchFound.isEmpty() && logger.close().get(0).getMessage().startsWith("No expression"));
         logger = new SkriptLogger();
-        Expression<?> wrongNumber = SyntaxParser.parseExpression("range from 1 to 3", SyntaxParser.OBJECT_PATTERN_TYPE, parserState, logger);
+        Optional<? extends Expression<?>> wrongNumber = SyntaxParser.parseExpression("range from 1 to 3", SyntaxParser.OBJECT_PATTERN_TYPE, parserState, logger);
         logger.logOutput();
-        assertTrue(wrongNumber == null && logger.close().get(0).getMessage().startsWith("A single"));
+        assertTrue(wrongNumber.isEmpty() && logger.close().get(0).getMessage().startsWith("A single"));
         logger = new SkriptLogger();
-        Expression<?> wrongRange = SyntaxParser.parseBooleanExpression("1 is between 'a' and 'b'", SyntaxParser.MAYBE_CONDITIONAL, parserState, logger);
+        Optional<? extends Expression<Boolean>> wrongRange = SyntaxParser.parseBooleanExpression("1 is between 'a' and 'b'", SyntaxParser.MAYBE_CONDITIONAL, parserState, logger);
         logger.logOutput();
-        assertTrue(wrongRange == null && logger.close().get(0).getMessage().startsWith("1 cannot"));
+        assertTrue(wrongRange.isEmpty() && logger.close().get(0).getMessage().startsWith("'1' cannot"));
     }
 }

--- a/src/test/java/io/github/syst3ms/skriptparser/log/SkriptLoggerTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/log/SkriptLoggerTest.java
@@ -17,7 +17,7 @@ public class SkriptLoggerTest {
     }
 
     @Test
-    public void skriptLoggerTest() throws Exception {
+    public void skriptLoggerTest() {
         SkriptLogger logger = new SkriptLogger();
         ParserState parserState = new ParserState();
         Optional<? extends Expression<?>> noMatchFound = SyntaxParser.parseExpression("an expression that doesn't match anything", SyntaxParser.OBJECT_PATTERN_TYPE, parserState, logger);

--- a/src/test/java/io/github/syst3ms/skriptparser/parsing/SyntaxParserTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/parsing/SyntaxParserTest.java
@@ -10,7 +10,6 @@ import io.github.syst3ms.skriptparser.types.TypeManager;
 import io.github.syst3ms.skriptparser.util.CollectionUtils;
 import io.github.syst3ms.skriptparser.util.math.BigDecimalMath;
 import io.github.syst3ms.skriptparser.util.math.NumberMath;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -42,7 +41,7 @@ public class SyntaxParserTest {
         assertExpressionEquals(new SimpleLiteral<>(Boolean.class, true), actual);
     }
 
-    private void assertExpressionTypeEquals(Class<?> expected, Optional<? extends Expression<?>> expr) throws Exception {
+    private void assertExpressionTypeEquals(Class<?> expected, Optional<? extends Expression<?>> expr) {
         if (expr.isEmpty())
             fail("Null expression");
         if (expr.get().getReturnType() == expected)
@@ -81,7 +80,7 @@ public class SyntaxParserTest {
     }
 
     @Test
-    public void standardExpressionsTest() throws Exception {
+    public void standardExpressionsTest() {
         SkriptLogger logger = new SkriptLogger();
         ParserState parserState = new ParserState();
         // CondExprCompare

--- a/src/test/java/io/github/syst3ms/skriptparser/parsing/VariablesTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/parsing/VariablesTest.java
@@ -13,37 +13,48 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Optional;
 
 import static io.github.syst3ms.skriptparser.lang.TriggerContext.DUMMY;
 import static org.junit.Assert.*;
 
-@SuppressWarnings("ConstantConditions")
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class VariablesTest {
 
     static {
         TestRegistration.register();
     }
 
-    public void assertExpressionEquals(@Nullable Expression<?> expected, @Nullable Expression<?> actual) {
-        if (expected == actual)
+    public void assertExpressionEquals(Expression<?> expected, Optional<? extends Expression<?>> actual) {
+        if (actual.filter(expected::equals).isPresent())
             return;
-        if (expected == null || actual == null)
+        if (actual.isEmpty())
             fail();
-        assertArrayEquals(expected.getValues(DUMMY), actual.getValues(DUMMY));
+        assertArrayEquals(expected.getValues(DUMMY), actual.get().getValues(DUMMY));
     }
-    
-    private void run(Effect eff) {
-        Statement.runAll(eff, DUMMY);
+
+    private void assertExpressionTypeEquals(Class<?> expected, Optional<? extends Expression<?>> expr) throws Exception {
+        if (expr.isEmpty())
+            fail("Null expression");
+        if (expr.get().getReturnType() == expected)
+            return;
+        Optional<?> value = expr.get().getSingle(DUMMY);
+        if (value.isEmpty() || value.get().getClass() != expected)
+            fail("Different return types : expected " + expected + ", got " + value.map(Object::getClass).orElse(null));
+    }
+
+    private void run(Optional<? extends Effect> effect) {
+        effect.ifPresent(eff -> Statement.runAll(eff, DUMMY));
     }
 
     @Test
-    public void testVariables() {
+    public void testVariables() throws Exception {
         SkriptLogger logger = new SkriptLogger();
         ParserState parserState = new ParserState();
         run(SyntaxParser.parseEffect("set {variable} to \"test\"", parserState, logger));
         assertExpressionEquals(
                 new SimpleLiteral<>(String.class, "test"),
-                SyntaxParser.parseExpression("{variable}", new PatternType<>(TypeManager.getByClassExact(String.class), true), parserState, logger)
+                SyntaxParser.parseExpression("{variable}", new PatternType<>(TypeManager.getByClassExact(String.class).orElseThrow(AssertionError::new), true), parserState, logger)
         );
         run(SyntaxParser.parseEffect("delete {variable}", parserState, logger));
         assertExpressionEquals(
@@ -51,20 +62,16 @@ public class VariablesTest {
                 SyntaxParser.parseExpression("{variable}", SyntaxParser.OBJECT_PATTERN_TYPE, parserState, logger)
         );
         // Numbers
-        PatternType<Number> numberType = new PatternType<>(TypeManager.getByClassExact(Number.class), true);
+        PatternType<Number> numberType = new PatternType<>(TypeManager.getByClassExact(Number.class).orElseThrow(AssertionError::new), true);
         run(SyntaxParser.parseEffect("set {number} to 5", parserState, logger));
-        assertEquals(
+        assertExpressionTypeEquals(
                 BigInteger.class,
                 SyntaxParser.parseExpression("{number}", numberType, parserState, logger)
-                            .getSingle(DUMMY)
-                            .getClass()
         );
         run(SyntaxParser.parseEffect("set {number} to 5.2", parserState, logger));
-        assertEquals(
+        assertExpressionTypeEquals(
                 BigDecimal.class,
                 SyntaxParser.parseExpression("{number}", numberType, parserState, logger)
-                            .getSingle(DUMMY)
-                            .getClass()
         );
     }
 }

--- a/src/test/java/io/github/syst3ms/skriptparser/parsing/VariablesTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/parsing/VariablesTest.java
@@ -8,7 +8,6 @@ import io.github.syst3ms.skriptparser.lang.Statement;
 import io.github.syst3ms.skriptparser.log.SkriptLogger;
 import io.github.syst3ms.skriptparser.types.PatternType;
 import io.github.syst3ms.skriptparser.types.TypeManager;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -33,7 +32,7 @@ public class VariablesTest {
         assertArrayEquals(expected.getValues(DUMMY), actual.get().getValues(DUMMY));
     }
 
-    private void assertExpressionTypeEquals(Class<?> expected, Optional<? extends Expression<?>> expr) throws Exception {
+    private void assertExpressionTypeEquals(Class<?> expected, Optional<? extends Expression<?>> expr) {
         if (expr.isEmpty())
             fail("Null expression");
         if (expr.get().getReturnType() == expected)


### PR DESCRIPTION
This PR aims to make the API safer and less error-prone by replacing nullable return values with the `java.util.Optional` class introduced in Java 8. It also removes many of the differences between the `master` and  `skript-library` branches.

It also updates the project to Java 11, which adds convenient API methods, and most importantly the `var` keyword.

This API change is still highly experimental, so comments, questions and reviews are more than welcome.

This PR targets the current `skript-library` branch ; a parallel PR targets the `master` branch instead.