### PR TITLE
Improve/color syntax improvements

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorFromHex.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorFromHex.java
@@ -1,0 +1,56 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.color.Color;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A color specified by its hexadecimal value. One can use three types of hex values:
+ * <ul>
+ *     <li><b>3 hex digits:</b> each digit is doubled and the string is parsed as a 6-digit hex color.</li>
+ *     <li><b>6 hex digits:</b> each pair of digits is respectively red, green and blue.</li>
+ *     <li><b>8 hex digits:</b> same as a 6-digit hex color. The fourth pair is used for the alpha value.</li>
+ * </ul>
+ * A trailing hashtag (#) at the start of the string is allowed, but not necessary.
+ *
+ * @name Color from Hex
+ * @type EXPRESSION
+ * @pattern [the] color (from|of) [the] hex[adecimal] [value] %string%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class ExprColorFromHex implements Expression<Color> {
+	static {
+		Parser.getMainRegistration().addExpression(
+				ExprColorFromHex.class,
+				Color.class,
+				true,
+				"[the] color (from|of) [the] hex[adecimal] [value] %string%"
+		);
+	}
+
+	private Expression<String> hex;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+		hex = (Expression<String>) expressions[0];
+		return true;
+	}
+
+	@Override
+	public Color[] getValues(TriggerContext ctx) {
+		return hex.getSingle(ctx)
+				.map(val -> val.startsWith("#") ? val.substring(1) : val)
+				.map(val -> new Color[] {Color.ofHex(val)})
+				.orElse(new Color[0]);
+	}
+
+	@Override
+	public String toString(@Nullable TriggerContext ctx, boolean debug) {
+		return "color from hex " + hex.toString(ctx, debug);
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorFromRGB.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorFromRGB.java
@@ -13,10 +13,12 @@ import java.math.BigInteger;
  * A color specified by its RGB value.
  * Each value, this means red, green and blue, can be a range from 0 to 255.
  * Any values outside of those ranges will result in no color to be created.
+ * It is also possible to add the alpha value, which corresponds to the transparency.
+ * If the argument size is not exactly 3 or 4, no color will be created.
  *
  * @name Color from RGB
  * @type EXPRESSION
- * @pattern [[the] color (from|of)] [the] rgb [value] %integer%, %integer%(,| and) %integer%
+ * @pattern [the] color (from|of) [the] rgb[a] [value] %integers%
  * @since ALPHA
  * @author Mwexim
  */
@@ -26,35 +28,41 @@ public class ExprColorFromRGB implements Expression<Color> {
 				ExprColorFromRGB.class,
 				Color.class,
 				true,
-				"[[the] color (from|of)] [the] rgb [value] %integer%, %integer%(,| and) %integer%"
+				"[the] color (from|of) [the] rgb[a] [value] %integers%"
 		);
 	}
 
-	private Expression<BigInteger> red, green, blue;
+	private Expression<BigInteger> rgb;
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
-		red = (Expression<BigInteger>) expressions[0];
-		green = (Expression<BigInteger>) expressions[1];
-		blue = (Expression<BigInteger>) expressions[2];
+		rgb = (Expression<BigInteger>) expressions[0];
 		return true;
 	}
 
 	@Override
 	public Color[] getValues(TriggerContext ctx) {
-		int r = red.getSingle(ctx).map(BigInteger::intValue).orElse(-1);
-		int g = green.getSingle(ctx).map(BigInteger::intValue).orElse(-1);
-		int b = blue.getSingle(ctx).map(BigInteger::intValue).orElse(-1);
+		BigInteger[] values = rgb.getValues(ctx);
+		if (values.length != 3 && values.length != 4)
+			return new Color[0];
+		int r = values[0].intValue();
+		int g = values[1].intValue();
+		int b = values[2].intValue();
+		int a = Color.MAX_VALUE;
+		if (values.length == 4)
+			a = values[3].intValue();
+
 		if (0 <= r && r < 256
 				&& 0 <= g && g < 256
-				&& 0 <= b && b < 256)
-			return new Color[] {Color.of(r, g, b)};
+				&& 0 <= b && b < 256
+				&& 0 <= a && a < 256)
+			return new Color[] {Color.of(r, g, b, a)};
 		return new Color[0];
 	}
 
 	@Override
 	public String toString(@Nullable TriggerContext ctx, boolean debug) {
-		return "color from rgb " + red.toString(ctx, debug) + ", " + green.toString(ctx, debug) + " and " + blue.toString(ctx, debug);
+		return "color from rgb " + rgb.toString(ctx, debug);
 	}
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorValues.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorValues.java
@@ -27,11 +27,11 @@ public class ExprColorValues extends PropertyExpression<BigInteger, Color> {
 				BigInteger.class,
 				false,
 				"color",
-				"(0:rgb [(value|color)]|1:red value|2:green value|3:blue value)"
+				"(rgb[4:a] [value[s]]|1:red value|2:green value|3:blue value)"
 		);
 	}
 
