### PR TITLE
feature: Color type and syntaxes

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorFromRGB.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorFromRGB.java
@@ -26,7 +26,7 @@ public class ExprColorFromRGB implements Expression<Color> {
 				ExprColorFromRGB.class,
 				Color.class,
 				true,
-				"[the] color (from|of) [the] rgb [value] %integer%, %integer%(,| and) %integer%"
+				"[[the] color (from|of)] [the] rgb [value] %integer%, %integer%(,| and) %integer%"
 		);
 	}
 
@@ -49,7 +49,7 @@ public class ExprColorFromRGB implements Expression<Color> {
 		if (0 <= r && r < 256
 				&& 0 <= g && g < 256
 				&& 0 <= b && b < 256)
-			return new Color[] {Color.of((byte) r, (byte) g, (byte) b)};
+			return new Color[] {Color.of(r, g, b)};
 		return new Color[0];
 	}
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorFromRGB.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorFromRGB.java
@@ -1,0 +1,60 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.color.Color;
+import org.jetbrains.annotations.Nullable;
+
+import java.math.BigInteger;
+
+/**
+ * A color specified by its RGB value.
+ * Each value, this means red, green and blue, can be a range from 0 to 255.
+ * Any values outside of those ranges will result in no color to be created.
+ *
+ * @name Color from RGB
+ * @type EXPRESSION
+ * @pattern [the] color (from|of) [the] rgb [value] %integer%, %integer%(,| and) %integer%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class ExprColorFromRGB implements Expression<Color> {
+	static {
+		Parser.getMainRegistration().addExpression(
+				ExprColorFromRGB.class,
+				Color.class,
+				true,
+				"[the] color (from|of) [the] rgb [value] %integer%, %integer%(,| and) %integer%"
+		);
+	}
+
+	private Expression<BigInteger> red, green, blue;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+		red = (Expression<BigInteger>) expressions[0];
+		green = (Expression<BigInteger>) expressions[1];
+		blue = (Expression<BigInteger>) expressions[2];
+		return true;
+	}
+
+	@Override
+	public Color[] getValues(TriggerContext ctx) {
+		int r = red.getSingle(ctx).map(BigInteger::intValue).orElse(-1);
+		int g = green.getSingle(ctx).map(BigInteger::intValue).orElse(-1);
+		int b = blue.getSingle(ctx).map(BigInteger::intValue).orElse(-1);
+		if (0 <= r && r < 256
+				&& 0 <= g && g < 256
+				&& 0 <= b && b < 256)
+			return new Color[] {Color.of((byte) r, (byte) g, (byte) b)};
+		return new Color[0];
+	}
+
+	@Override
+	public String toString(@Nullable TriggerContext ctx, boolean debug) {
+		return "color from rgb " + red.toString(ctx, debug) + ", " + green.toString(ctx, debug) + ", " + blue.toString(ctx, debug);
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorFromRGB.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorFromRGB.java
@@ -16,7 +16,7 @@ import java.math.BigInteger;
  *
  * @name Color from RGB
  * @type EXPRESSION
- * @pattern [the] color (from|of) [the] rgb [value] %integer%, %integer%(,| and) %integer%
+ * @pattern [[the] color (from|of)] [the] rgb [value] %integer%, %integer%(,| and) %integer%
  * @since ALPHA
  * @author Mwexim
  */
