### PR TITLE
improve: PropertyExpression class

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateInformation.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateInformation.java
@@ -10,8 +10,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.math.BigInteger;
 import java.time.LocalDateTime;
-import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * Information of a certain date.
@@ -41,41 +39,39 @@ public class ExprDateInformation extends PropertyExpression<Number, SkriptDate> 
 
 	int parseMark;
 
-	@Override
-	public Optional<? extends Function<? super SkriptDate[], ? extends Number[]>> getPropertyFunction() {
-		return Optional.of(dates -> {
-			LocalDateTime lcd = dates[0].toLocalDateTime();
-			switch (parseMark) {
-				case 0:
-					return new Number[] {BigInteger.valueOf(lcd.getYear())};
-				case 1:
-					return new Number[] {BigInteger.valueOf(lcd.getMonthValue())};
-				case 2:
-					return new Number[] {BigInteger.valueOf(lcd.getDayOfYear())};
-				case 3:
-					return new Number[] {BigInteger.valueOf(lcd.getDayOfMonth())};
-				case 4:
-					return new Number[] {BigInteger.valueOf(lcd.getDayOfWeek().getValue())};
-				case 5:
-					return new Number[] {BigInteger.valueOf(lcd.getHour())};
-				case 6:
-					return new Number[] {BigInteger.valueOf(lcd.getMinute())};
-				case 7:
-					return new Number[] {BigInteger.valueOf(lcd.getSecond())};
-				case 8:
-					return new Number[] {BigInteger.valueOf(lcd.getNano() / 1_000_000)};
-				default:
-					throw new IllegalStateException();
-			}
-		});
-	}
-
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
 		parseMark = parseContext.getParseMark();
 		setOwner((Expression<SkriptDate>) expressions[0]);
 		return true;
+	}
+
+	@Override
+	public Number[] getProperty(SkriptDate[] owners) {
+		LocalDateTime lcd = owners[0].toLocalDateTime();
+		switch (parseMark) {
+			case 0:
+				return new Number[] {BigInteger.valueOf(lcd.getYear())};
+			case 1:
+				return new Number[] {BigInteger.valueOf(lcd.getMonthValue())};
+			case 2:
+				return new Number[] {BigInteger.valueOf(lcd.getDayOfYear())};
+			case 3:
+				return new Number[] {BigInteger.valueOf(lcd.getDayOfMonth())};
+			case 4:
+				return new Number[] {BigInteger.valueOf(lcd.getDayOfWeek().getValue())};
+			case 5:
+				return new Number[] {BigInteger.valueOf(lcd.getHour())};
+			case 6:
+				return new Number[] {BigInteger.valueOf(lcd.getMinute())};
+			case 7:
+				return new Number[] {BigInteger.valueOf(lcd.getSecond())};
+			case 8:
+				return new Number[] {BigInteger.valueOf(lcd.getNano() / 1_000_000)};
+			default:
+				throw new IllegalStateException();
+		}
 	}
 
 	@Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateTimestamp.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateTimestamp.java
@@ -9,8 +9,6 @@ import io.github.syst3ms.skriptparser.util.SkriptDate;
 import org.jetbrains.annotations.Nullable;
 
 import java.math.BigInteger;
-import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * The timestamp of a date.
@@ -39,23 +37,20 @@ public class ExprDateTimestamp extends PropertyExpression<Number, SkriptDate> {
 
 	boolean unix;
 
-	@Override
-	public Optional<? extends Function<? super SkriptDate[], ? extends Number[]>> getPropertyFunction() {
-		return Optional.of(
-				dates -> new Number[] {
-					unix
-						? BigInteger.valueOf(Math.floorDiv(dates[0].getTimestamp(), 1000))
-						: BigInteger.valueOf(dates[0].getTimestamp())
-				}
-		);
-	}
-
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
 		unix = parseContext.getParseMark() == 1;
 		setOwner((Expression<SkriptDate>) expressions[0]);
 		return true;
+	}
+
+	@Override
+	public Number[] getProperty(SkriptDate[] owners) {
+		return new Number[] {
+				unix ? BigInteger.valueOf(Math.floorDiv(owners[0].getTimestamp(), 1000))
+						: BigInteger.valueOf(owners[0].getTimestamp())
+		};
 	}
 
 	@Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateValues.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateValues.java
@@ -10,8 +10,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.time.LocalDateTime;
 import java.time.format.TextStyle;