-	int parseMark;
+	private int parseMark;
 
 	@SuppressWarnings("unchecked")
 	@Override
@@ -57,6 +57,13 @@ public class ExprColorValues extends PropertyExpression<BigInteger, Color> {
 				return new BigInteger[] {BigInteger.valueOf(c.getGreen())};
 			case 3:
 				return new BigInteger[] {BigInteger.valueOf(c.getBlue())};
+			case 4:
+				return new BigInteger[] {
+						BigInteger.valueOf(c.getRed()),
+						BigInteger.valueOf(c.getGreen()),
+						BigInteger.valueOf(c.getBlue()),
+						BigInteger.valueOf(c.getAlpha())
+				};
 			default:
 				throw new IllegalStateException();
 		}
@@ -64,7 +71,7 @@ public class ExprColorValues extends PropertyExpression<BigInteger, Color> {
 
 	@Override
 	public boolean isSingle() {
-		return parseMark != 0;
+		return parseMark != 0 && parseMark != 4;
 	}
 
 	@Override
@@ -78,6 +85,8 @@ public class ExprColorValues extends PropertyExpression<BigInteger, Color> {
 				return "green value of " + getOwner().toString(ctx, debug);
 			case 3:
 				return "blue value of " + getOwner().toString(ctx, debug);
+			case 4:
+				return "rgba value of " + getOwner().toString(ctx, debug);
 			default:
 				throw new IllegalStateException();
 		}

--- a/src/main/java/io/github/syst3ms/skriptparser/parsing/ScriptLoader.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/parsing/ScriptLoader.java
@@ -33,14 +33,13 @@ public class ScriptLoader {
      * @param debug whether debug is enabled
      */
     public static List<LogEntry> loadScript(Path scriptPath, boolean debug) {
-        var parser = new FileParser();
         var logger = new SkriptLogger(debug);
         List<FileElement> elements;
         String scriptName;
         try {
             var lines = FileUtils.readAllLines(scriptPath);
             scriptName = scriptPath.getFileName().toString().replaceAll("(.+)\\..+", "$1");
-            elements = parser.parseFileLines(scriptName,
+            elements = FileParser.parseFileLines(scriptName,
                     lines,
                     0,
                     1,

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
@@ -172,18 +172,7 @@ public class DefaultRegistration {
                 .register();
 
         registration.newType(Color.class, "color", "color@s")
-                .literalParser(s -> {
-                    s = s.replace('&', '#');
-                    var match = Color.COLOR_PATTERN.matcher(s.toLowerCase());
-                    if (match.matches()) {
-                        return Color.of(s);
-                    }
-                    try {
-                        return Color.ofLiteral(s);
-                    } catch (IllegalArgumentException ignored) {
-                        return null;
-                    }
-                })
+                .literalParser(s -> Color.ofLiteral(s).orElse(null))
                 .toStringFunction(Color::toString)
                 .register();
 

--- a/src/main/java/io/github/syst3ms/skriptparser/util/color/Color.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/color/Color.java
@@ -94,17 +94,17 @@ public class Color {
      * @param isAlpha whether or not the alpha parameter is present
      * @return a new Color instance
      */
-    public static Color of(int hex, boolean isAlpha) {
+    public static Color of(long hex, boolean isAlpha) {
         if (isAlpha) {
-            int r = (hex & 0xFF000000) >> 24;
-            int g = (hex & 0xFF0000) >> 16;
-            int b = (hex & 0xFF00) >> 8;
-            int a = (hex & 0xFF);
+            int r = (int) ((hex & 0xFF000000) >> 24);
+            int g = (int) ((hex & 0xFF0000) >> 16);
+            int b = (int) ((hex & 0xFF00) >> 8);
+            int a = (int) (hex & 0xFF);
             return new Color(r, g, b, a);
         } else {
-            int r = (hex & 0xFF0000) >> 16;
-            int g = (hex & 0xFF00) >> 8;
-            int b = (hex & 0xFF);
+            int r = (int) ((hex & 0xFF0000) >> 16);
+            int g = (int) ((hex & 0xFF00) >> 8);
+            int b = (int) (hex & 0xFF);
             return new Color(r, g, b);
         }
     }
@@ -129,7 +129,7 @@ public class Color {
             case 6:
                 return of(Integer.parseInt(hex, 16));
             case 8:
-                return of(Integer.parseInt(hex, 16), true);
+                return of(Long.parseLong(hex, 16), true);
             default:
                 throw new IllegalStateException();
         }

--- a/src/test/java/io/github/syst3ms/skriptparser/file/FileParserTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/file/FileParserTest.java
@@ -21,20 +21,19 @@ public class FileParserTest {
         return new FileSection("unit-tests", line, content, Arrays.asList(elements), indentation);
     }
 
-    private List<FileElement> parseLines(FileParser parser, List<String> lines) {
-        return parser.parseFileLines("unit-tests", lines, 0, 1, new SkriptLogger());
+    private List<FileElement> parseLines(List<String> lines) {
+        return FileParser.parseFileLines("unit-tests", lines, 0, 1, new SkriptLogger());
     }
 
     @Test
     public void parseFileLines() {
-        FileParser parser = new FileParser();
         assertEquals(
             Collections.singletonList(simpleFileLine("line", 0, 1)),
-            parseLines(parser, Collections.singletonList("line"))
+            parseLines(Collections.singletonList("line"))
         );
         assertEquals(
             Collections.singletonList(fileSection("section", 0, 1)),
-            parseLines(parser, Collections.singletonList("section:"))
+            parseLines(Collections.singletonList("section:"))
         );
         assertEquals(
             Collections.singletonList(
@@ -45,7 +44,7 @@ public class FileParserTest {
                     simpleFileLine("element", 1, 2)
                 )
             ),
-            parseLines(parser, Arrays.asList("section with element:", "\telement"))
+            parseLines(Arrays.asList("section with element:", "\telement"))
         );
         List<FileElement> expected = Arrays.asList(
             simpleFileLine("nested sections", 0, 1),
@@ -63,8 +62,7 @@ public class FileParserTest {
         );
         assertEquals(
             expected,
-            parseLines(parser,
-                Arrays.asList(
+            parseLines(Arrays.asList(
                     "nested sections",
                     "section:",
                     "\tother section:",
@@ -84,7 +82,6 @@ public class FileParserTest {
         assertEquals(
             expected,
             parseLines(
-                parser,
                 Arrays.asList(
                     "elements after section",
                     "section:",
@@ -95,11 +92,11 @@ public class FileParserTest {
         );
         assertEquals(
             Collections.singletonList(simpleFileLine("code", 0, 1)),
-            parseLines(parser, Collections.singletonList("code # comment"))
+            parseLines(Collections.singletonList("code # comment"))
         );
         assertEquals(
             Collections.singletonList(simpleFileLine("code # not comment", 0, 1)),
-            parseLines(parser, Collections.singletonList("code ## not comment"))
+            parseLines(Collections.singletonList("code ## not comment"))
         );
     }
 

--- a/src/test/resources/expressions/ExprBooleanOperators.txt
+++ b/src/test/resources/expressions/ExprBooleanOperators.txt
@@ -21,19 +21,19 @@ test:
 	assert {list::8} is false with "{list::8} should be false: %{list::8}%"
 
 	# These will be used when #83 is successfully pushed
-#	 set {list::1} to true or true
-#	 set {list::2} to true or false
-#	 set {list::3} to false or true
-#	 set {list::4} to false or false
-#	 set {list::5} to true and true
-#	 set {list::6} to true and false
-#	 set {list::7} to false and true
-#	 set {list::8} to false and false
-#	 assert {list::1} is true with "{list::1} should be true: %{list::1}%"
-#	 assert {list::2} is true with "{list::2} should be true: %{list::2}%"
-#	 assert {list::3} is true with "{list::3} should be true: %{list::3}%"
-#	 assert {list::4} is false with "{list::4} should be false: %{list::4}%"
-#	 assert {list::5} is true with "{list::5} should be true: %{list::5}%"
-#	 assert {list::6} is false with "{list::6} should be false: %{list::6}%"
-#	 assert {list::7} is false with "{list::7} should be false: %{list::7}%"
-#	 assert {list::8} is false with "{list::8} should be false: %{list::8}%"
+	set {list::1} to true or true
+	set {list::2} to true or false
+	set {list::3} to false or true
+	set {list::4} to false or false
+	set {list::5} to true and true
+	set {list::6} to true and false
+	set {list::7} to false and true
+	set {list::8} to false and false
+	assert {list::1} is true with "{list::1} should be true: %{list::1}%"
+	assert {list::2} is true with "{list::2} should be true: %{list::2}%"
+	assert {list::3} is true with "{list::3} should be true: %{list::3}%"
+	assert {list::4} is false with "{list::4} should be false: %{list::4}%"
+	assert {list::5} is true with "{list::5} should be true: %{list::5}%"
+	assert {list::6} is false with "{list::6} should be false: %{list::6}%"
+	assert {list::7} is false with "{list::7} should be false: %{list::7}%"
+	assert {list::8} is false with "{list::8} should be false: %{list::8}%"

--- a/src/test/resources/expressions/ExprColorFromHex.txt
+++ b/src/test/resources/expressions/ExprColorFromHex.txt
@@ -1,0 +1,11 @@
+# Author(s):
+# 	- Mwexim
+# Date: 2021/02/06
+
+test:
+	set {var} to color from hex "#f00" # This will not create any issues.
+	assert {var} = red with "Color should equal red (%red%): %{var}%"
+
+	set {var} to color from hex "#ffff0000"
+	set {var2} to color from rgb (red value of yellow, green value of yellow, blue value of yellow and 0)
+	assert {var} = {var2} with "Colors should be equal: %{var}% != %{var2}%"

--- a/src/test/resources/expressions/ExprColorFromRGB.txt
+++ b/src/test/resources/expressions/ExprColorFromRGB.txt
@@ -3,5 +3,8 @@
 # Date: 2020/12/22
 
 test:
-	set {var} to color from rgb 169, 3, 252
-	assert {var} = &a903fc with "Colors do not match: %{var}% != %&a903fc%"
+	set {var} to color from rgb (169, 3 and 252)
+	assert {var} = color from hex "a903fc" with "Colors do not match: %{var}% != a903fc"
+
+	set {var} to color from rgb (72, 184, 35 and 103)
+	assert {var} = color from hex "48b82367" with "Colors do not match: %{var}% != 48b82367"

--- a/src/test/resources/expressions/ExprColorValues.txt
+++ b/src/test/resources/expressions/ExprColorValues.txt
@@ -3,8 +3,9 @@
 # Date: 2020/12/22
 
 test:
-	set {var} to &a903fc
-	assert rgb of {var} = 169, 3, 252 with "RGB value should be 169, 3, 252: %rgb of {var}%"
+	set {var} to color from hex "a903fc"
+	assert rgb of {var} = 169, 3 and 252 with "RGB value should be 169, 3 and 252: %rgb of {var}%"
+	assert rgba of {var} = 169, 3, 252 and 255 with "RGBA value should be 169, 3, 252 and 255: %rgba of {var}%"
 	assert red value of {var} = 169 with "Red value should be 169: %red value of {var}%"
-	assert green value of {var} = 3 with "Red value should be 3: %green value of {var}%"
-	assert blue value of {var} = 252 with "Red value should be 252: %blue value of {var}%"
+	assert green value of {var} = 3 with "Green value should be 3: %green value of {var}%"
+	assert blue value of {var} = 252 with "Blue value should be 252: %blue value of {var}%"

--- a/src/test/resources/general/comments.txt
+++ b/src/test/resources/general/comments.txt
@@ -1,0 +1,12 @@
+# Author(s):
+# 	- Mwexim
+# Date: 2021/02/06
+
+test:
+	# These are some general tests on comments, since their parsing behavior changed in the last commit.
+	# Comments will probably be merged with multiline syntax to operate in one single structure (planned for 0.2)
+	throws #ff0000 # It's a color.
+	throws "##BlackLivesMatter" = "#BlackLivesMatter"
+
+	throws true ###= false
+	assert true # ##= false


### PR DESCRIPTION
This pull request aims to fix the mess I added in #82. The syntax was odd, the behaviour not flexible enough and overall the features were limited.
- Removed the literal parsing for hex colours. You'll need to write `color from hex "ff0000"` instead of `&ff0000`
- Rewrote the comment parsing mechanism and made sure you can now use color codes together with hashtags.
   - For example: `color from hex "#ffff00"` would've thrown an error previously, but now it doesn't because the hashtag is followed by a valid colour code. This seems very unnecessary now, but I am planning to add some tag syntax for colours in the future that could use this.
   - Other behaviour remains the same.
- Added support for the 'alpha' value in RGBA (transparency).
- Added support for 3-digit hex values (and 8-digit hex values as well).
- Changed the ExprColorFromRGB pattern to take in a list of integers. I feel this is a lot more intuitive than the other pattern.
- Made FileParser#parseFileLines static (why was this not the case?)
- Fixed some tests

I am planning to release a notable design update for 0.2, which will merge the parsing of multiline tokens and comments into one structure.