### PR TITLE
feature: general syntax

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprVariableIndices.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprVariableIndices.java
@@ -1,0 +1,63 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.lang.Variable;
+import io.github.syst3ms.skriptparser.log.ErrorType;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * All indices of a given list variable.
+ *
+ * @name Indices of List
+ * @type EXPRESSION
+ * @pattern [all [of] [the]] ind(exes|ices) of %^objects%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class ExprVariableIndices implements Expression<String> {
+	static {
+		Parser.getMainRegistration().addExpression(
+				ExprVariableIndices.class,
+				String.class,
+				false,
+				"[all [of] [the]] ind(exes|ices) of %^objects%"
+		);
+	}
+
+	private Variable<Object> value;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+		value = (Variable<Object>) expressions[0];
+		if (value.isSingle()) {
+			var logger = parseContext.getLogger();
+			logger.error(
+					"Only list variables are allowed, found '" + value.toString(TriggerContext.DUMMY, logger.isDebug()) + "'",
+					ErrorType.SEMANTIC_ERROR
+			);
+			return false;
+		}
+		return true;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public String[] getValues(TriggerContext ctx) {
+		return value.getRaw(ctx)
+				.map(val -> (Map<String, Object>) val) // We know for a fact it is a list variable
+				.map(val -> val.keySet().toArray(new String[0]))
+				.orElse(new String[0]);
+
+	}
+
+	@Override
+	public String toString(@Nullable TriggerContext ctx, boolean debug) {
+		return "indices of " + value.toString(ctx, debug);
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/LitScriptName.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/LitScriptName.java
@@ -1,0 +1,49 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.Literal;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.log.SkriptLogger;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.FileUtils;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The name of the current executed script, without the extension.
+ *
+ * @name Script Name
+ * @pattern [the] [current] script[['s] name]
+ * @pattern name of [the] [current] script
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class LitScriptName implements Literal<String> {
+    static {
+        Parser.getMainRegistration().addExpression(
+                LitScriptName.class,
+                String.class,
+                true,
+                "[the] [current] script[['s] name]",
+                "name of [the] [current] script"
+        );
+    }
+
+    private SkriptLogger logger;
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        logger = parseContext.getLogger();
+        return true;
+    }
+
+    @Override
+    public String[] getValues() {
+        return new String[] {FileUtils.removeExtension(logger.getFileName())};
+    }
+
+    @Override
+    public String toString(@Nullable TriggerContext ctx, boolean debug) {
+        return "script name";
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
@@ -24,7 +24,7 @@ public class FileUtils {
     /**
      * Parses a file and returns a list containing all of its lines.
      * <p>
-     * This parser offers the possiblity to stretch out code across multiple lines by simply adding a single backslash
+     * This parser offers the possibility to stretch out code across multiple lines by simply adding a single backslash
      * before a line break to indicate to the parser that it should be considered as a single line. For example :
      * <pre>
      *     set {large_list::*} to "one long string", \
@@ -105,6 +105,26 @@ public class FileUtils {
             sb.append(line);
         }
         return sb.toString();
+    }
+
+    public static String removeExtension(String s) {
+        String separator = System.getProperty("file.separator");
+        String filename;
+
+        // Remove the path up until the filename.
+        int lastSeparatorIndex = s.lastIndexOf(separator);
+        if (lastSeparatorIndex == -1) {
+            filename = s;
+        } else {
+            filename = s.substring(lastSeparatorIndex + 1);
+        }
+
+        // Remove the extension.
+        int extensionIndex = filename.lastIndexOf(".");
+        if (extensionIndex == -1)
+            return filename;
+
+        return filename.substring(0, extensionIndex);
     }
 
     /**

--- a/src/test/resources/expressions/ExprVariableIndices.txt
+++ b/src/test/resources/expressions/ExprVariableIndices.txt
@@ -1,0 +1,13 @@
+# Author(s):
+# 	- Mwexim
+# Date: 2021/01/01
+
+test:
+	set {list::1} to "Hello"
+	set {list::test} to "World"
+	set {list::foo} to 5
+	set {list::bar::boo} to 5 hours
+
+	assert indices of {list::*} = "1", "test", "foo" and "bar" with "Indices should be '1', 'test', 'foo' and 'bar': %indices of {list::*}%"
+	throws indices of {var}
+	throws indices of "Hello" and "World"

--- a/src/test/resources/expressions/LitScriptName.txt
+++ b/src/test/resources/expressions/LitScriptName.txt
@@ -1,0 +1,6 @@
+# Author(s):
+# 	- Mwexim
+# Date: 2021/01/01
+
+test:
+	assert current script name = "LitScriptName" with "Current script name should be 'LitScriptName': %script name%"


### PR DESCRIPTION
This pull request adds 2 small syntax classes specified in #40.
- LitScriptName: the name of the current script, without the extension.
- ExprVariableIndices: all the indices of a list variable.

No major changes overall.