### PR TITLE
[Feat./Impr.] Add time type and time expressions and improvements

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/event/AtTimeContext.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/event/AtTimeContext.java
@@ -1,0 +1,14 @@
+package io.github.syst3ms.skriptparser.event;
+
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+
+/**
+ * The at time-event context.
+ */
+public class AtTimeContext implements TriggerContext {
+
+    @Override
+    public String getName() {
+        return "at time";
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/event/EvtAtTime.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/event/EvtAtTime.java
@@ -1,0 +1,53 @@
+package io.github.syst3ms.skriptparser.event;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.Literal;
+import io.github.syst3ms.skriptparser.lang.SkriptEvent;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.Time;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This event will trigger each day at a given time.
+ * Note that this may have some delay. The event certainly isn't accurate to the millisecond.
+ *
+ * @name At Time
+ * @type EVENT
+ * @pattern at %*time%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class EvtAtTime extends SkriptEvent {
+
+    static {
+        Parser.getMainRegistration()
+                .newEvent(EvtAtTime.class, "*at %*time%")
+                .setHandledContexts(AtTimeContext.class)
+                .register();
+    }
+
+    private Literal<Time> time;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        time = (Literal<Time>) expressions[0];
+        return true;
+    }
+
+    @Override
+    public boolean check(TriggerContext ctx) {
+        return ctx instanceof AtTimeContext && time.getSingle().isPresent();
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return "at " + time.toString(ctx, debug);
+    }
+
+    public Literal<Time> getTime() {
+        return time;
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateAgoLater.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateAgoLater.java
@@ -21,11 +21,11 @@ import java.util.Optional;
  * @since ALPHA
  * @author Mwexim
  */
-public class ExprAgoLater implements Expression<SkriptDate> {
+public class ExprDateAgoLater implements Expression<SkriptDate> {
 
 	static {
 		Parser.getMainRegistration().addExpression(
-				ExprAgoLater.class,
+				ExprDateAgoLater.class,
 				SkriptDate.class,
 				true,
 				3,

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateFromUnix.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateFromUnix.java
@@ -46,7 +46,7 @@ public class ExprDateFromUnix implements Expression<SkriptDate> {
 		return timestamp.getSingle(ctx)
 				.map(
 					t -> new SkriptDate[]{
-							unix ? new SkriptDate(t.longValue() * 1000) : new SkriptDate(t.longValue())
+							SkriptDate.of(unix ? t.longValue() * 1000 : t.longValue())
 					}
 				).orElse(new SkriptDate[0]);
 	}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateInformation.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateInformation.java
@@ -17,8 +17,8 @@ import java.util.function.Function;
  *
  * @name Date Information
  * @type EXPRESSION
- * @pattern [the] (year|month|day of year|day of month|day of week|hours|minutes|seconds) of [date] %date%
- * @pattern [date] %date%'[s] (year|month|day of year|day of month|day of week|hours|minutes|seconds)
+ * @pattern [the] (year|month|day of year|day of month|day of week|hours|minutes|seconds|milli[second]s) of [date] %date%
+ * @pattern [date] %date%'[s] (year|month|day of year|day of month|day of week|hours|minutes|seconds|milli[second]s)
  * @since ALPHA
  * @author Mwexim
  */
@@ -30,12 +30,12 @@ public class ExprDateInformation extends PropertyExpression<Number, SkriptDate> 
 				Number.class,
 				true,
 				"*[date] %date%",
-				"(0:year|1:month|2:day of year|3:day of month|4:day of week|5:hours|6:minutes|7:seconds)"
+				"(0:year|1:month|2:day of year|3:day of month|4:day of week|5:hours|6:minutes|7:seconds|8:milli[second]s)"
 		);
 	}
 
 	private final static String[] CHOICES = {
-			"year", "month", "day of year", "day of month", "day of week", "hours", "minutes", "seconds"
+			"year", "month", "day of year", "day of month", "day of week", "hours", "minutes", "seconds", "milliseconds"
 	};
 
 	int parseMark;
@@ -61,8 +61,10 @@ public class ExprDateInformation extends PropertyExpression<Number, SkriptDate> 
 					return new Number[] {lcd.getMinute()};
 				case 7:
 					return new Number[] {lcd.getSecond()};
+				case 8:
+					return new Number[] {lcd.getNano() / 1_000_000};
 				default:
-					return new Number[0];
+					throw new IllegalStateException();
 			}
 		});
 	}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateNow.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateNow.java
@@ -41,9 +41,9 @@ public class ExprDateNow implements Expression<SkriptDate> {
 			case 0:
 				return new SkriptDate[] {SkriptDate.now()};
 			case 1:
-				return new SkriptDate[] {new SkriptDate(SkriptDate.now().getTimestamp() - SkriptDate.MILLIS_PER_DAY)};
+				return new SkriptDate[] {SkriptDate.of(SkriptDate.now().getTimestamp() - SkriptDate.MILLIS_PER_DAY)};
 			case 2:
-				return new SkriptDate[] {new SkriptDate(SkriptDate.now().getTimestamp() + SkriptDate.MILLIS_PER_DAY)};
+				return new SkriptDate[] {SkriptDate.of(SkriptDate.now().getTimestamp() + SkriptDate.MILLIS_PER_DAY)};
 		}
 		return new SkriptDate[0];
 	}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateTodayAt.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateTodayAt.java
