### PR TITLE
fix: boolean operator fix (#23)

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
@@ -64,6 +64,12 @@ public class SyntaxParser {
     // Gradle requires the cast, but IntelliJ considers it redundant
     public static final PatternType<Object> OBJECTS_PATTERN_TYPE = new PatternType<>((Type<Object>) TypeManager.getByClass(Object.class).orElseThrow(AssertionError::new), false);
 
+    public static final ExpressionInfo<ExprBooleanOperators, Boolean> EXPRESSION_BOOLEANOPERATORS
+            = (ExpressionInfo<ExprBooleanOperators, Boolean>) SyntaxManager.getAllExpressions().stream()
+            .filter(i -> i.getSyntaxClass() == ExprBooleanOperators.class)
+            .findFirst()
+            .orElseThrow();
+
     /**
      * All {@link Effect effects} that are successfully parsed during parsing, in order of last successful parsing
      */
@@ -128,13 +134,9 @@ public class SyntaxParser {
         }
         if (!isList) {
             // We parse boolean operators first to prevent clutter while parsing.
-            var operatorInfo = (ExpressionInfo<ExprBooleanOperators, Boolean>) SyntaxManager.getAllExpressions()
-                    .stream()
-                    .filter(i -> i.getSyntaxClass() == ExprBooleanOperators.class)
-                    .findFirst()
-                    .orElseThrow();
-            var booleanOperator = matchExpressionInfo(s, operatorInfo, expectedType, parserState, logger);
+            var booleanOperator = matchExpressionInfo(s, EXPRESSION_BOOLEANOPERATORS, expectedType, parserState, logger);
             if (booleanOperator.isPresent()) {
+                recentExpressions.acknowledge(EXPRESSION_BOOLEANOPERATORS);
                 logger.clearErrors();
                 return booleanOperator;
             }

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
@@ -1,5 +1,6 @@
 package io.github.syst3ms.skriptparser.parsing;
 
+import io.github.syst3ms.skriptparser.expressions.ExprBooleanOperators;
 import io.github.syst3ms.skriptparser.file.FileSection;
 import io.github.syst3ms.skriptparser.lang.*;
 import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
@@ -118,6 +119,24 @@ public class SyntaxParser {
                 return Optional.empty();
             } else {
                 return variable;
+            }
+        }
+        // The isList variable's sole purpose is to prevent us from exchanging boolean operators with lists.
+        boolean isList = s.toLowerCase().startsWith("list ");
+        if (isList) {
+            s = s.substring("list ".length());
+        }
+        if (!isList) {
+            // We parse boolean operators first to prevent clutter while parsing.
+            var operatorInfo = (ExpressionInfo<ExprBooleanOperators, Boolean>) SyntaxManager.getAllExpressions()
+                    .stream()
+                    .filter(i -> i.getSyntaxClass() == ExprBooleanOperators.class)
+                    .findFirst()
+                    .orElseThrow();
+            var booleanOperator = matchExpressionInfo(s, operatorInfo, expectedType, parserState, logger);
+            if (booleanOperator.isPresent()) {
+                logger.clearErrors();
+                return booleanOperator;
             }
         }
         if (!expectedType.isSingle()) {

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
@@ -121,9 +121,8 @@ public class SyntaxParser {
                 return variable;
             }
         }
-        // The isList variable's sole purpose is to prevent us from exchanging boolean operators with lists.
-        boolean isList = s.toLowerCase().startsWith("list ");
-        if (isList) {
+        // This is to prevent us from exchanging boolean operators with lists.
+        if (s.toLowerCase().startsWith("list ")) {
             s = s.substring("list ".length());
         } else {
             // We parse boolean operators first to prevent clutter while parsing.

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
@@ -64,7 +64,7 @@ public class SyntaxParser {
     // Gradle requires the cast, but IntelliJ considers it redundant
     public static final PatternType<Object> OBJECTS_PATTERN_TYPE = new PatternType<>((Type<Object>) TypeManager.getByClass(Object.class).orElseThrow(AssertionError::new), false);
 
-    public static final ExpressionInfo<ExprBooleanOperators, Boolean> EXPRESSION_BOOLEANOPERATORS
+    public static final ExpressionInfo<ExprBooleanOperators, Boolean> EXPRESSION_BOOLEAN_OPERATORS
             = (ExpressionInfo<ExprBooleanOperators, Boolean>) SyntaxManager.getAllExpressions().stream()
             .filter(i -> i.getSyntaxClass() == ExprBooleanOperators.class)
             .findFirst()
@@ -132,9 +132,9 @@ public class SyntaxParser {
             s = s.substring("list ".length());
         } else {
             // We parse boolean operators first to prevent clutter while parsing.
-            var booleanOperator = matchExpressionInfo(s, EXPRESSION_BOOLEANOPERATORS, expectedType, parserState, logger);
+            var booleanOperator = matchExpressionInfo(s, EXPRESSION_BOOLEAN_OPERATORS, expectedType, parserState, logger);
             if (booleanOperator.isPresent()) {
-                recentExpressions.acknowledge(EXPRESSION_BOOLEANOPERATORS);
+                recentExpressions.acknowledge(EXPRESSION_BOOLEAN_OPERATORS);
                 logger.clearErrors();
                 return booleanOperator;
             }

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
@@ -125,8 +125,7 @@ public class SyntaxParser {
         boolean isList = s.toLowerCase().startsWith("list ");
         if (isList) {
             s = s.substring("list ".length());
-        }
-        if (!isList) {
+        } else {
             // We parse boolean operators first to prevent clutter while parsing.
             var operatorInfo = (ExpressionInfo<ExprBooleanOperators, Boolean>) SyntaxManager.getAllExpressions()
                     .stream()

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/SyntaxParser.java
@@ -157,6 +157,7 @@ public class SyntaxParser {
         // Let's not loop over the same elements again
         var remainingExpressions = SyntaxManager.getAllExpressions();
         recentExpressions.removeFrom(remainingExpressions);
+        remainingExpressions.remove(EXPRESSION_BOOLEAN_OPERATORS);
         for (var info : remainingExpressions) {
             var expr = matchExpressionInfo(s, info, expectedType, parserState, logger);
             if (expr.isPresent()) {


### PR DESCRIPTION
Closes #23.

This is a small fix for the bug described in the above issue.
Basically, expression parsing now goes as follows:
1. Literal parsing (unchanged)
2. Variable parsing (unchanged)
3. Boolean operator parsing (forced)
4. List parsing (unchanged)
5. Expression parsing (unchanged)

This means boolean operators will now have priority, which was needed in the expression. If you still want to use a boolean list (why, I don't know...), you can just paste 'list' in front of your expression to force-parse it as a list.

Note that these changes are propositional and that any suggestions are welcome. This is just my take on the problem. I think changing the whole list syntax is a bit over the top for such a small issue.
Let me know if you are satisfied with the 'list' prefix as well.