-import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * Names of certain values of a date, for example the name of the month.
@@ -37,35 +35,33 @@ public class ExprDateValues extends PropertyExpression<String, SkriptDate> {
 
 	int parseMark;
 
-	@Override
-	public Optional<? extends Function<? super SkriptDate[], ? extends String[]>> getPropertyFunction() {
-		return Optional.of(dates -> {
-			LocalDateTime lcd = dates[0].toLocalDateTime();
-			switch (parseMark) {
-				case 0:
-					return new String[] {lcd.toLocalDate().getEra().getDisplayName(
-							TextStyle.FULL, SkriptDate.DATE_LOCALE
-					)};
-				case 1:
-					return new String[] {lcd.getMonth().getDisplayName(
-							TextStyle.FULL, SkriptDate.DATE_LOCALE
-					)};
-				case 2:
-					return new String[] {lcd.getDayOfWeek().getDisplayName(
-							TextStyle.FULL, SkriptDate.DATE_LOCALE
-					)};
-				default:
-					return new String[0];
-			}
-		});
-	}
-
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
 		parseMark = parseContext.getParseMark();
 		setOwner((Expression<SkriptDate>) expressions[0]);
 		return true;
+	}
+
+	@Override
+	public String[] getProperty(SkriptDate[] owners) {
+		LocalDateTime lcd = owners[0].toLocalDateTime();
+		switch (parseMark) {
+			case 0:
+				return new String[] {
+						lcd.toLocalDate().getEra().getDisplayName(TextStyle.FULL, SkriptDate.DATE_LOCALE)
+				};
+			case 1:
+				return new String[] {
+						lcd.getMonth().getDisplayName(TextStyle.FULL, SkriptDate.DATE_LOCALE)
+				};
+			case 2:
+				return new String[] {
+						lcd.getDayOfWeek().getDisplayName(TextStyle.FULL, SkriptDate.DATE_LOCALE)
+				};
+			default:
+				throw new IllegalStateException();
+		}
 	}
 
 	@Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
@@ -6,8 +6,6 @@ import io.github.syst3ms.skriptparser.lang.properties.PropertyExpression;
 import org.jetbrains.annotations.Nullable;
 
 import java.math.BigInteger;
-import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * Length of a string.
@@ -31,8 +29,8 @@ public class ExprLength extends PropertyExpression<Number, String> {
     }
 
     @Override