@@ -1,0 +1,61 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.SkriptDate;
+import io.github.syst3ms.skriptparser.util.Time;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+
+/**
+ * Today at a given time. When no time is set,
+ * it will take today's date as it would be midnight.
+ *
+ * @name Today At
+ * @type EXPRESSION
+ * @pattern today at %time%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class ExprDateTodayAt implements Expression<SkriptDate> {
+
+	static {
+		Parser.getMainRegistration().addExpression(
+				ExprDateTodayAt.class,
+				SkriptDate.class,
+				true,
+				"today [1:at %time%]"
+		);
+	}
+
+	private Expression<Time> time;
+	private boolean simple;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+		simple = parseContext.getParseMark() == 1;
+		if (simple)
+			time = (Expression<Time>) expressions[0];
+ 		return true;
+	}
+
+	@Override
+	public SkriptDate[] getValues(TriggerContext ctx) {
+		return simple
+				? time.getSingle(ctx)
+				.map(ti -> new SkriptDate[] {
+						SkriptDate.today().plus(Duration.ofMillis(ti.toMillis()))
+				})
+				.orElse(new SkriptDate[0])
+				: new SkriptDate[] {SkriptDate.today()};
+	}
+
+	@Override
+	public String toString(@Nullable TriggerContext ctx, boolean debug) {
+		return "today" + (simple ? " at " + time.toString(ctx, debug) : "");
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDifference.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDifference.java
@@ -39,11 +39,14 @@ public class ExprDifference implements Expression<Object> {
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
-        first = (Expression<Object>) expressions[0];
-        second = (Expression<Object>) expressions[1];
+        var converted = Expression.convertPair(expressions[0], expressions[1]);
+        first = (Expression<Object>) converted.getFirst();
+        second = (Expression<Object>) converted.getSecond();
+
         var commonType = TypeManager.getByClass(
                 ClassUtils.getCommonSuperclass(first.getReturnType(), second.getReturnType())
         );
+
         if (commonType.isEmpty()) {
             commonType = TypeManager.getByClassExact(Object.class);
             assert commonType.isPresent();
@@ -52,7 +55,17 @@ public class ExprDifference implements Expression<Object> {
         var arithmetic = type.getArithmetic();
         commonSuperClass = commonType.get().getTypeClass();
         if (arithmetic.isEmpty()) {
-            parseContext.getLogger().error("Can't compare these two values", ErrorType.SEMANTIC_ERROR);
+            var firstType = TypeManager.getByClass(first.getReturnType());
+            var secondType = TypeManager.getByClass(second.getReturnType());
+            assert firstType.isPresent() && secondType.isPresent();
+            parseContext.getLogger().error(
+                    "Can't compare these two values"
+                            + " (types '"
+                            + firstType.get().getBaseName()
+                            + "' and '"
+                            + secondType.get().getBaseName()
+                            + "' are inconvertible)",
+                    ErrorType.SEMANTIC_ERROR);
             return false;
         }
         math = arithmetic.get();

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDifference.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDifference.java
@@ -49,9 +49,8 @@ public class ExprDifference implements Expression<Object> {
 
         if (commonType.isEmpty()) {
             commonType = TypeManager.getByClassExact(Object.class);
-            assert commonType.isPresent();
         }
-        var type = commonType.get();
+        var type = commonType.orElseThrow(AssertionError::new);
         var arithmetic = type.getArithmetic();
         commonSuperClass = commonType.get().getTypeClass();
         if (arithmetic.isEmpty()) {

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDurationSinceUntil.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDurationSinceUntil.java
@@ -10,47 +10,51 @@ import org.jetbrains.annotations.Nullable;
 import java.time.Duration;
 
 /**
- * The duration that has passed since a given date. This will basically compare
- * the current date and the given date.
- * Note that when the given date is in the feature, the duration will represent 0.
- * The precision can differ several milliseconds.
+ * Compares the given date with the current date.
+ * Note that the first pattern is to compare with the past
+ * and the second one to compare with the future.
+ * Note that the accuracy can be off some milliseconds.
  *
- * @name Duration Since
+ * @name Duration Since/Until
  * @type EXPRESSION
  * @pattern [the] (duration|time) [passed] since [date] %date%
+ * @pattern [the] (duration|time) (until|till) [date] %date%
  * @since ALPHA
  * @author Mwexim
  */
