### PR TITLE
[feature] Added ExprMutableList

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprMutableList.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprMutableList.java
@@ -1,17 +1,16 @@
 package io.github.syst3ms.skriptparser.expressions;
 
-import java.util.Arrays;
-import java.util.Collections;
-
-import org.jetbrains.annotations.Nullable;
-
 import io.github.syst3ms.skriptparser.Parser;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 /**
- * Reverses, shuffle or order given list.
+ * Reverse, shuffle or order a given list.
  *
  * @name Mutable List
  * @pattern reverse[d] %objects%
@@ -21,11 +20,6 @@ import io.github.syst3ms.skriptparser.parsing.ParseContext;
  * @author Olyno
  */
 public class ExprMutableList implements Expression<Object> {
-
-    private enum MutableType {
-        REVERSE, SHUFFLE, SORT
-    }
-
     static {
         Parser.getMainRegistration().addExpression(
             ExprMutableList.class,
@@ -38,13 +32,13 @@ public class ExprMutableList implements Expression<Object> {
     }
 
     private Expression<Object> list;
-    private MutableType type;
+    private int type;
 
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
         list = (Expression<Object>) expressions[0];
-        type = MutableType.values()[matchedPattern];
+        type = matchedPattern;
         return true;
     }
 
@@ -52,22 +46,27 @@ public class ExprMutableList implements Expression<Object> {
     public Object[] getValues(TriggerContext ctx) {
         Object[] values = list.getValues(ctx);
         switch (type) {
-            case REVERSE:
+            case 0:
                 Collections.reverse(Arrays.asList(values));
                 break;
-            case SHUFFLE:
+            case 1:
                 Collections.shuffle(Arrays.asList(values));
                 break;
-            case SORT:
+            case 2:
                 Arrays.sort(values);
                 break;
-
+            default:
+                throw new IllegalStateException();
         }
         return values;
     }
 
     @Override
     public String toString(@Nullable TriggerContext ctx, boolean debug) {
-        return type.name().replaceAll("_", "").toLowerCase() + " " + list.toString(ctx, debug);
+        return (type == 0
+                ? "reversed " : type == 1
+                ? "shuffled "
+                : "sorted ")
+                + list.toString(ctx, debug);
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprMutableList.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprMutableList.java
@@ -11,42 +11,63 @@ import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 
 /**
- * Reverses given list.
+ * Reverses, shuffle or order given list.
  *
- * @name Reversed List
- * @pattern reversed %objects% 
+ * @name Mutable List
+ * @pattern reverse[d] %objects%
+ * @pattern shuffle[d] %objects%
+ * @pattern sort[ed] %objects%
  * @since ALPHA
  * @author Olyno
  */
-public class ExprReversedList implements Expression<Object> {
+public class ExprMutableList implements Expression<Object> {
+
+    private enum MutableType {
+        REVERSE, SHUFFLE, SORT
+    }
 
     static {
         Parser.getMainRegistration().addExpression(
-            ExprReversedList.class,
+            ExprMutableList.class,
             Object.class,
             false,
-            "reversed %objects%"
+            "reverse[d] %objects%",
+            "shuffle[d] %objects%",
+            "sort[ed] %objects%"
         );
     }
 
     private Expression<Object> list;
+    private MutableType type;
 
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
         list = (Expression<Object>) expressions[0];
+        type = MutableType.values()[matchedPattern];
         return true;
     }
 
     @Override
     public Object[] getValues(TriggerContext ctx) {
         Object[] values = list.getValues(ctx);
-        Collections.reverse(Arrays.asList(values)); 
+        switch (type) {
+            case REVERSE:
+                Collections.reverse(Arrays.asList(values));
+                break;
+            case SHUFFLE:
+                Collections.shuffle(Arrays.asList(values));
+                break;
+            case SORT:
+                Arrays.sort(values);
+                break;
+
+        }
         return values;
     }
 
     @Override
     public String toString(@Nullable TriggerContext ctx, boolean debug) {
-        return "reversed " + list.toString(ctx, debug);
+        return type.name().replaceAll("_", "").toLowerCase() + " " + list.toString(ctx, debug);
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprReversedList.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprReversedList.java
@@ -1,0 +1,52 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.jetbrains.annotations.Nullable;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+
+/**
+ * Reverses given list.
+ *
+ * @name Reversed List
+ * @pattern reversed %objects% 
+ * @since ALPHA
+ * @author Olyno
+ */
+public class ExprReversedList implements Expression<Object> {
+
+    static {
+        Parser.getMainRegistration().addExpression(
+            ExprReversedList.class,
+            Object.class,
+            false,
+            "reversed %objects%"
+        );
+    }
+
+    private Expression<Object> list;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        list = (Expression<Object>) expressions[0];
+        return true;
+    }
+
+    @Override
+    public Object[] getValues(TriggerContext ctx) {
+        Object[] values = list.getValues(ctx);
+        Collections.reverse(Arrays.asList(values)); 
+        return values;
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return "reversed " + list.toString(ctx, debug);
+    }
+}


### PR DESCRIPTION
This pull request includes a new expression.

**Patterns:**

```py
reverse[d] %objects%
shuffle[d] %objects%
sort[ed] %objects%
```

**Usage:**

```py
on script load:
    set {_x::*} to "a", "b", "c" and "d"
    print "%reversed {_x::*}%" # d, c, b and a
    print "%shuffled {_x::*}%" # d, b, a and c
    print "%sorted {_x::*}%" # a, b, c and d
```