### PR TITLE
printLogs is now public static

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/Parser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/Parser.java
@@ -149,7 +149,7 @@ public class Parser {
         SkriptAddon.getAddons().forEach(SkriptAddon::finishedLoading);
     }
 
-    private static void printLogs(List<LogEntry> logs, Calendar time, boolean tipsEnabled) {
+    public static void printLogs(List<LogEntry> logs, Calendar time, boolean tipsEnabled) {
         for (LogEntry log : logs) {
             ConsoleColors color = ConsoleColors.WHITE;
             if (log.getType() == LogType.WARNING) {


### PR DESCRIPTION
This pull request includes only the method ``Parser#printLogs`` which become public to be accessible from tier projects (skript-cli).