-public class ExprDurationSince implements Expression<Duration> {
+public class ExprDurationSinceUntil implements Expression<Duration> {
 
 	static {
 		Parser.getMainRegistration().addExpression(
-				ExprDurationSince.class,
+				ExprDurationSinceUntil.class,
 				Duration.class,
 				true,
-				"[the] (duration|time) [passed] since [date] %date%"
+				"[the] (duration|time) [passed] since [date] %date%",
+				"[the] (duration|time) (until|till) [date] %date%"
 		);
 	}
 
-	Expression<SkriptDate> date;
+	private Expression<SkriptDate> date;
+	private boolean past;
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
 		date = (Expression<SkriptDate>) expressions[0];
+		past = matchedPattern == 0;
 		return true;
 	}
 
 	@Override
 	public Duration[] getValues(TriggerContext ctx) {
 		return date.getSingle(ctx)
-				.filter(da -> da.compareTo(SkriptDate.now()) < 1)
+				.filter(da -> da.compareTo(SkriptDate.now()) < 0 || !past)
 				.map(da -> new Duration[] {da.difference(SkriptDate.now())})
 				.orElse(new Duration[0]);
 	}
 
 	@Override
 	public String toString(@Nullable TriggerContext ctx, boolean debug) {
-		return "duration since " + date.toString(ctx, debug);
+		return "duration " + (past ? "since " : "until ") + date.toString(ctx, debug);
 	}
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprParseAs.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprParseAs.java
@@ -84,7 +84,7 @@ public class ExprParseAs implements Expression<Object> {
 						);
 						try {
 							long timestamp = parseFormat.parse(s).getTime();
-							return new SkriptDate(timestamp);
+							return SkriptDate.of(timestamp);
 						} catch (ParseException ex) {
 							return null;
 						}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprTimeInformation.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprTimeInformation.java
@@ -1,0 +1,72 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.lang.base.PropertyExpression;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.Time;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Information of a certain time.
+ *
+ * @name Date Information
+ * @type EXPRESSION
+ * @pattern [the] (hours|minutes|seconds|milli[second]s) of [time] %time%
+ * @pattern [time] %time%'[s] (hours|minutes|seconds|milli[second]s)
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class ExprTimeInformation extends PropertyExpression<Number, Time> {
+
+	static {
+		Parser.getMainRegistration().addPropertyExpression(
+				ExprTimeInformation.class,
+				Number.class,
+				true,
+				"*[time] %time%",
+				"(0:hours|1:minutes|2:seconds|3:milli[second]s)"
+		);
+	}
+
+	private final static String[] CHOICES = {
+			"hours", "minutes", "seconds", "milliseconds"
+	};
+
+	int parseMark;
+
+	@Override
+	public Optional<? extends Function<? super Time[], ? extends Number[]>> getPropertyFunction() {
+		return Optional.of(times -> {
+			switch (parseMark) {
+				case 0:
+					return new Number[] {times[0].getHour()};
+				case 1:
+					return new Number[] {times[0].getMinute()};
+				case 2:
+					return new Number[] {times[0].getSecond()};
+				case 3:
+					return new Number[] {times[0].getMillis()};
+				default:
+					throw new IllegalStateException();
+			}
+		});
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+		parseMark = parseContext.getParseMark();
+		setOwner((Expression<Time>) expressions[0]);
+		return true;
+	}
+
+	@Override
+	public String toString(@Nullable TriggerContext ctx, boolean debug) {
+		return CHOICES[parseMark] + " of time " + getOwner().toString(ctx, debug);
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/LitTimeConstants.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/LitTimeConstants.java
@@ -1,0 +1,78 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.Literal;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.log.ErrorType;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.Time;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Midnight and noon time constants and the ability to use
+ * expressions like {@code 12 o' clock} for literal usage.
+ *
+ * @name Time Constants
+ * @pattern (midnight|noon|midday)
+ * @pattern %*integer% o'[ ]clock
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class LitTimeConstants implements Literal<Time> {
+    static {
+        Parser.getMainRegistration().addExpression(
+                LitTimeConstants.class,
+                Time.class,
+                true,
+                "(noon|midday|1:midnight)",
+                "%*integer% o'[ ]clock"
+        );
+    }
+
+    private Literal<Long> hours;
+    private boolean onClock;
+    private boolean midnight;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        onClock = matchedPattern == 1;
+        midnight = parseContext.getParseMark() == 0;
+        if (onClock) {
+            hours = (Literal<Long>) expressions[0];
+            if (hours.getSingle().isPresent()) {
+                long h = hours.getSingle().get();
+                if (h < 0 || 24 < h) {
+                    parseContext.getLogger().error("The given hour ('"
+                                    + h + "') is not in between 0 and 24",
+                            ErrorType.SEMANTIC_ERROR
+                    );
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public Time[] getValues() {
+        if (onClock) {
+            return hours.getSingle()
+                    .map(h -> Time.of(h.intValue(), 0, 0, 0))
+                    .map(t -> new Time[] {t})
+                    .orElse(new Time[0]);
+        } else {
+            return new Time[] {midnight ? Time.MIDNIGHT : Time.NOON};
+        }
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        if (onClock) {
+            return hours.toString(ctx, debug) + " o' clock";
+        } else {
+            return midnight ? "midnight" : "noon";
+        }
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
@@ -7,9 +7,12 @@ import io.github.syst3ms.skriptparser.parsing.SkriptParserException;
 import io.github.syst3ms.skriptparser.parsing.SkriptRuntimeException;
 import io.github.syst3ms.skriptparser.registration.SyntaxManager;
 import io.github.syst3ms.skriptparser.sections.SecLoop;
+import io.github.syst3ms.skriptparser.types.TypeManager;
 import io.github.syst3ms.skriptparser.types.changers.ChangeMode;
 import io.github.syst3ms.skriptparser.types.conversions.Converters;
+import io.github.syst3ms.skriptparser.util.ClassUtils;
 import io.github.syst3ms.skriptparser.util.CollectionUtils;
+import io.github.syst3ms.skriptparser.util.Pair;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -33,8 +36,8 @@ public interface Expression<T> extends SyntaxElement {
     /*
      * This is staying until we figure out a better way to implement this
      */
-    default T[] getArray(TriggerContext e) {
-        return getValues(e);
+    default T[] getArray(TriggerContext ctx) {
+        return getValues(ctx);
     }
 
     /**
@@ -59,12 +62,12 @@ public interface Expression<T> extends SyntaxElement {
 
     /**
      * Gets a single value out of this Expression
-     * @param e the event
+     * @param ctx the event
      * @return the single value of this Expression, or {@code null} if it has no value
      * @throws SkriptRuntimeException if the expression returns more than one value
      */
-    default Optional<? extends T> getSingle(TriggerContext e) {
-        var values = getValues(e);
+    default Optional<? extends T> getSingle(TriggerContext ctx) {
+        var values = getValues(ctx);
         if (values.length == 0) {
             return Optional.empty();
         } else if (values.length > 1) {
@@ -193,6 +196,52 @@ public interface Expression<T> extends SyntaxElement {
         if (!hasElement)
             return invert;
         return invert != and;
+    }
+
+    /**
+     * Checks if these two expressions have a common superclass. If not, the following process is started:
+     * <ol>
+     *     <li>The first expression is converted to the second one.</li>
+     *     <li>If failed, the second one is converted to the first one.</li>
+     *     <li>If failed, the same instances are returned as a pair.</li>
+     * </ul>
+     * Otherwise, a pair of the same instances is returned.
+     * @param first the first expression
+     * @param second the second expression
+     * @return the converted expressions as a pair
+     */
+    static <T, U> Pair<Expression<?>, Expression<?>> convertPair(Expression<T> first, Expression<U> second) {
+        // If the common superclass of these expressions are not a valid type,
+        // Then we'll need to convert them
+        var commonType = TypeManager.getByClass(
+                ClassUtils.getCommonSuperclass(first.getReturnType(), second.getReturnType())
+        );
+
+        if (commonType.isPresent()) {
+            return new Pair<>(first, second);
+        } else {
+            // We convert the expressions because their types currently are not similar.
+            var firstConverted = first.convertExpression(second.getReturnType());
+            if (firstConverted.isPresent()) {
+                commonType = TypeManager.getByClass(
+                        ClassUtils.getCommonSuperclass(firstConverted.get().getReturnType(), second.getReturnType())
+                );
+                if (commonType.isPresent()) {
+                    return new Pair<>(firstConverted.get(), second);
+                }
+            } else {
+                var secondConverted = second.convertExpression(first.getReturnType());
+                if (secondConverted.isPresent()) {
+                    commonType = TypeManager.getByClass(
+                            ClassUtils.getCommonSuperclass(secondConverted.get().getReturnType(), first.getReturnType())
+                    );
+                    if (commonType.isPresent()) {
+                        return new Pair<>(first, secondConverted.get());
+                    }
+                }
+            }
+        }
+        return new Pair<>(first, second);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/ExpressionList.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/ExpressionList.java
@@ -56,14 +56,14 @@ public class ExpressionList<T> implements Expression<T> {
     }
 
     @Override
-    public T[] getArray(TriggerContext e) {
+    public T[] getArray(TriggerContext ctx) {
         if (and) {
-            return getValues(e);
+            return getValues(ctx);
         } else {
             var shuffle = Arrays.asList(expressions);
             Collections.shuffle(shuffle);
             for (var expr : shuffle) {
-                var values = expr.getValues(e);
+                var values = expr.getValues(ctx);
                 if (values.length > 0)
                     return values;
             }

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
@@ -5,9 +5,9 @@ import io.github.syst3ms.skriptparser.types.changers.Arithmetic;
 import io.github.syst3ms.skriptparser.types.comparisons.Comparator;
 import io.github.syst3ms.skriptparser.types.comparisons.Comparators;
 import io.github.syst3ms.skriptparser.types.comparisons.Relation;
-import io.github.syst3ms.skriptparser.types.conversions.Converters;
 import io.github.syst3ms.skriptparser.types.ranges.Ranges;
 import io.github.syst3ms.skriptparser.util.SkriptDate;
+import io.github.syst3ms.skriptparser.util.Time;
 import io.github.syst3ms.skriptparser.util.TimeUtils;
 import io.github.syst3ms.skriptparser.util.math.BigDecimalMath;
 
@@ -291,6 +291,31 @@ public class DefaultRegistration {
                     }
                 })
                 .register();
+        registration.newType(Time.class, "time", "time@s")
+                .literalParser(s -> TimeUtils.parseTime(s).orElse(null))
+                .toStringFunction(Time::toString)
+                .arithmetic(new Arithmetic<Time, Duration>() {
+                    @Override
+                    public Duration difference(Time first, Time second) {
+                        return first.difference(second);
+                    }
+
+                    @Override
+                    public Time add(Time value, Duration difference) {
+                        return value.plus(difference);
+                    }
+
+                    @Override
+                    public Time subtract(Time value, Duration difference) {
+                        return value.minus(difference);
+                    }
+
+                    @Override
+                    public Class<? extends Duration> getRelativeType() {
+                        return Duration.class;
+                    }
+                })
+                .register();
 
         /*
          * Comparators
@@ -386,8 +411,8 @@ public class DefaultRegistration {
         /*
          * Converters
          */
-        Converters.registerConverter(Number.class, Long.class, n -> Optional.of(n instanceof Long ? (Long) n : n.longValue()));
-        Converters.registerConverter(Number.class, BigInteger.class, n -> {
+        registration.addConverter(Number.class, Long.class, n -> Optional.of(n instanceof Long ? (Long) n : n.longValue()));
+        registration.addConverter(Number.class, BigInteger.class, n -> {
             if (n instanceof BigInteger) {
                 return Optional.of((BigInteger) n);
             } else if (n instanceof Long) {
@@ -396,6 +421,7 @@ public class DefaultRegistration {
                 return Optional.of(BigInteger.valueOf(n.longValue()));
             }
         });
+        registration.addConverter(SkriptDate.class, Time.class, da -> Optional.of(Time.of(da)));
       
         registration.register(); // Ignoring logs here, we control the input
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/util/NumberUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/NumberUtils.java
@@ -1,22 +1,9 @@
 package io.github.syst3ms.skriptparser.util;
 
-import java.math.BigInteger;
-
 /**
  * Utility functions for numbers that don't have to do with math.
  */
 public class NumberUtils {
-
-	/**
-	 * Checks if a given integer is between two values, both inclusive.
-	 * @param i the value to check
-	 * @param a the lower bound
-	 * @param b the upper bound
-	 * @return whether or not the value lays in between or is equal to a and b
-	 */
-	public static boolean between(int i, int a, int b) {
-		return a <= i && i <= b;
-	}
 
 	/**
 	 * Parse a string as an integer.
@@ -48,16 +35,5 @@ public class NumberUtils {
 		} catch (final NumberFormatException e) {
 			return str.startsWith("-") ? Long.MIN_VALUE : Long.MAX_VALUE;
 		}
-	}
-
-	/**
-	 * Parse a string as a BigInteger.
-	 * Note that the parsed string is expected to be a parsable BigInteger.
-	 * Therefore it will only take care of overflow situations.
-	 * @param str the string to parse
-	 * @return the parsed integer
-	 */
-	public static BigInteger parseBigInteger(String str) {
-		return BigInteger.valueOf(parseLong(str));
 	}
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/util/NumberUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/NumberUtils.java
@@ -1,0 +1,63 @@
+package io.github.syst3ms.skriptparser.util;
+
+import java.math.BigInteger;
+
+/**
+ * Utility functions for numbers that don't have to do with math.
+ */
+public class NumberUtils {
+
+	/**
+	 * Checks if a given integer is between two values, both inclusive.
+	 * @param i the value to check
+	 * @param a the lower bound
+	 * @param b the upper bound
+	 * @return whether or not the value lays in between or is equal to a and b
+	 */
+	public static boolean between(int i, int a, int b) {
+		return a <= i && i <= b;
+	}
+
+	/**
+	 * Parse a string as an integer.
+	 * Note that the parsed string is expected to be a parsable integer.
+	 * Therefore it will only take care of overflow situations.
+	 * @param str the string to parse
+	 * @return the parsed integer
+	 */
+	public static int parseInt(String str) {
+		assert str.matches("-?\\d+");
+		try {
+			return Integer.parseInt(str);
+		} catch (final NumberFormatException e) {
+			return str.startsWith("-") ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+		}
+	}
+
+	/**
+	 * Parse a string as a long.
+	 * Note that the parsed string is expected to be a parsable long.
+	 * Therefore it will only take care of overflow situations.
+	 * @param str the string to parse
+	 * @return the parsed integer
+	 */
+	public static long parseLong(String str) {
+		assert str.matches("-?\\d+");
+		try {
+			return Long.parseLong(str);
+		} catch (final NumberFormatException e) {
+			return str.startsWith("-") ? Long.MIN_VALUE : Long.MAX_VALUE;
+		}
+	}
+
+	/**
+	 * Parse a string as a BigInteger.
+	 * Note that the parsed string is expected to be a parsable BigInteger.
+	 * Therefore it will only take care of overflow situations.
+	 * @param str the string to parse
+	 * @return the parsed integer
+	 */
+	public static BigInteger parseBigInteger(String str) {
+		return BigInteger.valueOf(parseLong(str));
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/SkriptDate.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/SkriptDate.java
@@ -12,7 +12,6 @@ import java.util.TimeZone;
  * @author Njol
  */
 public class SkriptDate implements Comparable<SkriptDate> {
-
     // TODO make a config for this
     public final static String DATE_FORMAT = "EEEE dd MMMM yyyy HH:mm:ss.SSS zzzXXX";
     public final static Locale DATE_LOCALE = new Locale("US");
@@ -24,15 +23,11 @@ public class SkriptDate implements Comparable<SkriptDate> {
      */
     private long timestamp;
 
-    public SkriptDate() {
-        this(System.currentTimeMillis());
-    }
-
-    public SkriptDate(long timestamp) {
+    private SkriptDate(long timestamp) {
         this.timestamp = timestamp;
     }
 
-    public SkriptDate(long timestamp, TimeZone zone) {
+    private SkriptDate(long timestamp, TimeZone zone) {
         long offset = zone.getOffset(timestamp);
         this.timestamp = timestamp - offset;
     }
@@ -42,10 +37,27 @@ public class SkriptDate implements Comparable<SkriptDate> {
      * @return new {@link SkriptDate} with the current time
      */
     public static SkriptDate now() {
-        return new SkriptDate(System.currentTimeMillis());
+        return SkriptDate.of(System.currentTimeMillis());
     }
 
-    public Duration difference(SkriptDate other) {
+    public static SkriptDate of(long timestamp) {
+        return new SkriptDate(timestamp);
+    }
+
+    public static SkriptDate of(long timestamp, TimeZone zone) {
+        return new SkriptDate(timestamp, zone);
+    }
+
+    /**
+     * The current day when it started.
+     * @return the current day like it would just start
+     */
+	public static SkriptDate today() {
+	    var localDate = LocalDate.now().atStartOfDay(ZoneId.systemDefault());
+	    return SkriptDate.of(localDate.toEpochSecond() * 1000);
+	}
+
+	public Duration difference(SkriptDate other) {
         return Duration.ZERO.plusMillis(Math.abs(timestamp - other.getTimestamp()));
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/util/SkriptDate.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/SkriptDate.java
@@ -58,7 +58,7 @@ public class SkriptDate implements Comparable<SkriptDate> {
 	}
 
 	public Duration difference(SkriptDate other) {
-        return Duration.ZERO.plusMillis(Math.abs(timestamp - other.getTimestamp()));
+        return Duration.ofMillis(timestamp - other.getTimestamp()).abs();
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/util/ThreadUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/ThreadUtils.java
@@ -39,4 +39,14 @@ public class ThreadUtils {
 		scheduler.scheduleAtFixedRate(code, duration.toMillis(), duration.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
+	/**
+	 * Runs certain code periodically.
+	 * @param code the runnable that needs to be executed
+	 * @param initialDelay the initial delay
+	 * @param duration the delay
+	 */
+	public static void runPeriodically(Runnable code, Duration initialDelay, Duration duration) {
+		ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+		scheduler.scheduleAtFixedRate(code, initialDelay.toMillis(), duration.toMillis(), TimeUnit.MILLISECONDS);
+	}
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/util/Time.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/Time.java
@@ -1,0 +1,161 @@
+package io.github.syst3ms.skriptparser.util;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+
+/**
+ * Represents a time, written as HH:mm:ss.SSS.
+ * @author Mwexim
+ */
+public class Time implements Comparable<Time> {
+    // TODO make a config for this
+    public final static String TIME_FORMAT = "HH:mm:ss.SSS";
+    public final static Locale TIME_LOCALE = Locale.US;
+
+    /**
+     * Returns the latest possible time, being 23:59:59.999.
+     */
+    public final static Time LATEST = Time.of(23, 59, 59, 999);
+    /**
+     * Represents midnight, being 00:00:00.000.
+     */
+    public final static Time MIDNIGHT = Time.of(0, 0, 0, 0);
+    /**
+     * Represents noon, being 12:00:00.000.
+     */
+    public final static Time NOON = Time.of(12, 0, 0, 0);
+
+    private LocalTime time;
+
+    private Time(LocalTime time) {
+        this.time = time;
+    }
+
+    /**
+     * The current time, as it would be visible on a clock.
+     * @return the current time
+     */
+    public static Time now() {
+        return new Time(LocalTime.now());
+    }
+
+    /**
+     * The time instance from given values.
+     * @param hours the hours, between 0 and 23
+     * @param minutes the minutes, between 0 and 59
+     * @param seconds the seconds, between 0 and 59
+     * @param millis the milliseconds, between 0 and 999
+     * @return a new time instance
+     */
+    public static Time of(int hours, int minutes, int seconds, int millis) {
+        return new Time(LocalTime.of(hours, minutes, seconds, millis * 1_000_000));
+    }
+
+    /**
+     * The time instance from a given LocalTime instance.
+     * @param time the LocalTime instance
+     * @return a new time instance
+     */
+    public static Time of(LocalTime time) {
+        return new Time(time);
+    }
+
+    public static Time of (SkriptDate date) {
+        return new Time(LocalTime.ofInstant(Instant.ofEpochMilli(date.getTimestamp()), ZoneId.systemDefault()));
+    }
+
+    public int getHour() {
+        return time.getHour();
+    }
+
+    public int getMinute() {
+        return time.getMinute();
+    }
+
+    public int getSecond() {
+        return time.getSecond();
+    }
+
+    public int getMillis() {
+        return time.getNano() / 1_000_000;
+    }
+
+    public LocalTime getTime() {
+        return time;
+    }
+
+    /**
+     * @return the amount of milliseconds that passed since the start of the day
+     */
+    public int toMillis() {
+        return (int) MIDNIGHT.getTime().until(time, ChronoUnit.MILLIS);
+    }
+
+    /**
+     * The duration between two given time instances
+     * @param other the time instance to compare
+     * @return the duration between the instances, or {@link Duration#ZERO ZERO} if one instance is invalid
+     */
+    public Duration difference(Time other) {
+        return Duration.ofMillis(time.until(other.getTime(), ChronoUnit.MILLIS));
+    }
+
+    /**
+     * Add a {@link Duration} to this time.
+     * @param span {@link Duration} to add
+     */
+    public void add(Duration span) {
+        time = time.plusNanos(span.toMillis() * 1_000_000);
+    }
+
+    /**
+     * Subtract a {@link Duration} from this time.
+     * @param span {@link Duration} to subtract
+     */
+    public void subtract(Duration span) {
+        time = time.minusNanos(span.toMillis() * 1_000_000);
+    }
+
+    /**
+     * Get a new instance of this time with the added Duration.
+     * @param span {@link Duration} to add to this Time
+     * @return new {@link Time} with the added Duration
+     */
+    public Time plus(Duration span) {
+        return new Time(time.plusNanos(span.toMillis() * 1_000_000));
+    }
+
+    /**
+     * Get a new instance of this time with the subtracted Duration.
+     * @param span {@link Duration} to subtract from this Time
+     * @return new {@link Time} with the subtracted Duration
+     */
+    public Time minus(Duration span) {
+        return new Time(time.minusNanos(span.toMillis() * 1_000_000));
+    }
+
+    @Override
+    public int compareTo(Time other) {
+        return time.compareTo(other.getTime());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Time time = (Time) o;
+        return this.time.equals(time.getTime());
+    }
+
+    @Override
+    public String toString() {
+        return time.format(DateTimeFormatter.ofPattern(TIME_FORMAT, TIME_LOCALE));
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/Time.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/Time.java
@@ -93,7 +93,9 @@ public class Time implements Comparable<Time> {
      * @return the amount of milliseconds that passed since the start of the day
      */
     public int toMillis() {
-        return (int) MIDNIGHT.getTime().until(time, ChronoUnit.MILLIS);
+        var millis = MIDNIGHT.getTime().until(time, ChronoUnit.MILLIS);
+        assert millis >= 0;
+        return (int) millis;
     }
 
     /**
@@ -102,7 +104,7 @@ public class Time implements Comparable<Time> {
      * @return the duration between the instances, or {@link Duration#ZERO ZERO} if one instance is invalid
      */
     public Duration difference(Time other) {
-        return Duration.ofMillis(time.until(other.getTime(), ChronoUnit.MILLIS));
+        return Duration.ofMillis(time.until(other.getTime(), ChronoUnit.MILLIS)).abs();
     }
 
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/util/TimeUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/TimeUtils.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import static io.github.syst3ms.skriptparser.util.NumberUtils.parseInt;
+import static io.github.syst3ms.skriptparser.util.math.NumberMath.parseInt;
 
 public class TimeUtils {
 

--- a/src/main/java/io/github/syst3ms/skriptparser/util/TimeUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/TimeUtils.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import static io.github.syst3ms.skriptparser.util.NumberUtils.between;
 import static io.github.syst3ms.skriptparser.util.NumberUtils.parseInt;
 
 public class TimeUtils {
@@ -116,13 +115,13 @@ public class TimeUtils {
             int hours = parseInt(parts[0]);
             if (hours == 24) {
                 hours = 0; // Allows to write 24:00 -> 24:59 instead of 00:00 -> 00:59
-            } else if (!between(hours, 0, 23)) {
+            } else if (hours < 0 || 23 < hours) {
                 return Optional.empty();
             }
             int minutes = parts.length > 1
                     ? parseInt(parts[0])
                     : 0;
-            if (!between(minutes, 0, 59)) {
+            if (0 <= minutes && minutes <= 59) {
                 return Optional.empty();
             }
             return Optional.of(Time.of(hours, minutes, 0, 0));
@@ -130,14 +129,14 @@ public class TimeUtils {
             // Second category
             int hours = parseInt(secondMatcher.group(1));
             if (hours == 12) {
-                hours = 0;
-            } else if (!between(hours, 0, 11)) {
+                hours = 0; // 12 AM is 00:00:00.000 for some weird reason
+            } else if (hours < 0 || 11 < hours) {
                 return Optional.empty();
             }
             int minutes = 0;
             if (secondMatcher.group(3) != null)
                 minutes = parseInt(secondMatcher.group(3));
-            if (!between(minutes, 0, 59)) {
+            if (minutes < 0 || 59 < minutes) {
                 return Optional.empty();
             }
             if (secondMatcher.group(4).equalsIgnoreCase("pm"))
@@ -148,11 +147,11 @@ public class TimeUtils {
             int hours = parseInt(thirdMatcher.group(1));
             if (hours == 24) {
                 hours = 0; // Allows to write 24:00 -> 24:59 instead of 00:00 -> 00:59
-            } else if (!between(hours, 0, 23)) {
+            } else if (hours < 0 || 23 < hours) {
                 return Optional.empty();
             }
             int minutes = parseInt(thirdMatcher.group(2));
-            if (!between(minutes, 0, 59)) {
+            if (minutes < 0 || 59 < minutes) {
                 return Optional.empty();
             }
             int seconds = 0, millis = 0;
@@ -162,7 +161,7 @@ public class TimeUtils {
             if (thirdMatcher.group(7) != null) {
                 millis = parseInt(thirdMatcher.group(7));
             }
-            if (!between(seconds, 0, 59) || !between(millis, 0, 999)) {
+            if (seconds < 0 || 59 < seconds || millis < 0 || 999 < millis) {
                 return Optional.empty();
             }
             return Optional.of(Time.of(hours,minutes, seconds, millis));

--- a/src/main/java/io/github/syst3ms/skriptparser/util/TimeUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/TimeUtils.java
@@ -3,6 +3,10 @@ package io.github.syst3ms.skriptparser.util;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static io.github.syst3ms.skriptparser.util.NumberUtils.between;
+import static io.github.syst3ms.skriptparser.util.NumberUtils.parseInt;
 
 public class TimeUtils {
 
@@ -11,6 +15,11 @@ public class TimeUtils {
      */
     public static Duration TICK = Duration.ofMillis(50);
 
+    /**
+     * Parses a string as a duration
+     * @param str the string to parse
+     * @return the parsed duration, empty if no match
+     */
     public static Optional<Duration> parseDuration(String str) {
         // TODO parsing gets in trouble with lists
         if (str.isEmpty())
@@ -76,7 +85,7 @@ public class TimeUtils {
                     return Optional.empty(); // Seconds was already used elsewhere and is used again.
                 dur = dur.plusSeconds(amount);
                 passed[3] = true;
-            } else if (s.matches("milliseconds?")) {
+            } else if (s.matches("milli(second)?s?")) {
                 if (passed[4]) return Optional.empty(); // Millis was already used elsewhere and is used again.
                 dur = dur.plusMillis(amount);
                 passed[4] = true;
@@ -85,6 +94,81 @@ public class TimeUtils {
             }
         }
         return Optional.of(dur);
+    }
+
+    public static Optional<Time> parseTime(String str) {
+        if (str.isEmpty())
+            return Optional.empty();
+
+        var firstMatcher = Pattern.compile("\\d?\\dh(\\d\\d)?").matcher(str);
+        var secondMatcher = Pattern.compile("(\\d?\\d)(:(\\d\\d))? ?(am|pm)", Pattern.CASE_INSENSITIVE).matcher(str);
+        var thirdMatcher = Pattern.compile("(\\d?\\d):(\\d\\d)(:(\\d\\d(\\.(\\d\\d\\d))?))?").matcher(str);
+
+        /*
+         * We will sort time literals in 3 categories:
+         * 1. [#]#h[##], like 18h30
+         * 2. [#]#[:##][ ](am|pm), like 11 am or 12:30pm
+         * 3. [#]#:##[:##[.###]], like 18:30:15.500
+         */
+        if (firstMatcher.matches()) {
+            // First category
+            String[] parts = str.split("h");
+            int hours = parseInt(parts[0]);
+            if (hours == 24) {
+                hours = 0; // Allows to write 24:00 -> 24:59 instead of 00:00 -> 00:59
+            } else if (!between(hours, 0, 23)) {
+                return Optional.empty();
+            }
+            int minutes = parts.length > 1
+                    ? parseInt(parts[0])
+                    : 0;
+            if (!between(minutes, 0, 59)) {
+                return Optional.empty();
+            }
+            return Optional.of(Time.of(hours, minutes, 0, 0));
+        } else if (secondMatcher.matches()) {
+            // Second category
+            int hours = parseInt(secondMatcher.group(1));
+            if (hours == 12) {
+                hours = 0;
+            } else if (!between(hours, 0, 11)) {
+                return Optional.empty();
+            }
+            int minutes = 0;
+            if (secondMatcher.group(3) != null)
+                minutes = parseInt(secondMatcher.group(3));
+            if (!between(minutes, 0, 59)) {
+                return Optional.empty();
+            }
+            if (secondMatcher.group(4).equalsIgnoreCase("pm"))
+                hours += 12;
+            return Optional.of(Time.of(hours, minutes, 0, 0));
+        } else if (thirdMatcher.matches()) {
+            // Third category
+            int hours = parseInt(thirdMatcher.group(1));
+            if (hours == 24) {
+                hours = 0; // Allows to write 24:00 -> 24:59 instead of 00:00 -> 00:59
+            } else if (!between(hours, 0, 23)) {
+                return Optional.empty();
+            }
+            int minutes = parseInt(thirdMatcher.group(2));
+            if (!between(minutes, 0, 59)) {
+                return Optional.empty();
+            }
+            int seconds = 0, millis = 0;
+            if (thirdMatcher.group(5) != null) {
+                seconds = parseInt(thirdMatcher.group(5));
+            }
+            if (thirdMatcher.group(7) != null) {
+                millis = parseInt(thirdMatcher.group(7));
+            }
+            if (!between(seconds, 0, 59) || !between(millis, 0, 999)) {
+                return Optional.empty();
+            }
+            return Optional.of(Time.of(hours,minutes, seconds, millis));
+        } else {
+            return Optional.empty();
+        }
     }
 
     public static String toStringDuration(Duration dur) {
@@ -147,5 +231,4 @@ public class TimeUtils {
     private static boolean oneIsTrue(Boolean... booleans) {
         return Arrays.stream(booleans).anyMatch(Boolean::booleanValue);
     }
-
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/util/math/NumberMath.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/math/NumberMath.java
@@ -284,6 +284,38 @@ public class NumberMath {
         return scaled.add(padding).setScale(rand.scale(), BigDecimalMath.DEFAULT_ROUNDING_MODE); // Finally, we add the padding
     }
 
+    /**
+     * Parse a string as an integer.
+     * Note that the parsed string is expected to be a parsable integer.
+     * Therefore it will only take care of overflow situations.
+     * @param str the string to parse
+     * @return the parsed integer
+     */
+    public static int parseInt(String str) {
+        assert str.matches("-?\\d+");
+        try {
+            return Integer.parseInt(str);
+        } catch (final NumberFormatException e) {
+            return str.startsWith("-") ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+        }
+    }
+
+    /**
+     * Parse a string as a long.
+     * Note that the parsed string is expected to be a parsable long.
+     * Therefore it will only take care of overflow situations.
+     * @param str the string to parse
+     * @return the parsed integer
+     */
+    public static long parseLong(String str) {
+        assert str.matches("-?\\d+");
+        try {
+            return Long.parseLong(str);
+        } catch (final NumberFormatException e) {
+            return str.startsWith("-") ? Long.MIN_VALUE : Long.MAX_VALUE;
+        }
+    }
+
     private static Number changeBoundExclusion(Number n, Number other) {
         /*
          * The methods used for each number type have an inclusive lower bound but an exclusive upper bound.


### PR DESCRIPTION
This is a relatively big pull request, featuring the new Time type and many dates related improvements.
- New Time utility class
- Added Time type with parser (supports both European and American format).
- Added Date to time conversion
- ExprDateTodayAt: converts a time into a date (I didn't want to make a literal converter since this is more syntax-friendly) or returns today's date at midnight
- Improved many expressions like ExprDurationSince and ExprDateInformation
- Refactored some files to make their names more convenient
- Improved SkriptDate class
- Added EvtAtTime, that triggers the event at a given time