### PR TITLE
feature: additional SecLoop, ExprElement and EffWait syntax

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
@@ -60,13 +60,13 @@ public class EffWait extends Effect {
         throw new UnsupportedOperationException();
     }
 
-    @SuppressWarnings({"unchecked", "ConstantConditions"})
+    @SuppressWarnings("unchecked")
     @Override
     public Optional<? extends Statement> walk(TriggerContext ctx) {
-        if (isConditional) {
-            if (getNext().isEmpty())
-                return Optional.empty();
+        if (getNext().isEmpty())
+            return Optional.empty();
 
+        if (isConditional) {
             // The code we want to run each check.
             Consumer<ExecutorService> code = exec -> {
                 if (condition.getSingle(ctx).filter(b -> negated == b).isPresent()) {
@@ -106,8 +106,6 @@ public class EffWait extends Effect {
             Optional<? extends Duration> dur = duration.getSingle(ctx);
             if (dur.isEmpty())
                 return getNext();
-            if (getNext().isEmpty())
-                return Optional.empty();
 
             ThreadUtils.runAfter(() -> Statement.runAll(getNext().get(), ctx), dur.get());
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
@@ -29,8 +29,8 @@ import java.util.function.Consumer;
 public class EffWait extends Effect {
     static {
         Parser.getMainRegistration().addEffect(
-            EffWait.class,
-            "(wait|halt) [for] %duration%",
+                EffWait.class,
+                "(wait|halt) [for] %duration%",
                 "(wait|halt) (0:until|1:while) %=boolean% [for %*duration%]"
         );
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffWait.java
@@ -1,41 +1,57 @@
 package io.github.syst3ms.skriptparser.effects;
 
 import io.github.syst3ms.skriptparser.Parser;
-import io.github.syst3ms.skriptparser.lang.Effect;
-import io.github.syst3ms.skriptparser.lang.Expression;
-import io.github.syst3ms.skriptparser.lang.Statement;
-import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.lang.*;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.util.ThreadUtils;
+import io.github.syst3ms.skriptparser.util.TimeUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * Waits a certain duration and then executes all the code after this effect.
  * Note that new events may be triggered during the wait time.
+ * When using the {@code wait while %=boolean%} effect, if the condition is never met,
+ * the program could go to a recursive state, never escaping from an infinite loop.
+ * This is why we advice you to give a limit.
  *
  * @name Wait
  * @pattern (wait|halt) [for] %duration%
+ * @pattern (wait|halt) (0:until|1:while) %=boolean% [for %*duration%]
  * @since ALPHA
  * @author Mwexim
  */
 public class EffWait extends Effect {
-
     static {
         Parser.getMainRegistration().addEffect(
             EffWait.class,
-            "(wait|halt) [for] %duration%"
+            "(wait|halt) [for] %duration%",
+                "(wait|halt) (0:until|1:while) %=boolean% [for %*duration%]"
         );
     }
 
     private Expression<Duration> duration;
+    private Expression<Boolean> condition;
+    private boolean isConditional;
+    private boolean negated;
 
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
-        duration = (Expression<Duration>) expressions[0];
+        isConditional = matchedPattern == 1;
+        if (isConditional) {
+            condition = (Expression<Boolean>) expressions[0];
+            if (expressions.length == 2)
+                duration = (Literal<Duration>) expressions[1];
+            negated = parseContext.getParseMark() == 0;
+        } else {
+            duration = (Expression<Duration>) expressions[0];
+        }
         return true;
     }
 
@@ -44,14 +60,57 @@ public class EffWait extends Effect {
         throw new UnsupportedOperationException();
     }
 
+    @SuppressWarnings({"unchecked", "ConstantConditions"})
     @Override
     public Optional<? extends Statement> walk(TriggerContext ctx) {
-        Optional<? extends Duration> dur = duration.getSingle(ctx);
-        if (dur.isEmpty())
-            return getNext();
-        if (getNext().isEmpty())
-            return Optional.empty();
-        ThreadUtils.runAfter(() -> Statement.runAll(getNext().get(), ctx), dur.get());
+        if (isConditional) {
+            if (getNext().isEmpty())
+                return Optional.empty();
+
+            // The code we want to run each check.
+            Consumer<ExecutorService> code = exec -> {
+                if (condition.getSingle(ctx).filter(b -> negated == b).isPresent()) {
+                    Statement.runAll(getNext().get(), ctx);
+                    exec.shutdownNow();
+                }
+            };
+
+            if (duration == null) {
+                var thread = ThreadUtils.buildPeriodic();
+                thread.scheduleAtFixedRate(
+                        () -> code.accept(thread),
+                        0,
+                        TimeUtils.TICK.toMillis(),
+                        TimeUnit.MILLISECONDS
+                );
+            } else {
+                var dur = ((Optional<Duration>) ((Literal<Duration>) duration).getSingle()).orElse(Duration.ZERO);
+                long millis = dur.toMillis();
+                var thread = ThreadUtils.buildPeriodic();
+                thread.scheduleAtFixedRate(
+                        () -> code.accept(thread),
+                        0,
+                        TimeUtils.TICK.toMillis(),
+                        TimeUnit.MILLISECONDS
+                );
+                thread.schedule(
+                        () -> {
+                            Statement.runAll(getNext().get(), ctx);
+                            thread.shutdownNow();
+                        },
+                        millis,
+                        TimeUnit.MILLISECONDS
+                );
+            }
+        } else {
+            Optional<? extends Duration> dur = duration.getSingle(ctx);
+            if (dur.isEmpty())
+                return getNext();
+            if (getNext().isEmpty())
+                return Optional.empty();
+
+            ThreadUtils.runAfter(() -> Statement.runAll(getNext().get(), ctx), dur.get());
+        }
         return Optional.empty();
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprElement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprElement.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -19,6 +20,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * @type EXPRESSION
  * @pattern ([the] first|[the] last|[a] random|[the] %integer%(st|nd|rd|th)) element out [of] %objects%
  * @pattern [the] (first|last) %integer% elements out [of] %objects%
+ * @pattern %integer% random elements out [of] %objects%
  * @pattern %objects%\[%integer%\]
  * @since ALPHA
  * @author Mwexim
@@ -32,6 +34,7 @@ public class ExprElement implements Expression<Object> {
 				true,
 				"(0:[the] first|1:[the] last|2:[a] random|3:[the] %integer%(st|nd|rd|th)) element out [of] %objects%",
 				"[the] (0:first|1:last) %integer% elements out [of] %objects%",
+				"%integer% random elements out [of] %objects%",
 				"%objects%\\[%integer%\\]");
 	}
 
@@ -58,13 +61,16 @@ public class ExprElement implements Expression<Object> {
 				}
 				break;
 			case 1:
+			case 2:
 				range = (Expression<BigInteger>) expressions[0];
 				expr = (Expression<Object>) expressions[1];
 				break;
-			default:
+			case 3:
 				expr = (Expression<Object>) expressions[0];
 				range = (Expression<BigInteger>) expressions[1];
 				break;
+			default:
+				throw new IllegalStateException();
 		}
 		return true;
 	}
@@ -113,6 +119,10 @@ public class ExprElement implements Expression<Object> {
 					return Arrays.copyOfRange(values, values.length - r, values.length);
 				}
 			case 2:
+				var shuffled = Arrays.asList(values);
+				Collections.shuffle(shuffled, random);
+				return shuffled.subList(0, r).toArray();
+			case 3:
 				return new Object[] {values[r - 1]};
 			default:
 				return new Object[0];
@@ -123,12 +133,13 @@ public class ExprElement implements Expression<Object> {
 	public String toString(@Nullable TriggerContext ctx, boolean debug) {
 		switch (pattern) {
 			case 0:
-			case 2:
+			case 3:
 				return "element out of " + expr.toString(ctx, debug);
 			case 1:
+			case 2:
 				return "elements out of " + expr.toString(ctx, debug);
 			default:
-				return "";
+				throw new IllegalStateException();
 		}
 	}
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprRange.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprRange.java
@@ -49,7 +49,7 @@ public class ExprRange implements Expression<Object> {
         comparator = Comparators.getComparator(from.getReturnType(), to.getReturnType()).orElse(null);
         if (range == null) {
             SkriptLogger logger = parseContext.getLogger();
-            logger.error("Cannot get a range between " + from.toString(null, logger.isDebug()) + " and " + from.toString(null, logger.isDebug()), ErrorType.SEMANTIC_ERROR);
+            logger.error("Cannot get a range between " + from.toString(null, logger.isDebug()) + " and " + to.toString(null, logger.isDebug()), ErrorType.SEMANTIC_ERROR);
             return false;
         }
         return true;

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/SimpleLiteral.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/SimpleLiteral.java
@@ -111,7 +111,7 @@ public class SimpleLiteral<T> implements Literal<T> {
 
     @Override
     public Iterator<T> iterator(TriggerContext context) {
-        if (!isSingle())
+        if (isSingle())
             throw new SkriptRuntimeException("Can't loop a single literal !");
         return CollectionUtils.iterator(values);
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/sections/SecLoop.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/sections/SecLoop.java
@@ -74,15 +74,13 @@ public class SecLoop extends ArgumentSection {
 	public Optional<? extends Statement> walk(TriggerContext ctx) {
 		if (isNumericLoop) {
 			var range = (BigInteger[]) times.getSingle(ctx)
+					.filter(t -> t.compareTo(BigInteger.ZERO) > 0)
 					.map(t -> Ranges.getRange(BigInteger.class).orElseThrow()
 							.getFunction()
 							.apply(BigInteger.ONE, t)) // Upper bound is inclusive
 					.orElse(new BigInteger[0]);
-			/*
-			 * We just set the looped expression to a range from 1 to the amount of times.
-			 * This allows the usage of 'loop-number' to see the iteration,
-			 * something that is lacking in the main Skript project.
-			 */
+			// We just set the looped expression to a range from 1 to the amount of times.
+			// This allows the usage of 'loop-number' to get the current iteration
 			expr = new SimpleLiteral<>(BigInteger.class, range);
 		}
 

--- a/src/main/java/io/github/syst3ms/skriptparser/sections/SecLoop.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/sections/SecLoop.java
@@ -73,7 +73,7 @@ public class SecLoop extends ArgumentSection {
 	@Override
 	public Optional<? extends Statement> walk(TriggerContext ctx) {
 		if (isNumericLoop) {
-			var range = (BigInteger[]) times.getSingle(ctx)
+			BigInteger[] range = (BigInteger[]) times.getSingle(ctx)
 					.filter(t -> t.compareTo(BigInteger.ZERO) > 0)
 					.map(t -> Ranges.getRange(BigInteger.class).orElseThrow()
 							.getFunction()

--- a/src/main/java/io/github/syst3ms/skriptparser/util/ThreadUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/ThreadUtils.java
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit;
 public class ThreadUtils {
 
 	/**
-	 * Run certain code once on a separate thread
+	 * Run certain code once on a separate thread. The thread is shut down after the code ran.
 	 * @param code the runnable that needs to be executed
 	 */
 	public static void runAsync(Runnable code) {
@@ -19,7 +19,7 @@ public class ThreadUtils {
 	}
 
 	/**
-	 * Run certain code once after a certain delay.
+	 * Run certain code once after a certain delay. The thread is shut down after the code ran.
 	 * @param code the runnable that needs to be executed
 	 * @param duration the delay
 	 */
@@ -35,8 +35,7 @@ public class ThreadUtils {
 	 * @param duration the delay
 	 */
 	public static void runPeriodically(Runnable code, Duration duration) {
-		ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-		scheduler.scheduleAtFixedRate(code, duration.toMillis(), duration.toMillis(), TimeUnit.MILLISECONDS);
+		runPeriodically(code, duration, duration);
 	}
 
 	/**
@@ -48,5 +47,44 @@ public class ThreadUtils {
 	public static void runPeriodically(Runnable code, Duration initialDelay, Duration duration) {
 		ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 		scheduler.scheduleAtFixedRate(code, initialDelay.toMillis(), duration.toMillis(), TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * Runs certain code periodically but with a final bound.
+	 * @param code the runnable that needs to be executed
+	 * @param duration the delay
+	 * @param maxTime the duration this thread will be opened in milliseconds
+	 */
+	public static void runPeriodicallyBounded(Runnable code, Duration duration, Duration maxTime) {
+		runPeriodicallyBounded(code, duration, duration, maxTime);
+	}
+
+	/**
+	 * Runs certain code periodically but with a final bound.
+	 * @param code the runnable that needs to be executed
+	 * @param initialDelay the initial delay
+	 * @param duration the delay
+	 * @param maxTime the duration this thread will be opened in milliseconds
+	 */
+	public static void runPeriodicallyBounded(Runnable code, Duration initialDelay, Duration duration, Duration maxTime) {
+		ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+		scheduler.scheduleAtFixedRate(code, initialDelay.toMillis(), duration.toMillis(), TimeUnit.MILLISECONDS);
+		scheduler.schedule(scheduler::shutdownNow, maxTime.toMillis(), TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * Builds a new thread using an {@link ExecutorService}, allowing various utility methods.
+	 * @return the created thread
+	 */
+	public static ExecutorService buildAsync() {
+		return Executors.newCachedThreadPool();
+	}
+
+	/**
+	 * Builds a new thread using an {@link ScheduledExecutorService}, allowing various utility methods.
+	 * @return the created thread
+	 */
+	public static ScheduledExecutorService buildPeriodic() {
+		return Executors.newSingleThreadScheduledExecutor();
 	}
 }


### PR DESCRIPTION
This pull request adds three simple syntaxes to some existing ones:
- SecLoop: added `loop N times` syntax. I made it so that the actual code doesn't get looped N amount of times, but rather a range from 1 to N. This way, users can use `loop-number` in their code to refer to the current iteration, something Skript has been missing for an eternity.
- EffWait: added `wait while X (for Y time)`. Some small addition that Skript actually doesn't support. I had to revamp the ThreadUtils a bit for this.
- ExprElement: added `N random elements` syntax.

Furthermore, I fixed one error in the SimpleLiteral class and fixed some error message in the ExprRange syntax class.

These syntaxes all came from the #40 issue.