### PR TITLE
[Feature] Add PropertyConditionals as utility class

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprIsSet.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprIsSet.java
@@ -2,10 +2,8 @@ package io.github.syst3ms.skriptparser.expressions;
 
 import io.github.syst3ms.skriptparser.Parser;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
-import io.github.syst3ms.skriptparser.lang.Expression;
-import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
-import io.github.syst3ms.skriptparser.parsing.ParseContext;
-import org.jetbrains.annotations.Nullable;
+import io.github.syst3ms.skriptparser.lang.properties.ConditionalType;
+import io.github.syst3ms.skriptparser.lang.properties.PropertyConditional;
 
 /**
  * Check if a given expression is set (null on the Java side) or not.
@@ -16,32 +14,19 @@ import org.jetbrains.annotations.Nullable;
  * @since ALPHA
  * @author Syst3ms
  */
-public class CondExprIsSet extends ConditionalExpression {
-    private Expression<?> expr;
+public class CondExprIsSet extends PropertyConditional<Object> {
 
     static {
-        Parser.getMainRegistration().addExpression(
+        Parser.getMainRegistration().addSelfRegisteringElement(
                 CondExprIsSet.class,
-                Boolean.class,
-                true,
-                "%~objects% (is|are)[1:( not|n't)] set"
+                "*%~objects%",
+                ConditionalType.BE,
+                "set"
         );
     }
 
     @Override
-    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
-        expr = expressions[0];
-        setNegated(parseContext.getParseMark() == 1);
-        return true;
-    }
-
-    @Override
-    public boolean check(TriggerContext ctx) {
-        return isNegated() != (expr == null || expr.getValues(ctx).length == 0);
-    }
-
-    @Override
-    public String toString(@Nullable TriggerContext ctx, boolean debug) {
-        return expr.toString(ctx, debug) + (isNegated() ? " is not " : " is ") + "set";
+    public boolean check(TriggerContext ctx, Object[] performers) {
+        return isNegated() == (performers.length == 0);
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprAmount.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprAmount.java
@@ -4,7 +4,7 @@ import io.github.syst3ms.skriptparser.Parser;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.lang.Variable;
-import io.github.syst3ms.skriptparser.lang.base.PropertyExpression;
+import io.github.syst3ms.skriptparser.lang.properties.PropertyExpression;
 import io.github.syst3ms.skriptparser.log.ErrorType;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprContextValue.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprContextValue.java
@@ -5,7 +5,7 @@ import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.registration.contextvalues.ContextValue;
-import io.github.syst3ms.skriptparser.registration.contextvalues.ContextValueTime;
+import io.github.syst3ms.skriptparser.registration.contextvalues.ContextValueState;
 import io.github.syst3ms.skriptparser.registration.contextvalues.ContextValues;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,7 +30,7 @@ public class ExprContextValue implements Expression<Object> {
 	}
 
 	private String name;
-	private ContextValueTime time;
+	private ContextValueState time;
 	private ContextValue<?> value;
 
 	@Override
@@ -38,13 +38,13 @@ public class ExprContextValue implements Expression<Object> {
 		name = parseContext.getMatches().get(0).group();
 		switch (parseContext.getParseMark()) {
 			case 1:
-				time = ContextValueTime.PAST;
+				time = ContextValueState.PAST;
 				break;
 			case 2:
-				time = ContextValueTime.FUTURE;
+				time = ContextValueState.FUTURE;
 				break;
 			default:
-				time = ContextValueTime.PRESENT;
+				time = ContextValueState.PRESENT;
 		}
 		for (Class<? extends TriggerContext> ctx : parseContext.getParserState().getCurrentContexts()) {
 			for (ContextValue<?> val : ContextValues.getContextValues()) {
@@ -70,9 +70,9 @@ public class ExprContextValue implements Expression<Object> {
 	@Override
 	public String toString(final @Nullable TriggerContext ctx, final boolean debug) {
 		String state = "";
-		if (time == ContextValueTime.PAST) {
+		if (time == ContextValueState.PAST) {
 			state = "past ";
-		} else if (time == ContextValueTime.FUTURE) {
+		} else if (time == ContextValueState.FUTURE) {
 			state = "future ";
 		}
 		return state + "context-" + name;

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateInformation.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateInformation.java
@@ -3,7 +3,7 @@ package io.github.syst3ms.skriptparser.expressions;
 import io.github.syst3ms.skriptparser.Parser;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
-import io.github.syst3ms.skriptparser.lang.base.PropertyExpression;
+import io.github.syst3ms.skriptparser.lang.properties.PropertyExpression;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.util.SkriptDate;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateTimestamp.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateTimestamp.java
@@ -3,7 +3,7 @@ package io.github.syst3ms.skriptparser.expressions;
 import io.github.syst3ms.skriptparser.Parser;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
-import io.github.syst3ms.skriptparser.lang.base.PropertyExpression;
+import io.github.syst3ms.skriptparser.lang.properties.PropertyExpression;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.util.SkriptDate;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateValues.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateValues.java
@@ -3,7 +3,7 @@ package io.github.syst3ms.skriptparser.expressions;
 import io.github.syst3ms.skriptparser.Parser;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
-import io.github.syst3ms.skriptparser.lang.base.PropertyExpression;
+import io.github.syst3ms.skriptparser.lang.properties.PropertyExpression;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.util.SkriptDate;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
@@ -2,7 +2,7 @@ package io.github.syst3ms.skriptparser.expressions;
 
 import io.github.syst3ms.skriptparser.Parser;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
-import io.github.syst3ms.skriptparser.lang.base.PropertyExpression;
+import io.github.syst3ms.skriptparser.lang.properties.PropertyExpression;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/SelfRegistrable.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/SelfRegistrable.java
@@ -1,0 +1,18 @@
+package io.github.syst3ms.skriptparser.lang;
+
+import io.github.syst3ms.skriptparser.registration.SkriptRegistration;
+
+/**
+ * An interface for {@link SyntaxElement SyntaxElements} that
+ * register following a certain pattern.
+ * Because of this reoccurring pattern, there is no need to make a separate method for
+ * it in {@link SkriptRegistration}.
+ */
+public interface SelfRegistrable {
+	/**
+	 * Register this syntax class.
+	 * @param reg the registration that wants to registers this syntax class
+	 * @param args the arguments that were use to register this syntax class
+	 */
+	void register(SkriptRegistration reg, Object... args);
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/base/ConditionalExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/base/ConditionalExpression.java
@@ -34,7 +34,6 @@ public abstract class ConditionalExpression implements Expression<Boolean> {
         return negated;
     }
 
-
     /**
      * Decides whether the output of a condition should be inverted in order to create a "negated" condition.
      * This was made a built-in method because it is a very common feature of conditions.

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/properties/ConditionalType.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/properties/ConditionalType.java
@@ -1,0 +1,24 @@
+package io.github.syst3ms.skriptparser.lang.properties;
+
+/**
+ * @see PropertyConditional
+ */
+public enum ConditionalType {
+	/**
+	 * The property is of the form {@code something is something},
+	 * plurality and negation supported.
+	 */
+	BE,
+
+	/**
+	 * The property is of the form {@code something can something},
+	 * plurality and negation supported.
+	 */
+	CAN,
+
+	/**
+	 * The property is of the form {@code something has something},
+	 * plurality and negation supported.
+	 */
+	HAVE
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/properties/PropertyConditional.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/properties/PropertyConditional.java
@@ -1,0 +1,136 @@
+package io.github.syst3ms.skriptparser.lang.properties;
+
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.SelfRegistrable;
+import io.github.syst3ms.skriptparser.lang.SyntaxElement;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.registration.SkriptRegistration;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This class can be used for an easier writing of conditions that contain only one type in the pattern
+ * and are in one of the following forms:
+ * <ul>
+ *     <li>{@code something is something}</li>
+ *     <li>{@code something can something}</li>
+ *     <li>{@code something has something}</li>
+ * </ul>
+ * The plural and negated forms are also supported.
+ *
+ * The gains of using this class:
+ * <ul>
+ *     <li>The {@link SyntaxElement#toString(TriggerContext, boolean) toString(TriggerContext, boolean)}
+ *     method is already implemented and it works well with the plural and negated forms</li>
+ *     <li>It implements {@link SelfRegistrable}, which means an easy registration is possible</li>
+ * </ul>
+ * </br>
+ * <i>Description partly copied from original Skript project.</i>
+ * @param <P> the type of the performer in this condition
+ * @author Mwexim
+ */
+public abstract class PropertyConditional<P> extends ConditionalExpression implements SelfRegistrable {
+    private Expression<P> performer;
+    private String performerName;
+    private ConditionalType conditionalType;
+    private String propertyName;
+
+    public Expression<P> getPerformer() {
+        return performer;
+    }
+
+    public void setPerformer(Expression<P> performer) {
+        this.performer = performer;
+    }
+
+    /**
+     * This default {@code init()} implementation automatically properly sets the performer in this condition,
+     * which can be accessed using {@link #getPerformer()}. If this implementation is overridden for one reason
+     * or another, it must call {@link #setPerformer(Expression)} properly.
+     * @param expressions an array of expressions representing all the expressions that are being passed
+     *                    to this syntax element.
+     * @param matchedPattern the index of the pattern that was successfully matched. It corresponds to the order of
+     *                       the syntaxes in registration
+     * @param parseContext an object containing additional information about the parsing of this syntax element, like
+     *                    regex matches and parse marks
+     * @return whether the initialization was successful or not.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        setPerformer((Expression<P>) expressions[0]);
+        setNegated(matchedPattern == 1);
+        return true;
+    }
+
+    @Override
+    public boolean check(TriggerContext ctx) {
+        return check(ctx, performer.getValues(ctx));
+    }
+
+    public abstract boolean check(TriggerContext ctx, P[] performers);
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return toString(ctx, debug, performer, conditionalType, propertyName);
+    }
+
+    private String toString(@Nullable TriggerContext ctx, boolean debug,
+                            Expression<P> perf,
+                            ConditionalType conditionalType,
+                            String property) {
+        switch (conditionalType) {
+            case BE:
+                return perf.toString(ctx, debug) + (perf.isSingle() ? " is " : " are ") + (isNegated() ? "not " : "") + property;
+            case CAN:
+                return perf.toString(ctx, debug) + (isNegated() ? " can't " : " can ") + property;
+            case HAVE:
+                if (perf.isSingle())
+                    return perf.toString(ctx, debug) + (isNegated() ? " doesn't have " : " has ") + property;
+                else
+                    return perf.toString(ctx, debug) + (isNegated() ? " don't have " : " have ") + property;
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void register(SkriptRegistration reg, Object... args) {
+        if (args.length != 3)
+            throw new IllegalArgumentException("A PropertyCondition needs exactly 3 arguments");
+        performerName = (String) args[0];
+        conditionalType = (ConditionalType) args[1];
+        propertyName = (String) args[2];
+
+        reg.addExpression(getClass(),
+                Boolean.class,
+                true,
+                composePatterns(performerName, conditionalType, propertyName)
+        );
+    }
+
+    private String[] composePatterns(String performer, ConditionalType conditionalType, String property) {
+        var type = performer.startsWith("*") ? performer.substring(1) : "%" + performer + "%";
+        switch (conditionalType) {
+            case BE:
+                return new String[] {
+                        type + " (is|are) " + property,
+                        type + " (is|are)( not|n't) " + property,
+                };
+            case CAN:
+                return new String[] {
+                        type + " can " + property,
+                        type + " can([ ]not|'t) " + property,
+                };
+            case HAVE:
+                return new String[] {
+                        type + " (has|have) " + property,
+                        type + " does( not|n't) have " + property,
+                };
+            default:
+                throw new AssertionError();
+        }
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/properties/PropertyExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/properties/PropertyExpression.java
@@ -1,4 +1,4 @@
-package io.github.syst3ms.skriptparser.lang.base;
+package io.github.syst3ms.skriptparser.lang.properties;
 
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.TriggerContext;
@@ -34,16 +34,6 @@ public abstract class PropertyExpression<T, O> implements Expression<T> {
     public void setOwner(Expression<O> owner) {
         this.owner = owner;
     }
-    
-    /**
-     * If this property only relies on one simple method applied to the owner, it can be represented here
-     * using a {@link Function}. This function will be applied in the default implementation of {@link #getValues(TriggerContext)}
-     * supplied by this class.
-     * @return the function that needs to be applied in order to get the correct values.
-     */
-    public Optional<? extends Function<? super O[], ? extends T[]>> getPropertyFunction() {
-        return Optional.empty();
-    }
 
     /**
      * There are 2 kinds of possession:
@@ -76,6 +66,16 @@ public abstract class PropertyExpression<T, O> implements Expression<T> {
     public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
         setOwner((Expression<O>) expressions[0]);
         return true;
+    }
+
+    /**
+     * If this property only relies on one simple method applied to the owner, it can be represented here
+     * using a {@link Function}. This function will be applied in the default implementation of {@link #getValues(TriggerContext)}
+     * supplied by this class.
+     * @return the function that needs to be applied in order to get the correct values.
+     */
+    public Optional<? extends Function<? super O[], ? extends T[]>> getPropertyFunction() {
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/properties/package-info.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/properties/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.github.syst3ms.skriptparser.lang.properties;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptAddon.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptAddon.java
@@ -24,7 +24,7 @@ public abstract class SkriptAddon {
     }
 
     /**
-     * When a {@linkplain Trigger} is successfully parsed, it is "broadcasted" to all addons through this method,
+     * When a {@linkplain Trigger} is successfully parsed, it is "broadcast" to all addons through this method,
      * in the hopes that one of them will be able to handle it.
      * @param trigger the trigger to be handled
      * @see #canHandleEvent(SkriptEvent)

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
@@ -1,14 +1,14 @@
 package io.github.syst3ms.skriptparser.registration;
 
 import io.github.syst3ms.skriptparser.lang.*;
-import io.github.syst3ms.skriptparser.lang.base.PropertyExpression;
+import io.github.syst3ms.skriptparser.lang.properties.PropertyExpression;
 import io.github.syst3ms.skriptparser.log.ErrorType;
 import io.github.syst3ms.skriptparser.log.LogEntry;
 import io.github.syst3ms.skriptparser.log.SkriptLogger;
 import io.github.syst3ms.skriptparser.parsing.SkriptParserException;
 import io.github.syst3ms.skriptparser.pattern.*;
 import io.github.syst3ms.skriptparser.registration.contextvalues.ContextValue;
-import io.github.syst3ms.skriptparser.registration.contextvalues.ContextValueTime;
+import io.github.syst3ms.skriptparser.registration.contextvalues.ContextValueState;
 import io.github.syst3ms.skriptparser.registration.contextvalues.ContextValues;
 import io.github.syst3ms.skriptparser.registration.tags.Tag;
 import io.github.syst3ms.skriptparser.registration.tags.TagInfo;
@@ -22,6 +22,7 @@ import io.github.syst3ms.skriptparser.types.conversions.Converters;
 import io.github.syst3ms.skriptparser.util.MultiMap;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.util.function.Function;
 
@@ -111,6 +112,19 @@ public class SkriptRegistration {
      */
     public List<TagInfo<?>> getTags() {
         return tags;
+    }
+
+    /**
+     * Registers a syntax class that can register itself.
+     * @param c the syntax' class
+     * @param args the arguments
+     */
+    public void addSelfRegisteringElement(Class<? extends SelfRegistrable> c, Object... args) {
+        try {
+            c.getDeclaredConstructor().newInstance().register(this, args);
+        } catch (InstantiationException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            logger.error("Couldn't instantiate class '" + c.getName() + "'", ErrorType.EXCEPTION);
+        }
     }
 
     /**
@@ -640,7 +654,7 @@ public class SkriptRegistration {
          * @param <T2> the type class
          * @return the registrar
          */
-        public final <C extends TriggerContext, T2> EventRegistrar<T> addContextValue(Class<C> context, Class<T2> type, String name, Function<C, T2[]> contextFunction, ContextValueTime time) {
+        public final <C extends TriggerContext, T2> EventRegistrar<T> addContextValue(Class<C> context, Class<T2> type, String name, Function<C, T2[]> contextFunction, ContextValueState time) {
             contextValues.add(new ContextValue<>(context, type, name, (Function<TriggerContext, T2[]>) contextFunction, time));
             return this;
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/contextvalues/ContextValue.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/contextvalues/ContextValue.java
@@ -12,7 +12,7 @@ public class ContextValue<T> {
     private final Class<T> type;
     private final String name;
     private final Function<TriggerContext, T[]> contextFunction;
-    private final ContextValueTime time;
+    private final ContextValueState time;
 
     /**
      * Construct a context value.
@@ -22,7 +22,7 @@ public class ContextValue<T> {
      * @param contextFunction the function to apply to the context
      */
     public ContextValue(Class<? extends TriggerContext> context, Class<T> type, String name, Function<TriggerContext, T[]> contextFunction) {
-        this(context, type, name, contextFunction, ContextValueTime.PRESENT);
+        this(context, type, name, contextFunction, ContextValueState.PRESENT);
     }
 
     /**
@@ -33,7 +33,7 @@ public class ContextValue<T> {
      * @param contextFunction the function to apply to the context
      * @param time            whether this value represent a present, past or future state
      */
-    public ContextValue(Class<? extends TriggerContext> context, Class<T> type, String name, Function<TriggerContext, T[]> contextFunction, ContextValueTime time) {
+    public ContextValue(Class<? extends TriggerContext> context, Class<T> type, String name, Function<TriggerContext, T[]> contextFunction, ContextValueState time) {
         this.context = context;
         this.type = type;
         this.name = name;
@@ -71,11 +71,11 @@ public class ContextValue<T> {
     /**
      * @return whether this happens in the present, past or future
      */
-    public ContextValueTime getTime() {
+    public ContextValueState getTime() {
         return time;
     }
 
-    public boolean matches(Class<? extends TriggerContext> handledContext, String name, ContextValueTime time) {
+    public boolean matches(Class<? extends TriggerContext> handledContext, String name, ContextValueState time) {
         return handledContext.equals(this.context)
                 && this.name.equalsIgnoreCase(name)
                 && this.time.equals(time);

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/contextvalues/ContextValueState.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/contextvalues/ContextValueState.java
@@ -4,7 +4,7 @@ package io.github.syst3ms.skriptparser.registration.contextvalues;
  * An enum to indicate the relative position in time between two similar context values.
  * Note that this is just to <b>indicate</b> time difference.
  */
-public enum ContextValueTime {
+public enum ContextValueState {
 
 	/**
 	 * The context value indicates something before the event happened.


### PR DESCRIPTION
This pull request adds a new utility class named PropertyConditional:
- They work the same as PropertyExpressions in a way that the patterns are made for you
- A new function is used named SelfRegistrable: these classes can register themselves.
   - They don't actually automatically register, but the register process is just the same. This way we don't have to add new methods like `addPropertyCondition()` for each type of syntax (obviously every syntax type can now be transformed into a SelfRegistrable class, but we keep those methods as utility.
   - Note that I explicitly did not check for casting errors in the PropertyConditional implementation of the register method, since developers hard-code there syntax anyway and should take care of the errors themselves. If wanted I'll change this.
- I think this implementation is highly valuable since it reduces the amount of methods needed to implement to only one (!!) for basic implementations.

Furthermore, I fixed a small grammar mistake and refactored some files.