### PR TITLE
feature: Enum type util

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
@@ -335,7 +335,7 @@ public class SkriptRegistration {
      * The {@link TypeRegistrar#literalParser(Function) literalParser(Function)}
      * and {@link TypeRegistrar#toStringFunction(Function) toStringFunction(Function)} methods
      * are implemented at default.
-     * Note that the represented Enum's values need to be in the {@code UPPER_CASE_SNAKE} convention.
+     * Note that the represented Enum's values need to be in the {@code SCREAMING_CASE_SNAKE} convention.
      * @param c the class the Type represents
      * @param pattern the Type's pattern
      * @param <T> the represented class

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
@@ -335,7 +335,7 @@ public class SkriptRegistration {
      * The {@link TypeRegistrar#literalParser(Function) literalParser(Function)}
      * and {@link TypeRegistrar#toStringFunction(Function) toStringFunction(Function)} methods
      * are implemented at default.
-     * Note that the represented Enum's values need to be in the {@code SCREAMING_CASE_SNAKE} convention.
+     * Note that the represented Enum's values need to be in the {@code SCREAMING_SNAKE_CASE} convention.
      * @param c the class the Type represents
      * @param pattern the Type's pattern
      * @param <T> the represented class
@@ -364,7 +364,7 @@ public class SkriptRegistration {
      * The {@link TypeRegistrar#literalParser(Function) literalParser(Function)}
      * and {@link TypeRegistrar#toStringFunction(Function) toStringFunction(Function)} methods
      * are implemented at default.
-     * Note that the represented Enum's values need to be in the {@code SCREAMING_CASE_SNAKE} convention.
+     * Note that the represented Enum's values need to be in the {@code SCREAMING_SNAKE_CASE} convention.
      * @param c the class the Type represents
      * @param pattern the Type's pattern
      * @param <T> the represented class

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
@@ -344,6 +344,10 @@ public class SkriptRegistration {
     public <T extends Enum<T>> TypeRegistrar<T> newEnumType(Class<T> c, String name, String pattern) {
         return new TypeRegistrar<>(c, name, pattern)
                 .literalParser(s -> {
+                    // We won't allow ugly syntax.
+                    // Otherwise, a field like 'MY_ENUM_CONSTANT' would allow 'my enum_constant'.
+                    if (s.contains("_"))
+                        return null;
                     s = s.replaceAll(" ", "_").toUpperCase();
                     try {
                         return Enum.valueOf(c, s);
@@ -351,7 +355,7 @@ public class SkriptRegistration {
                         return null;
                     }
                 })
-                .toStringFunction(o -> o.toString().replaceAll(" ", "_").toLowerCase());
+                .toStringFunction(o -> o.toString().replaceAll("_", " ").toLowerCase());
     }
 
     /**
@@ -368,6 +372,10 @@ public class SkriptRegistration {
     public <T extends Enum<T>> void addEnumType(Class<T> c, String name, String pattern) {
         new TypeRegistrar<>(c, name, pattern)
                 .literalParser(s -> {
+                    // We won't allow ugly syntax.
+                    // Otherwise, a field like 'MY_ENUM_CONSTANT' would allow 'my enum_constant'.
+                    if (s.contains("_"))
+                        return null;
                     s = s.replaceAll(" ", "_").toUpperCase();
                     try {
                         return Enum.valueOf(c, s);
@@ -375,7 +383,7 @@ public class SkriptRegistration {
                         return null;
                     }
                 })
-                .toStringFunction(o -> o.toString().replaceAll(" ", "_").toLowerCase())
+                .toStringFunction(o -> o.toString().replaceAll("_", " ").toLowerCase())
                 .register();
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
@@ -309,6 +309,17 @@ public class SkriptRegistration {
     }
 
     /**
+     * Starts a registration process for a {@link Type}
+     * @param c the class the Type represents
+     * @param pattern the Type's pattern
+     * @param <T> the represented class
+     * @return an {@link TypeRegistrar}
+     */
+    public <T> TypeRegistrar<T> newType(Class<T> c, String name, String pattern) {
+        return new TypeRegistrar<>(c, name, pattern);
+    }
+
+    /**
      * Registers a {@link Type}
      * @param c the class the Type represents
      * @param pattern the Type's pattern
@@ -319,14 +330,53 @@ public class SkriptRegistration {
     }
 
     /**
-     * Starts a registration process for a {@link Type}
+     * Starts the registration process for an {@link Enum} as a {@link Type}.
+     * <br>
+     * The {@link TypeRegistrar#literalParser(Function) literalParser(Function)}
+     * and {@link TypeRegistrar#toStringFunction(Function) toStringFunction(Function)} methods
+     * are implemented at default.
+     * Note that the represented Enum's values need to be in the {@code UPPER_CASE_SNAKE} convention.
      * @param c the class the Type represents
      * @param pattern the Type's pattern
      * @param <T> the represented class
      * @return an {@link TypeRegistrar}
      */
-    public <T> TypeRegistrar<T> newType(Class<T> c, String name, String pattern) {
-        return new TypeRegistrar<>(c, name, pattern);
+    public <T extends Enum<T>> TypeRegistrar<T> newEnumType(Class<T> c, String name, String pattern) {
+        return new TypeRegistrar<>(c, name, pattern)
+                .literalParser(s -> {
+                    s = s.replaceAll(" ", "_").toUpperCase();
+                    try {
+                        return Enum.valueOf(c, s);
+                    } catch (IllegalArgumentException ignored) {
+                        return null;
+                    }
+                })
+                .toStringFunction(o -> o.toString().replaceAll(" ", "_").toLowerCase());
+    }
+
+    /**
+     * Registers an {@link Enum} as a {@link Type}.
+     * <br>
+     * The {@link TypeRegistrar#literalParser(Function) literalParser(Function)}
+     * and {@link TypeRegistrar#toStringFunction(Function) toStringFunction(Function)} methods
+     * are implemented at default.
+     * Note that the represented Enum's values need to be in the {@code UPPER_CASE_SNAKE} convention.
+     * @param c the class the Type represents
+     * @param pattern the Type's pattern
+     * @param <T> the represented class
+     */
+    public <T extends Enum<T>> void addEnumType(Class<T> c, String name, String pattern) {
+        new TypeRegistrar<>(c, name, pattern)
+                .literalParser(s -> {
+                    s = s.replaceAll(" ", "_").toUpperCase();
+                    try {
+                        return Enum.valueOf(c, s);
+                    } catch (IllegalArgumentException ignored) {
+                        return null;
+                    }
+                })
+                .toStringFunction(o -> o.toString().replaceAll(" ", "_").toLowerCase())
+                .register();
     }
 
     /**

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
@@ -364,7 +364,7 @@ public class SkriptRegistration {
      * The {@link TypeRegistrar#literalParser(Function) literalParser(Function)}
      * and {@link TypeRegistrar#toStringFunction(Function) toStringFunction(Function)} methods
      * are implemented at default.
-     * Note that the represented Enum's values need to be in the {@code UPPER_CASE_SNAKE} convention.
+     * Note that the represented Enum's values need to be in the {@code SCREAMING_CASE_SNAKE} convention.
      * @param c the class the Type represents
      * @param pattern the Type's pattern
      * @param <T> the represented class


### PR DESCRIPTION
This is a really small pull request that adds some quick utility changes for Enum classes. The registration of an Enum class will now most of the time only require one simple line to be added, resulting in less boilerplate code, resulting in happier devs :)

The registration process is very straightforward. Sadly enough, there is no real implementation possible yet, but this will surely follow in several addons in the future.
