### PR TITLE
[Feature] Add tips in error messages

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/Parser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/Parser.java
@@ -33,21 +33,30 @@ public class Parser {
 
     public static void main(String[] args) {
         boolean debug = false;
+        boolean tipsEnabled = true;
         String scriptName = "";
         String[] programArgs = new String[0];
         if (args.length == 0) {
-            System.err.println("You need to provide a script name !");
+            System.err.println("You need to provide a script name!");
             System.exit(1);
-        } else if (args.length > 1 && args[0].equals("--debug")) {
-            debug = true;
-            scriptName = args[1];
-            programArgs = Arrays.copyOfRange(args, 2, args.length);
         } else {
-            scriptName = args[0];
-            programArgs = Arrays.copyOfRange(args, 1, args.length);
+            int j = 0;
+            for (int i = 0; i < args.length; i++) {
+                String s = args[i];
+                if (s.equalsIgnoreCase("--debug")) {
+                    debug = true;
+                } else if (s.equalsIgnoreCase("--no-tips") || s.equalsIgnoreCase("--nt")) {
+                    tipsEnabled = false;
+                } else {
+                    j = i;
+                    break;
+                }
+            }
+            scriptName = args[j];
+            programArgs = Arrays.copyOfRange(args, j + 1, args.length);
         }
         init(new String[0], new String[0], programArgs, true);
-        run(scriptName, debug);
+        run(scriptName, debug, tipsEnabled);
     }
 
     /**
@@ -120,27 +129,27 @@ public class Parser {
         logs = registration.register();
         if (!logs.isEmpty()) {
             System.out.print(ConsoleColors.PURPLE);
-            System.out.println("Registration log :");
+            System.out.println("Registration log:");
         }
-        printLogs(logs, time);
+        printLogs(logs, time, false);
         if (!logs.isEmpty()) {
             System.out.println();
         }
     }
 
-    public static void run(String scriptName, boolean debug) {
+    public static void run(String scriptName, boolean debug, boolean tipsEnabled) {
         Calendar time = Calendar.getInstance();
         Path scriptPath = Paths.get(scriptName);
         logs = ScriptLoader.loadScript(scriptPath, debug);
         if (!logs.isEmpty()) {
             System.out.print(ConsoleColors.PURPLE);
-            System.out.println("Parsing log :");
+            System.out.println("Parsing log:");
         }
-        printLogs(logs, time);
+        printLogs(logs, time, tipsEnabled);
         SkriptAddon.getAddons().forEach(SkriptAddon::finishedLoading);
     }
 
-    private static void printLogs(List<LogEntry> logs, Calendar time) {
+    private static void printLogs(List<LogEntry> logs, Calendar time, boolean tipsEnabled) {
         for (LogEntry log : logs) {
             ConsoleColors color = ConsoleColors.WHITE;
             if (log.getType() == LogType.WARNING) {
@@ -153,6 +162,8 @@ public class Parser {
                 color = ConsoleColors.PURPLE;
             }
             System.out.printf(color + CONSOLE_FORMAT + ConsoleColors.RESET, time, log.getType().name(), log.getMessage());
+            if (tipsEnabled && log.getTip().isPresent())
+                System.out.printf(ConsoleColors.BLUE_BRIGHT + CONSOLE_FORMAT + ConsoleColors.RESET, time, "TIP", log.getTip().get());
         }
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprNumberArithmetic.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprNumberArithmetic.java
@@ -296,7 +296,11 @@ public class ExprNumberArithmetic implements Expression<Number> {
         if (second instanceof Literal) {
             Optional<? extends Number> value = ((Literal<? extends Number>) second).getSingle();
             if (value.filter(Operator::isZero).isPresent()) {
-                parseContext.getLogger().error("Cannot divide by 0 !", ErrorType.SEMANTIC_ERROR);
+                parseContext.getLogger().error(
+                        "Cannot divide by 0!",
+                        ErrorType.SEMANTIC_ERROR,
+                        "Make sure the expression/variable you want to divide with does not represent 0, as dividing by 0 results in mathematical issues"
+                );
                 return false;
             }
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/file/FileParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/file/FileParser.java
@@ -43,7 +43,11 @@ public class FileParser {
             }
             var lineIndentation = FileUtils.getIndentationLevel(line, false);
             if (lineIndentation > expectedIndentation) { // The line is indented too much
-                logger.error("The line is indented too much (line " + (lastLine + i) + ": \"" + content + "\")", ErrorType.STRUCTURE_ERROR);
+                logger.error(
+                        "The line is indented too much (line " + (lastLine + i) + ": \"" + content + "\")",
+                        ErrorType.STRUCTURE_ERROR,
+                        "You only need to indent once (using tabs) after each section. Try to omit some tabs so the line suffices this rule"
+                );
                 continue;
             } else if (lineIndentation < expectedIndentation) { // One indentation behind marks the end of a section
                 return elements;

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/base/RestrictedExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/base/RestrictedExpression.java
@@ -36,7 +36,10 @@ public abstract class RestrictedExpression<T> implements Expression<T> {
         }
         if (required == null) {
             var logger = parseContext.getLogger();
-            logger.error(getSpecificErrorMessage() + " : '" + this.toString(null, logger.isDebug()) + "'", ErrorType.SEMANTIC_ERROR);
+            logger.error(
+                    getSpecificErrorMessage() + " : '" + this.toString(null, logger.isDebug()) + "'",
+                    ErrorType.SEMANTIC_ERROR,
+                    "This expression cannot be used everywhere. Refer to the documentation to see the correct usage of this expression");
             return false;
         }
         return initialize(expressions, required, matchedPattern, parseContext);

--- a/src/main/java/io/github/syst3ms/skriptparser/log/LogEntry.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/log/LogEntry.java
@@ -3,6 +3,7 @@ package io.github.syst3ms.skriptparser.log;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * An entry in Skript's log.
@@ -13,13 +14,19 @@ public class LogEntry {
     private final int line;
     private final List<ErrorContext> errorContext;
     private final ErrorType errorType;
+    public final String tip;
 
     public LogEntry(String message, LogType verbosity, int line, List<ErrorContext> errorContext, @Nullable ErrorType errorType) {
+        this(message, verbosity, line, errorContext, errorType, null);
+    }
+
+    public LogEntry(String message, LogType verbosity, int line, List<ErrorContext> errorContext, @Nullable ErrorType errorType, @Nullable String tip) {
         this.type = verbosity;
         this.message = message;
         this.line = line;
         this.errorContext = errorContext;
         this.errorType = errorType;
+        this.tip = tip;
     }
 
     public String getMessage() {
@@ -36,6 +43,10 @@ public class LogEntry {
 
     ErrorType getErrorType() {
         return errorType;
+    }
+
+    public Optional<String> getTip() {
+        return Optional.ofNullable(tip);
     }
 
     public int getLine() {

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
@@ -22,7 +22,10 @@ import org.intellij.lang.annotations.MagicConstant;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -107,7 +110,10 @@ public class SyntaxParser {
             if (variable.filter(v -> !v.isSingle() && expectedType.isSingle()).isPresent()) {
                 logger.error("A single value was expected, but " +
                         s +
-                        " represents multiple values.", ErrorType.SEMANTIC_ERROR);
+                        " represents multiple values.",
+                        ErrorType.SEMANTIC_ERROR,
+                        "Use a loop/map to divert each element of this list into single elements"
+                );
                 return Optional.empty();
             } else {
                 return variable;
@@ -174,7 +180,10 @@ public class SyntaxParser {
             if (variable.filter(v -> !v.isSingle()).isPresent()) {
                 logger.error("A single value was expected, but " +
                         s +
-                        " represents multiple values.", ErrorType.SEMANTIC_ERROR);
+                        " represents multiple values.",
+                        ErrorType.SEMANTIC_ERROR,
+                        "Use a loop/map to divert each element of this list into single elements"
+                );
                 return Optional.empty();
             } else {
                 return variable;
@@ -188,13 +197,19 @@ public class SyntaxParser {
                 switch (conditional) {
                     case 0: // Can't be conditional
                         if (ConditionalExpression.class.isAssignableFrom(expr.get().getClass())) {
-                            logger.error("The boolean expression must not be conditional", ErrorType.SEMANTIC_ERROR);
+                            logger.error("The boolean expression must not be conditional",
+                                    ErrorType.SEMANTIC_ERROR,
+                                    "Rather than a condition, use a simple boolean here. Use 'whether %=boolean%' to convert a condition into a simple boolean"
+                            );
                             return Optional.empty();
                         }
                         break;
                     case 2: // Has to be conditional
                         if (!ConditionalExpression.class.isAssignableFrom(expr.get().getClass())) {
-                            logger.error("The boolean expression must be conditional", ErrorType.SEMANTIC_ERROR);
+                            logger.error("The boolean expression must be conditional",
+                                    ErrorType.SEMANTIC_ERROR,
+                                    "Rather than a simple boolean, use a condition here, like '{x} is more than 10'"
+                            );
                             return Optional.empty();
                         }
                     case 1: // Can be conditional
@@ -221,13 +236,19 @@ public class SyntaxParser {
                 switch (conditional) {
                     case 0: // Can't be conditional
                         if (ConditionalExpression.class.isAssignableFrom(expr.get().getClass())) {
-                            logger.error("The boolean expression must not be conditional", ErrorType.SEMANTIC_ERROR);
+                            logger.error("The boolean expression must not be conditional",
+                                    ErrorType.SEMANTIC_ERROR,
+                                    "Rather than a condition, use a simple boolean here. Use 'whether %=boolean%' to convert a condition into a simple boolean"
+                            );
                             return Optional.empty();
                         }
                         break;
                     case 2: // Has to be conditional
                         if (!ConditionalExpression.class.isAssignableFrom(expr.get().getClass())) {
-                            logger.error("The boolean expression must be conditional", ErrorType.SEMANTIC_ERROR);
+                            logger.error("The boolean expression must be conditional",
+                                    ErrorType.SEMANTIC_ERROR,
+                                    "Rather than a simple boolean, use a condition here, like '{x} is more than 10'"
+                            );
                             return Optional.empty();
                         }
                     case 1: // Can be conditional
@@ -290,7 +311,10 @@ public class SyntaxParser {
                     }
                     if (!expression.isSingle() &&
                             expectedType.isSingle()) {
-                        logger.error("A single value was expected, but '" + s + "' represents multiple values.", ErrorType.SEMANTIC_ERROR);
+                        logger.error("A single value was expected, but '" + s + "' represents multiple values.",
+                                ErrorType.SEMANTIC_ERROR,
+                                "Use a loop/map to divert each element of this list into single elements"
+                        );
                         continue;
                     }
                     if (parserState.isRestrictingExpressions() && parserState.forbidsSyntax(expression.getClass())) {

--- a/src/main/java/io/github/syst3ms/skriptparser/sections/SecLoop.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/sections/SecLoop.java
@@ -35,7 +35,11 @@ public class SecLoop extends CodeSection {
 	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
 		expr = expressions[0];
 		if (expr.isSingle()) {
-		    parseContext.getLogger().error("Cannot loop a single value", ErrorType.SEMANTIC_ERROR);
+		    parseContext.getLogger().error(
+		    		"Cannot loop a single value",
+				    ErrorType.SEMANTIC_ERROR,
+				    "Remove this loop, because you clearly don't need to loop a single value"
+		    );
 			return false;
 		}
 		return true;

--- a/src/main/java/io/github/syst3ms/skriptparser/util/ThreadUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/ThreadUtils.java
@@ -1,7 +1,10 @@
 package io.github.syst3ms.skriptparser.util;
 
 import java.time.Duration;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public class ThreadUtils {
 
@@ -12,6 +15,7 @@ public class ThreadUtils {
 	public static void runAsync(Runnable code) {
 		ExecutorService executor = Executors.newCachedThreadPool();
 		executor.submit(code);
+		executor.shutdown();
 	}
 
 	/**

--- a/src/test/java/io/github/syst3ms/skriptparser/log/SkriptLoggerTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/log/SkriptLoggerTest.java
@@ -21,15 +21,15 @@ public class SkriptLoggerTest {
         SkriptLogger logger = new SkriptLogger();
         ParserState parserState = new ParserState();
         Optional<? extends Expression<?>> noMatchFound = SyntaxParser.parseExpression("an expression that doesn't match anything", SyntaxParser.OBJECT_PATTERN_TYPE, parserState, logger);
-        logger.logOutput();
+        logger.finalizeLogs();
         assertTrue(noMatchFound.isEmpty() && logger.close().get(0).getMessage().startsWith("No expression"));
         logger = new SkriptLogger();
         Optional<? extends Expression<?>> wrongNumber = SyntaxParser.parseExpression("range from 1 to 3", SyntaxParser.OBJECT_PATTERN_TYPE, parserState, logger);
-        logger.logOutput();
+        logger.finalizeLogs();
         assertTrue(wrongNumber.isEmpty() && logger.close().get(0).getMessage().startsWith("A single"));
         logger = new SkriptLogger();
         Optional<? extends Expression<Boolean>> wrongRange = SyntaxParser.parseBooleanExpression("1 is between 'a' and 'b'", SyntaxParser.MAYBE_CONDITIONAL, parserState, logger);
-        logger.logOutput();
+        logger.finalizeLogs();
         assertTrue(wrongRange.isEmpty() && logger.close().get(0).getMessage().startsWith("'1' cannot"));
     }
 }


### PR DESCRIPTION
This pull request adds the ability to add tips to error messages, inspired by the message Kenzie left in the Discord.
- Tips are messages (blue bright) that give the user tips on how to solve certain errors. This can be very useful since some error messages may be confusing for new scripters.
- Added the ability to hide tips using the '--no-tips' tag (short form '--nt') as a program argument.
- Reworked the argument matching a bit.
- Added these tips to already existing error messages.
- Refactored the `logOutput()` method to be `finalizeLogs()` (which describes its purpose better)

I will currently let this settle as a draft, as I'm currently not 100% satisfied with the changes. I might just close this PR as a whole. 
Current doubts:
- Should tips be disabled by default?
- Should these tips be added to the LogEntry class or just added as an entry itself using a custom `tip()` method?
- Should this be added at all? Maybe describing the error messages better would clear things up?