### PR TITLE
feat./fix: add TagSpecialCharacters syntax and support for '\n' and '\t'

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
@@ -130,7 +130,17 @@ public class VariableString extends TaggedExpression {
                 if (i + 1 == charArray.length) {
                     return Optional.empty();
                 }
-                sb.append(charArray[++i]);
+                char next = charArray[++i];
+                switch (next) {
+                    case 'n':
+                        sb.append(System.lineSeparator());
+                        break;
+                    case 't':
+                        sb.append('\t');
+                        break;
+                    default:
+                        sb.append(c);
+                }
             } else if (c == '&') {
                 logger.recurse();
                 var tag = TagManager.parseTag(String.valueOf(charArray[++i]), logger);
@@ -168,7 +178,6 @@ public class VariableString extends TaggedExpression {
         return toString(ctx, "default");
     }
 
-    @SuppressWarnings("unchecked")
     public String toString(TriggerContext ctx, String tagCtx) {
         if (simple)
             return (String) data[0];
@@ -178,7 +187,7 @@ public class VariableString extends TaggedExpression {
                 .filter(o -> !(o instanceof Tag) || ((Tag) o).isUsable(tagCtx))
                 .toArray();
         var sb = new StringBuilder();
-        int tags = 1;
+        int currentTags = 1;
         List<Tag> ongoingTags = new ArrayList<>();
 
         for (int i = 0; i < actualData.length; i++) {
@@ -187,7 +196,7 @@ public class VariableString extends TaggedExpression {
                 sb.append(TypeManager.toString(((Expression<?>) o).getValues(ctx)));
             } else if (o instanceof Tag) {
                 ongoingTags.add((Tag) o);
-                int indexOfNext = CollectionUtils.ordinalConditionalIndexOf(Arrays.asList(actualData), tags, t -> t instanceof Tag);
+                int indexOfNext = CollectionUtils.ordinalConditionalIndexOf(actualData, ++currentTags, t -> t instanceof Tag);
                 if (indexOfNext == -1)
                     indexOfNext = actualData.length;
                 var affected = new StringBuilder();
@@ -202,13 +211,12 @@ public class VariableString extends TaggedExpression {
                         affected.append(o2);
                     }
                 }
-                ongoingTags.removeIf(t -> !t.combinesWith((Class<Tag>) o.getClass()));
-                var fin = ((Tag) o).getValue(affected.toString());
+                ongoingTags.removeIf(t -> !o.equals(t) && !((Tag) o).combinesWith(t.getClass()));
+                var fin = affected.toString();
                 for (Tag tag : ongoingTags) {
                     fin = tag.getValue(fin);
                 }
                 sb.append(fin);
-                tags++;
                 i = indexOfNext - 1;
             } else {
                 sb.append(o);

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/tags/ContinuousTag.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/tags/ContinuousTag.java
@@ -1,0 +1,28 @@
+package io.github.syst3ms.skriptparser.registration.tags;
+
+/**
+ * A continuous tag is a special sort of tag that always has a fixed value.
+ * This means that it will not change the affected String, but rather add another String
+ * in front of it.
+ * You don't want continuous tags to combine with each other, because this behavior will be repeated.
+ * That's why continuous tags combine with all tags except with other continuous tags.
+ * @author Mwexim
+ * @see Tag
+ */
+public interface ContinuousTag extends Tag {
+	@Override
+	default String getValue(String affected) {
+		return getValue() + affected;
+	}
+
+	/**
+	 * Returns the String that needs to be put in front of the affected String.
+	 * @return the applied string
+	 */
+	String getValue();
+
+	@Override
+	default boolean combinesWith(Class<? extends Tag> tag) {
+		return !ContinuousTag.class.isAssignableFrom(tag);
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/tags/TagCase.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/tags/TagCase.java
@@ -7,7 +7,7 @@ import io.github.syst3ms.skriptparser.registration.tags.Tag;
  * Applies lowercase or uppercase to the affected string.
  * @name Case Tag
  * @type TAG
- * @pattern <case=lower|upper>
+ * @pattern case=lower|upper
  * @since ALPHA
  * @author Mwexim
  */

--- a/src/main/java/io/github/syst3ms/skriptparser/tags/TagReset.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/tags/TagReset.java
@@ -7,7 +7,7 @@ import io.github.syst3ms.skriptparser.registration.tags.Tag;
  * A tag that resets all currently ongoing tags.
  * @name Reset Tag
  * @type TAG
- * @pattern <reset>, &r
+ * @pattern reset, r
  * @since ALPHA
  * @author Mwexim
  */

--- a/src/main/java/io/github/syst3ms/skriptparser/tags/TagSpecialCharacters.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/tags/TagSpecialCharacters.java
@@ -1,0 +1,60 @@
+package io.github.syst3ms.skriptparser.tags;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.registration.tags.ContinuousTag;
+
+/**
+ * Adds special characters to the string.
+ * @name Case Tag
+ * @type TAG
+ * @pattern br[eak]|tab
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class TagSpecialCharacters implements ContinuousTag {
+	static {
+		Parser.getMainRegistration().addTag(TagSpecialCharacters.class);
+	}
+
+	private int type;
+
+	public boolean init(String key, String[] parameters) {
+		if (parameters.length != 0)
+			return false;
+
+		switch (key) {
+			case "break":
+			case "br":
+				type = 0;
+				return true;
+			case "tab":
+				type = 1;
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	@Override
+	public String getValue() {
+		switch (type) {
+			case 0:
+				return System.lineSeparator();
+			case 1:
+				return "\t";
+			default:
+				throw new IllegalStateException();
+		}
+	}
+
+	public String toString(boolean debug) {
+		switch (type) {
+			case 0:
+				return "<break>";
+			case 1:
+				return "<tab>";
+			default:
+				throw new IllegalStateException();
+		}
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/CollectionUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/CollectionUtils.java
@@ -37,21 +37,21 @@ public class CollectionUtils {
 
     /**
      * Find the index of an item, where a given predicate applies,
-     * from a given class in a list, skipping over all these items
+     * from a given class in an array, skipping over all these items
      * as long as the amount of items skipped is smaller than a given amount.
-     * @param list the list
+     * @param array the array
      * @param n the ordinal you want to get the index from
      * @param condition the condition
      * @return the index, {@code -1} if no index was found
      */
-    public static <T> int ordinalConditionalIndexOf(List<T> list, int n, Predicate<T> condition) {
+    public static <T> int ordinalConditionalIndexOf(T[] array, int n, Predicate<T> condition) {
         int index = 0;
         int findTimes = 0;
         if (n == 0)
             return -1;
-        if (list.isEmpty())
+        if (array.length == 0)
             return -1;
-        for (T o : list) {
+        for (T o : array) {
             if (condition.test(o))
                 findTimes++;
             if (findTimes >= n)


### PR DESCRIPTION
This pull request is mainly focussed around tags but adds one simple syntax as well.
- Added support for `\n` and `\t` (respectively newline and tab) inside literal strings.
- Added the TagSpecialCharacters to allow things like `<break>` as an alternative to the ugly-looking newline character (\n).
- Fixed a lot of tag issues I overlooked in the first release.
- New ContinuousTag class for tags with a constant value.
- Improved tag documentation.