### PR TITLE
feature: ExecutableExpression

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/lang/base/ExecutableExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/base/ExecutableExpression.java
@@ -1,0 +1,45 @@
+package io.github.syst3ms.skriptparser.lang.base;
+
+import io.github.syst3ms.skriptparser.lang.Effect;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.SelfRegistrable;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.registration.SkriptRegistration;
+
+import java.util.Arrays;
+
+/**
+ * A base class for syntax that can be used as {@link Expression} or {@link Effect}.
+ * An example of this could be:
+ * <ul>
+ *     {@code replace all {x} in {y} with {z}} <br>
+ *     {@code print "%replace all {x} in {y} with {z}%}
+ * </ul>
+ * Both syntaxes are valid and this enables productive and better coding practices.
+ * <br>
+ * The class automatically implements the {@link #execute(TriggerContext)} to just call
+ * {@link #getValues(TriggerContext)}, ignoring the results.
+ * This behavior can obviously be overridden.
+ * Finally, this implements {@link SelfRegistrable}, enabling an easy registration process.
+ */
+public abstract class ExecutableExpression<T>
+        extends Effect
+        implements Expression<T>, SelfRegistrable {
+
+    @Override
+    protected void execute(TriggerContext ctx) {
+        getValues(ctx);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void register(SkriptRegistration reg, Object... args) {
+        Class<T> type = (Class<T>) args[0];
+        boolean isSingle = (boolean) args[1];
+        String[] patterns = (String[]) Arrays.copyOfRange(args, 2, args.length);
+
+        // The actual registration
+        reg.addExpression(getClass(), type, isSingle, patterns);
+        reg.addEffect(getClass(), patterns);
+    }
+}


### PR DESCRIPTION
This pull request adds a new utility class, called ExecutableExpression:
- ExecutableExpressions are syntaxes that can act like expressions and stand-alone effects.
  A great example of this would be the replace all {x} in {y} with {z}-effect. Other examples could be the peek/poll/offer methods in Queues, which I'm also going to implement later.
- Basic implementation of the Effect part: just call getValues() while ignoring the results.
- Implements SelfRegistrable, allowing an easy registration process.

Currently, there isn't any implementation for this, but after my Number API PR (#75) is merged, I am going to add some String syntaxes, one of which is the replace-effect from Skript.

_(Messed up so needed to remake my pull request)_