-    public Optional<? extends Function<? super String[], ? extends Number[]>> getPropertyFunction() {
-        return Optional.of(strings -> new Number[]{BigInteger.valueOf(strings[0].length())});
+    public Number[] getProperty(String[] owners) {
+        return new Number[] {BigInteger.valueOf(owners[0].length())};
     }
 
     @Override

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprTimeInformation.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprTimeInformation.java
@@ -9,8 +9,6 @@ import io.github.syst3ms.skriptparser.util.Time;
 import org.jetbrains.annotations.Nullable;
 
 import java.math.BigInteger;
-import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * Information of a certain time.
@@ -40,30 +38,28 @@ public class ExprTimeInformation extends PropertyExpression<Number, Time> {
 
 	int parseMark;
 
-	@Override
-	public Optional<? extends Function<? super Time[], ? extends Number[]>> getPropertyFunction() {
-		return Optional.of(times -> {
-			switch (parseMark) {
-				case 0:
-					return new Number[] {BigInteger.valueOf(times[0].getHour())};
-				case 1:
-					return new Number[] {BigInteger.valueOf(times[0].getMinute())};
-				case 2:
-					return new Number[] {BigInteger.valueOf(times[0].getSecond())};
-				case 3:
-					return new Number[] {BigInteger.valueOf(times[0].getMillis())};
-				default:
-					throw new IllegalStateException();
-			}
-		});
-	}
-
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
 		parseMark = parseContext.getParseMark();
 		setOwner((Expression<Time>) expressions[0]);
 		return true;
+	}
+
+	@Override
+	public Number[] getProperty(Time[] owners) {
+		switch (parseMark) {
+			case 0:
+				return new Number[] {BigInteger.valueOf(owners[0].getHour())};
+			case 1:
+				return new Number[] {BigInteger.valueOf(owners[0].getMinute())};
+			case 2:
+				return new Number[] {BigInteger.valueOf(owners[0].getSecond())};
+			case 3:
+				return new Number[] {BigInteger.valueOf(owners[0].getMillis())};
+			default:
+				throw new IllegalStateException();
+		}
 	}
 
 	@Override

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/properties/PropertyExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/properties/PropertyExpression.java
@@ -5,8 +5,6 @@ import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 
 import java.lang.reflect.Array;
-import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * A base class for expressions that contain general properties.
@@ -26,28 +24,6 @@ import java.util.function.Function;
  */
 public abstract class PropertyExpression<T, O> implements Expression<T> {
     private Expression<O> owner;
-
-    public Expression<O> getOwner() {
-        return owner;
-    }
-
-    public void setOwner(Expression<O> owner) {
-        this.owner = owner;
-    }
-
-    /**
-     * There are 2 kinds of possession:
-     * <ul>
-     *     <li><b>Genitive:</b>Mwexim's book</li>
-     *     <li><b>Regular:</b>book of Mwexim</li>
-     * </ul>
-     * One may use this method to check if the pattern is in genitive form.
-     * @param matchedPattern the matched pattern of a property
-     * @return whether this pattern is in the genitive form or not.
-     */
-    public static boolean isGenitive(int matchedPattern) {
-        return matchedPattern == 0;
-    }
 
     /**
      * This default {@code init()} implementation automatically properly sets the owner of this property,
@@ -69,31 +45,52 @@ public abstract class PropertyExpression<T, O> implements Expression<T> {
     }
 
     /**
-     * If this property only relies on one simple method applied to the owner, it can be represented here
-     * using a {@link Function}. This function will be applied in the default implementation of {@link #getValues(TriggerContext)}
+     * If this property only relies on one simple method applied to the owner, it can be represented
+     * using this method. This function will be applied in the default implementation of {@link #getValues(TriggerContext)}
      * supplied by this class.
-     * @return the function that needs to be applied in order to get the correct values.
+     *
+     * @param owners the owners of this property, never is empty
+     * @return the return values of this property
      */
-    public Optional<? extends Function<? super O[], ? extends T[]>> getPropertyFunction() {
-        return Optional.empty();
+    @SuppressWarnings("unchecked")
+    public T[] getProperty(O[] owners) {
+        return (T[]) Array.newInstance(owners.getClass().getComponentType(), 0);
     }
 
     /**
-     * A simple default method that will apply {@link #getPropertyFunction()} on the {@link #owner} of this property.
+     * A simple default method that will apply {@link #getProperty(Object[])} on the {@link #owner} of this property.
      *
      * @param ctx the event
-     * @return the values of this property after applying the {@link #getPropertyFunction()} function on the owner.
+     * @return the values of this property after applying the {@link #getProperty(Object[])} function on the owner.
      */
     @SuppressWarnings("unchecked")
     @Override
     public T[] getValues(TriggerContext ctx) {
-        var objs = getOwner().getValues(ctx);
-        if (objs.length == 0)
-            return (T[]) Array.newInstance(objs.getClass().getComponentType(), 0);
-        return getPropertyFunction()
-                .orElseThrow(() -> new UnsupportedOperationException(
-                        "getPropertyFunction() must be overridden if getValues() isn't!"
-                ))
-                .apply(objs);
+        var owners = getOwner().getValues(ctx);
+        if (owners.length == 0)
+            return (T[]) Array.newInstance(owners.getClass().getComponentType(), 0);
+        return getProperty(owners);
+    }
+
+    public Expression<O> getOwner() {
+        return owner;
+    }
+
+    public void setOwner(Expression<O> owner) {
+        this.owner = owner;
+    }
+
+    /**
+     * There are 2 kinds of possession:
+     * <ul>
+     *     <li><b>Genitive:</b>Mwexim's book</li>
+     *     <li><b>Regular:</b>book of Mwexim</li>
+     * </ul>
+     * One may use this method to check if the pattern is in the genitive form.
+     * @param matchedPattern the matched pattern of a property
+     * @return whether this pattern is in the genitive form or not.
+     */
+    public static boolean isGenitive(int matchedPattern) {
+        return matchedPattern == 0;
     }
 }


### PR DESCRIPTION
This PR aims to make some changes I wanted to apply for a really long time. I feel now the Optional API is added, the usage of a method that returns an Optional of a Function is a bit over the top. 
Therefore, I changed that method to be more similar to the #getValues() one. One could argue that it now is not needed anymore to make a separate method since they are very similar, but I still think this has some utility for pure properties (properties that only demand a getProperty implementation).