@@ -55,6 +55,6 @@ public class ExprColorFromRGB implements Expression<Color> {
 
 	@Override
 	public String toString(@Nullable TriggerContext ctx, boolean debug) {
-		return "color from rgb " + red.toString(ctx, debug) + ", " + green.toString(ctx, debug) + ", " + blue.toString(ctx, debug);
+		return "color from rgb " + red.toString(ctx, debug) + ", " + green.toString(ctx, debug) + " and " + blue.toString(ctx, debug);
 	}
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorValues.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorValues.java
@@ -9,8 +9,6 @@ import io.github.syst3ms.skriptparser.util.color.Color;
 import org.jetbrains.annotations.Nullable;
 
 import java.math.BigInteger;
-import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * Certain color values of a given color.
@@ -19,7 +17,6 @@ import java.util.function.Function;
  * @type EXPRESSION
  * @pattern [the] (0:rgb (value|color)|1:red [value]|2:green [value]|3:blue [value]) of %color%
  * @pattern %color%'[s] (0:rgb (value|color)|1:red [value]|2:green [value]|3:blue [value])
- * @pattern %color% as rgb
  * @since ALPHA
  * @author Mwexim
  */
@@ -45,26 +42,24 @@ public class ExprColorValues extends PropertyExpression<BigInteger, Color> {
 	}
 
 	@Override
-	public Optional<? extends Function<? super Color[], ? extends BigInteger[]>> getPropertyFunction() {
-		return Optional.of(colors -> {
-			Color c = colors[0];
-			switch (parseMark) {
-				case 0:
-					return new BigInteger[] {
-							BigInteger.valueOf(c.getRed()),
-							BigInteger.valueOf(c.getGreen()),
-							BigInteger.valueOf(c.getBlue())
-					};
-				case 1:
-					return new BigInteger[] {BigInteger.valueOf(c.getRed())};
-				case 2:
-					return new BigInteger[] {BigInteger.valueOf(c.getGreen())};
-				case 3:
-					return new BigInteger[] {BigInteger.valueOf(c.getBlue())};
-				default:
-					throw new IllegalStateException();
-			}
-		});
+	public BigInteger[] getProperty(Color[] owners) {
+		Color c = owners[0];
+		switch (parseMark) {
+			case 0:
+				return new BigInteger[] {
+						BigInteger.valueOf(c.getRed()),
+						BigInteger.valueOf(c.getGreen()),
+						BigInteger.valueOf(c.getBlue())
+				};
+			case 1:
+				return new BigInteger[] {BigInteger.valueOf(c.getRed())};
+			case 2:
+				return new BigInteger[] {BigInteger.valueOf(c.getGreen())};
+			case 3:
+				return new BigInteger[] {BigInteger.valueOf(c.getBlue())};
+			default:
+				throw new IllegalStateException();
+		}
 	}
 
 	@Override
@@ -76,7 +71,7 @@ public class ExprColorValues extends PropertyExpression<BigInteger, Color> {
 	public String toString(@Nullable TriggerContext ctx, boolean debug) {
 		switch (parseMark) {
 			case 0:
-				return getOwner().toString(ctx, debug) + " as rgb";
+				return "rgb value of " + getOwner().toString(ctx, debug);
 			case 1:
 				return "red value of " + getOwner().toString(ctx, debug);
 			case 2:

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorValues.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorValues.java
@@ -30,13 +30,7 @@ public class ExprColorValues extends PropertyExpression<BigInteger, Color> {
 				BigInteger.class,
 				false,
 				"color",
-				"(0:rgb (value|color)|1:red value|2:green value|3:blue value)"
-		);
-		Parser.getMainRegistration().addExpression(
-				ExprColorValues.class,
-				BigInteger.class,
-				false,
-				"%color% as rgb"
+				"(0:rgb [(value|color)]|1:red value|2:green value|3:blue value)"
 		);
 	}
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorValues.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorValues.java
@@ -1,0 +1,96 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.lang.properties.PropertyExpression;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.color.Color;
+import org.jetbrains.annotations.Nullable;
+
+import java.math.BigInteger;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Certain color values of a given color.
+ *
+ * @name Date Values
+ * @type EXPRESSION
+ * @pattern [the] (0:rgb (value|color)|1:red [value]|2:green [value]|3:blue [value]) of %color%
+ * @pattern %color%'[s] (0:rgb (value|color)|1:red [value]|2:green [value]|3:blue [value])
+ * @pattern %color% as rgb
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class ExprColorValues extends PropertyExpression<BigInteger, Color> {
+	static {
+		Parser.getMainRegistration().addPropertyExpression(
+				ExprColorValues.class,
+				BigInteger.class,
+				false,
+				"color",
+				"(0:rgb (value|color)|1:red value|2:green value|3:blue value)"
+		);
+		Parser.getMainRegistration().addExpression(
+				ExprColorValues.class,
+				BigInteger.class,
+				false,
+				"%color% as rgb"
+		);
+	}
+
+	int parseMark;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+		parseMark = parseContext.getParseMark();
+		setOwner((Expression<Color>) expressions[0]);
+		return true;
+	}
+
+	@Override
+	public Optional<? extends Function<? super Color[], ? extends BigInteger[]>> getPropertyFunction() {
+		return Optional.of(colors -> {
+			Color c = colors[0];
+			switch (parseMark) {
+				case 0:
+					return new BigInteger[] {
+							BigInteger.valueOf(c.getRed()),
+							BigInteger.valueOf(c.getGreen()),
+							BigInteger.valueOf(c.getBlue())
+					};
+				case 1:
+					return new BigInteger[] {BigInteger.valueOf(c.getRed())};
+				case 2:
+					return new BigInteger[] {BigInteger.valueOf(c.getGreen())};
+				case 3:
+					return new BigInteger[] {BigInteger.valueOf(c.getBlue())};
+				default:
+					throw new IllegalStateException();
+			}
+		});
+	}
+
+	@Override
+	public boolean isSingle() {
+		return parseMark != 0;
+	}
+
+	@Override
+	public String toString(@Nullable TriggerContext ctx, boolean debug) {
+		switch (parseMark) {
+			case 0:
+				return getOwner().toString(ctx, debug) + " as rgb";
+			case 1:
+				return "red value of " + getOwner().toString(ctx, debug);
+			case 2:
+				return "green value of " + getOwner().toString(ctx, debug);
+			case 3:
+				return "blue value of " + getOwner().toString(ctx, debug);
+			default:
+				throw new IllegalStateException();
+		}
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
@@ -1,6 +1,8 @@
 package io.github.syst3ms.skriptparser.registration;
 
 import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.types.Type;
+import io.github.syst3ms.skriptparser.types.TypeManager;
 import io.github.syst3ms.skriptparser.types.changers.Arithmetic;
 import io.github.syst3ms.skriptparser.types.comparisons.Comparator;
 import io.github.syst3ms.skriptparser.types.comparisons.Comparators;
@@ -9,6 +11,7 @@ import io.github.syst3ms.skriptparser.types.ranges.Ranges;
 import io.github.syst3ms.skriptparser.util.SkriptDate;
 import io.github.syst3ms.skriptparser.util.Time;
 import io.github.syst3ms.skriptparser.util.TimeUtils;
+import io.github.syst3ms.skriptparser.util.color.Color;
 import io.github.syst3ms.skriptparser.util.math.BigDecimalMath;
 
 import java.math.BigDecimal;
@@ -162,6 +165,27 @@ public class DefaultRegistration {
                     .toStringFunction(String::valueOf)
                     .register();
 
+        registration.newType(Type.class, "type", "type@s")
+                .literalParser(s -> TypeManager.getByExactName(s.toLowerCase())
+                        .orElse(null))
+                .toStringFunction(Type::getBaseName)
+                .register();
+
+        registration.newType(Color.class, "color", "color@s")
+                .literalParser(s -> {
+                    var match = Color.COLOR_PATTERN.matcher(s);
+                    if (match.matches()) {
+                        return Color.of(s.replaceAll("&", "#"));
+                    }
+                    try {
+                        return Color.ofLiteral(s);
+                    } catch (IllegalArgumentException ignored) {
+                        return null;
+                    }
+                })
+                .toStringFunction(Color::toString)
+                .register();
+
         registration.newType(Duration.class, "duration", "duration@s")
                 .literalParser(s -> TimeUtils.parseDuration(s).orElse(null))
                 .toStringFunction(TimeUtils::toStringDuration)
@@ -262,6 +286,7 @@ public class DefaultRegistration {
                     }
                 }
         );
+
         Comparators.registerComparator(
                 Duration.class,
                 Duration.class,
@@ -293,6 +318,7 @@ public class DefaultRegistration {
                     }
                 }
         );
+
         // Actually a character range
         Ranges.registerRange(
                 String.class,
@@ -317,6 +343,7 @@ public class DefaultRegistration {
                 return Optional.of(BigInteger.valueOf(n.longValue()));
             }
         });
+
         registration.addConverter(SkriptDate.class, Time.class, da -> Optional.of(Time.of(da)));
 
         registration.register(); // Ignoring logs here, we control the input

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
@@ -173,7 +173,7 @@ public class DefaultRegistration {
 
         registration.newType(Color.class, "color", "color@s")
                 .literalParser(s -> {
-                    var match = Color.COLOR_PATTERN.matcher(s);
+                    var match = Color.COLOR_PATTERN.matcher(s.toLowerCase());
                     if (match.matches()) {
                         return Color.of(s.replaceAll("&", "#"));
                     }

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
@@ -173,9 +173,10 @@ public class DefaultRegistration {
 
         registration.newType(Color.class, "color", "color@s")
                 .literalParser(s -> {
+                    s = s.replace('&', '#');
                     var match = Color.COLOR_PATTERN.matcher(s.toLowerCase());
                     if (match.matches()) {
-                        return Color.of(s.replaceAll("&", "#"));
+                        return Color.of(s);
                     }
                     try {
                         return Color.ofLiteral(s);

--- a/src/main/java/io/github/syst3ms/skriptparser/util/color/Color.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/color/Color.java
@@ -26,12 +26,20 @@ public class Color {
     public static Color PINK = of(0xff00ff);
     public static Color PURPLE = of(0x800080);
 
-    private final byte red, green, blue;
+    private final int red, green, blue;
 
-    private Color(byte r, byte g, byte b) {
-        red = r;
-        green = g;
-        blue = b;
+    private Color(int r, int g, int b) {
+        if (0 <= r && r < 256
+                && 0 <= g && g < 256
+                && 0 <= b && b < 256) {
+            red = r;
+            green = g;
+            blue = b;
+        } else {
+            throw new IllegalArgumentException(
+                    String.format("Red, green and blue values are not in range 0-255: found %s,%s,%s", r, g, b)
+            );
+        }
     }
 
     /**
@@ -41,7 +49,7 @@ public class Color {
      * @param b the blue value
      * @return a new Color instance
      */
-    public static Color of(byte r, byte g, byte b) {
+    public static Color of(int r, int g, int b) {
         return new Color(r, g, b);
     }
 
@@ -54,7 +62,7 @@ public class Color {
         int r = (hex & 0xFF0000) >> 16;
         int g = (hex & 0xFF00) >> 8;
         int b = (hex & 0xFF);
-        return new Color((byte) r, (byte) g, (byte) b);
+        return new Color(r, g, b);
     }
 
     /**
@@ -120,21 +128,21 @@ public class Color {
     /**
      * @return the red value of this color
      */
-    public byte getRed() {
+    public int getRed() {
         return red;
     }
 
     /**
      * @return the green value of this color
      */
-    public byte getGreen() {
+    public int getGreen() {
         return green;
     }
 
     /**
      * @return the blue value of this color
      */
-    public byte getBlue() {
+    public int getBlue() {
         return blue;
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/util/color/Color.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/color/Color.java
@@ -1,30 +1,35 @@
 package io.github.syst3ms.skriptparser.util.color;
 
+import java.util.Map;
 import java.util.regex.Pattern;
+
+import static java.util.Map.entry;
 
 /**
  * Represents a color, written like #xxxxxx or with an RGB format.
  * @author Mwexim
  */
 public class Color {
-    public static Pattern COLOR_PATTERN = Pattern.compile("[#&][0-9a-f]{6}");
+    public static final Pattern COLOR_PATTERN = Pattern.compile("#[0-9a-f]{6}");
 
-    public static Color WHITE = of(0xffffff);
-    public static Color SILVER = of(0xc0c0c0);
-    public static Color GRAY = of(0x808080);
-    public static Color BLACK = of(0x000000);
-    public static Color RED = of(0xff0000);
-    public static Color DARK_RED = of(0x800000);
-    public static Color YELLOW = of(0xffff00);
-    public static Color DARK_YELLOW = of(0x808000);
-    public static Color LIME = of(0x00ff00);
-    public static Color GREEN = of(0x008000);
-    public static Color AQUA = of(0x0000ff);
-    public static Color CYAN = of(0x008080);
-    public static Color BLUE = of(0x0000ff);
-    public static Color DARK_BLUE = of(0x000080);
-    public static Color PINK = of(0xff00ff);
-    public static Color PURPLE = of(0x800080);
+    private static final Map<String, Color> COLOR_CONSTANTS = Map.ofEntries(
+        entry("WHITE", of(0xffffff)),
+        entry("SILVER", of(0xc0c0c0)),
+        entry("GRAY", of(0x808080)),
+        entry("BLACK", of(0x000000)),
+        entry("RED", of(0xff0000)),
+        entry("DARK_RED", of(0x800000)),
+        entry("YELLOW", of(0xffff00)),
+        entry("DARK_YELLOW", of(0x808000)),
+        entry("LIME", of(0x00ff00)),
+        entry("GREEN", of(0x008000)),
+        entry("AQUA", of(0x0000ff)),
+        entry("CYAN", of(0x008080)),
+        entry("BLUE", of(0x0000ff)),
+        entry("DARK_BLUE", of(0x000080)),
+        entry("PINK", of(0xff00ff)),
+        entry("PURPLE", of(0x800080))
+    );
 
     private final int red, green, blue;
 
@@ -81,48 +86,7 @@ public class Color {
      */
     public static Color ofLiteral(String literal) {
         String actual = literal.replaceAll(" ", "_").toUpperCase();
-        switch (actual) {
-            case "WHITE":
-                return WHITE;
-            case "SILVER":
-                return SILVER;
-            case "GRAY":
-                return GRAY;
-            case "BLACK":
-                return BLACK;
-            case "RED":
-                return RED;
-            case "DARK_RED":
-            case "MAROON":
-                return DARK_RED;
-            case "YELLOW":
-                return YELLOW;
-            case "DARK_YELLOW":
-            case "OLIVE":
-                return DARK_YELLOW;
-            case "LIME":
-                return LIME;
-            case "GREEN":
-                return GREEN;
-            case "LIGHT_BLUE":
-            case "AQUA":
-                return AQUA;
-            case "CYAN":
-            case "TEAL":
-                return CYAN;
-            case "BLUE":
-                return BLUE;
-            case "DARK_BLUE":
-            case "NAVY":
-                return DARK_BLUE;
-            case "PINK":
-            case "FUCHSIA":
-                return PINK;
-            case "PURPLE":
-                return PURPLE;
-            default:
-                throw new IllegalArgumentException();
-        }
+        return COLOR_CONSTANTS.get(actual);
     }
 
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/util/color/Color.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/color/Color.java
@@ -1,0 +1,162 @@
+package io.github.syst3ms.skriptparser.util.color;
+
+import java.util.regex.Pattern;
+
+/**
+ * Represents a color, written like #xxxxxx or with an RGB format.
+ * @author Mwexim
+ */
+public class Color {
+    public static Pattern COLOR_PATTERN = Pattern.compile("[#&][0-9a-f]{6}");
+
+    public static Color WHITE = of(0xffffff);
+    public static Color SILVER = of(0xc0c0c0);
+    public static Color GRAY = of(0x808080);
+    public static Color BLACK = of(0x000000);
+    public static Color RED = of(0xff0000);
+    public static Color DARK_RED = of(0x800000);
+    public static Color YELLOW = of(0xffff00);
+    public static Color DARK_YELLOW = of(0x808000);
+    public static Color LIME = of(0x00ff00);
+    public static Color GREEN = of(0x008000);
+    public static Color AQUA = of(0x0000ff);
+    public static Color CYAN = of(0x008080);
+    public static Color BLUE = of(0x0000ff);
+    public static Color DARK_BLUE = of(0x000080);
+    public static Color PINK = of(0xff00ff);
+    public static Color PURPLE = of(0x800080);
+
+    private final byte red, green, blue;
+
+    private Color(byte r, byte g, byte b) {
+        red = r;
+        green = g;
+        blue = b;
+    }
+
+    /**
+     * The Color instance of given hex value.
+     * @param r the red value
+     * @param g the green value
+     * @param b the blue value
+     * @return a new Color instance
+     */
+    public static Color of(byte r, byte g, byte b) {
+        return new Color(r, g, b);
+    }
+
+    /**
+     * The Color instance of given hex value.
+     * @param hex the hexadecimal value
+     * @return a new Color instance
+     */
+    public static Color of(int hex) {
+        int r = (hex & 0xFF0000) >> 16;
+        int g = (hex & 0xFF00) >> 8;
+        int b = (hex & 0xFF);
+        return new Color((byte) r, (byte) g, (byte) b);
+    }
+
+    /**
+     * The Color instance of given hex value.
+     * @param hex the hexadecimal value in String form (like #xxxxxx)
+     * @return a new Color instance
+     */
+    public static Color of(String hex) {
+        return of(Integer.parseInt(hex.substring(1), 16));
+    }
+
+    /**
+     * The Color instance of given literal.
+     * @param literal the literal value, like 'yellow' or 'green'.
+     * @return a new Color instance
+     */
+    public static Color ofLiteral(String literal) {
+        String actual = literal.replaceAll(" ", "_").toUpperCase();
+        switch (actual) {
+            case "WHITE":
+                return WHITE;
+            case "SILVER":
+                return SILVER;
+            case "GRAY":
+                return GRAY;
+            case "BLACK":
+                return BLACK;
+            case "RED":
+                return RED;
+            case "DARK_RED":
+            case "MAROON":
+                return DARK_RED;
+            case "YELLOW":
+                return YELLOW;
+            case "DARK_YELLOW":
+            case "OLIVE":
+                return DARK_YELLOW;
+            case "LIME":
+                return LIME;
+            case "GREEN":
+                return GREEN;
+            case "LIGHT_BLUE":
+            case "AQUA":
+                return AQUA;
+            case "CYAN":
+            case "TEAL":
+                return CYAN;
+            case "BLUE":
+                return BLUE;
+            case "DARK_BLUE":
+            case "NAVY":
+                return DARK_BLUE;
+            case "PINK":
+            case "FUCHSIA":
+                return PINK;
+            case "PURPLE":
+                return PURPLE;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * @return the red value of this color
+     */
+    public byte getRed() {
+        return red;
+    }
+
+    /**
+     * @return the green value of this color
+     */
+    public byte getGreen() {
+        return green;
+    }
+
+    /**
+     * @return the blue value of this color
+     */
+    public byte getBlue() {
+        return blue;
+    }
+
+    /**
+     * @return the hex value of this color, without the '#' appended
+     */
+    public String getHex() {
+        return String.format("%02x%02x%02x", red, green, blue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Color color = (Color) o;
+        return red == color.red && green == color.green && blue == color.blue;
+    }
+
+    @Override
+    public String toString() {
+        return '#' + getHex();
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/color/Color.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/color/Color.java
@@ -23,7 +23,7 @@ public class Color {
         entry("DARK_YELLOW", of(0x808000)),
         entry("LIME", of(0x00ff00)),
         entry("GREEN", of(0x008000)),
-        entry("AQUA", of(0x0000ff)),
+        entry("AQUA", of(0x00ffff)),
         entry("CYAN", of(0x008080)),
         entry("BLUE", of(0x0000ff)),
         entry("DARK_BLUE", of(0x000080)),


### PR DESCRIPTION
This pull request yet again adds syntaxes described in issue #40:
- A new Color class that stores colours based on their RGB value (but the stringify-method will present it as HEX). This means that the storing of colours is done through RGB but the actual parsing and displaying is just a HEX.
- Color type with parsing and displaying. Currently, the literal parser uses the '&' symbol (instead of the regular '#') to parse colours since hashtags are occupied for comments already. I was thinking about something like `0xffffff` or `xffffff` (or even `x_ffffff`) as alternatives. But currently, it'll be something like `&ffffff`. 
- Added ExprColorValues and ExprColorFromRGB (these classes speak for themselves).
- Added support for several literal colours like `yellow`, `lime`, `maroon`, ...

Lastly, I fixed an issue where the Type type was omitted for some weird reason, resulting in the ExprParseAs to not be usable.

I know the current design is a bit sloppy right now, so please let me know any improvements design-wise and coding-wise.