### PR TITLE
Fix/tag fix

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/file/FileParser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/file/FileParser.java
@@ -92,7 +92,7 @@ public class FileParser {
      */
     @Nullable
     private static String removeComments(String string) {
-        if (string.matches("^[\\s\\t]*#[^#]+") || string.equals("#") || string.isBlank()) {
+        if (string.matches("^[\\s\\t]*#[^#]+") || string.startsWith("#") || string.isBlank()) {
             return ""; // Whole string is a comment
         }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
@@ -105,7 +105,8 @@ public class VariableString extends TaggedExpression {
                 i += content.get().length() + 1;
             } else if (c == '<') {
                 if (i == charArray.length - 1) {
-                    return Optional.empty();
+                    sb.append(c);
+                    break;
                 }
                 var content = StringUtils.getBracketContent(s, i + 1, '>');
                 if (content.isEmpty()) {

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
@@ -1,7 +1,6 @@
 package io.github.syst3ms.skriptparser.lang;
 
 import io.github.syst3ms.skriptparser.lang.base.TaggedExpression;
-import io.github.syst3ms.skriptparser.log.ErrorType;
 import io.github.syst3ms.skriptparser.log.SkriptLogger;
 import io.github.syst3ms.skriptparser.parsing.ParseContext;
 import io.github.syst3ms.skriptparser.parsing.ParserState;
@@ -19,14 +18,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 /**
  * A string that possibly contains expressions inside it, meaning that its value may be unknown at parse time
  */
 @SuppressWarnings("ConfusingArgumentToVarargsMethod")
 public class VariableString extends TaggedExpression {
-    public static final Pattern R_LITERAL_CONTENT_PATTERN = Pattern.compile("^(.+?)\\((.+)\\)\\1$"); // It's actually rare to be able to use '.+' raw like this
     /**
      * An array containing raw data for this {@link VariableString}.
      * Contains {@link String} and {@link Expression} elements
@@ -56,17 +53,9 @@ public class VariableString extends TaggedExpression {
         if (s.startsWith("\"") && s.endsWith("\"") && StringUtils.nextSimpleCharacterIndex(s, 0) == s.length()) {
             return newInstance(s.substring(1, s.length() - 1), parserState, logger);
         } else if (s.startsWith("'") && s.endsWith("'") && StringUtils.nextSimpleCharacterIndex(s, 0) == s.length()) {
-            return Optional.of(new VariableString(new String[]{
-                    s.substring(1, s.length() - 1).replace("\\'", "'")
+            return Optional.of(new VariableString(new String[] {
+                    s.substring(1, s.length() - 1).replace("\\\"", "\"")
             }));
-        } else if (s.startsWith("R\"") && s.endsWith("\"")) {
-            var content = s.substring(2, s.length() - 1);
-            var m = R_LITERAL_CONTENT_PATTERN.matcher(content);
-            if (m.matches()) {
-                return Optional.of(new VariableString(new String[]{m.group(2)}));
-            } else {
-                logger.error("Invalid R literal string", ErrorType.MALFORMED_INPUT);
-            }
         }
         return Optional.empty();
     }
@@ -141,7 +130,7 @@ public class VariableString extends TaggedExpression {
                         sb.append('\t');
                         break;
                     default:
-                        sb.append(c);
+                        sb.append(next);
                 }
             } else if (c == '&') {
                 if (i == charArray.length - 1) {

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
@@ -125,7 +125,7 @@ public class VariableString extends TaggedExpression {
                 data.add(tag.get());
                 i += content.get().length() + ">".length();
             } else if (c == '\\') {
-                if (i + 1 == charArray.length) {
+                if (i == charArray.length - 1) {
                     return Optional.empty();
                 }
                 char next = charArray[++i];
@@ -140,8 +140,17 @@ public class VariableString extends TaggedExpression {
                         sb.append(c);
                 }
             } else if (c == '&') {
+                if (i == charArray.length - 1) {
+                    sb.append(c);
+                    break;
+                }
+                char next = charArray[++i];
+                if (Character.isWhitespace(next)) {
+                    sb.append(c).append(next);
+                    continue;
+                }
                 logger.recurse();
-                var tag = TagManager.parseTag(String.valueOf(charArray[++i]), logger);
+                var tag = TagManager.parseTag(String.valueOf(next), logger);
                 logger.callback();
                 if (tag.isEmpty()) {
                     return Optional.empty();

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/VariableString.java
@@ -87,6 +87,9 @@ public class VariableString extends TaggedExpression {
             if (c == '%') {
                 if (i == charArray.length - 1) {
                     return Optional.empty();
+                } else if (charArray[i + 1] == '%') {
+                    sb.append(charArray[++i]);
+                    continue;
                 }
                 var content = StringUtils.getPercentContent(s, i + 1);
                 var toParse = content.map(co -> co.replaceAll("\\\\(.)", "$1"));

--- a/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
@@ -103,16 +103,6 @@ public class StringUtils {
                 if (closing == -1)
                     return -1;
                 i = closing;
-            } else if (c == '\'') {
-                var closing = s.indexOf('\'', i + 1);
-                if (closing == -1)
-                    return -1;
-                i = closing;
-            } else if (c == 'R' && i < s.length() - 2 && chars[i + 1] == '"') {
-                var m = R_LITERAL_CONTENT_PATTERN.matcher(s).region(i + 2, s.length());
-                if (!m.lookingAt())
-                    return -1;
-                i = m.end() + 1;
             } else {
                 return i;
             }

--- a/src/test/java/io/github/syst3ms/skriptparser/log/SkriptLoggerTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/log/SkriptLoggerTest.java
@@ -27,7 +27,7 @@ public class SkriptLoggerTest {
         logger.finalizeLogs();
         assertTrue(wrongNumber.isEmpty() && logger.close().get(0).getMessage().startsWith("A single"));
         logger = new SkriptLogger();
-        Optional<? extends Expression<Boolean>> wrongRange = SyntaxParser.parseBooleanExpression("1 is between 'a' and 'b'", SyntaxParser.MAYBE_CONDITIONAL, parserState, logger);
+        Optional<? extends Expression<Boolean>> wrongRange = SyntaxParser.parseBooleanExpression("1 is between \"a\" and \"b\"", SyntaxParser.MAYBE_CONDITIONAL, parserState, logger);
         logger.finalizeLogs();
         assertTrue(wrongRange.isEmpty() && logger.close().get(0).getMessage().startsWith("'1' cannot"));
     }

--- a/src/test/resources/general/tags.txt
+++ b/src/test/resources/general/tags.txt
@@ -1,6 +1,8 @@
 # Author(s):
 # 	- Mwexim
-# Date: 2020/12/05
+# Date(s):
+#	- 2020/12/05
+#	- 2021/03/07 (issue #99)
 
 test:
 	# These are some general tests on tags, to test if they combine correctly into a string.
@@ -8,3 +10,8 @@ test:
 	set {var} to "He<case=upper>llo, <tab>my <reset>name i<case=lower><break>s MWEXIM A&rND I am the creator of this test."
 	set {var2} to "HeLLO, 	MY name i\ns mwexim aND I am the creator of this test."
 	assert {var} = {var2} with "Multiple tags didn't combine correctly: {var} (%{var}%) != %{var2}%"
+
+	# Issue #99
+	set {list::*} to "Hello", "&" and "World!"
+	set {var3} to join {list::*} with " "
+	assert "Hello & World!" = {var3} with "{list::*} joined by space should be 'Hello & World!': %{var3}%"

--- a/src/test/resources/general/tags.txt
+++ b/src/test/resources/general/tags.txt
@@ -2,7 +2,7 @@
 # 	- Mwexim
 # Date(s):
 #	- 2020/12/05
-#	- 2021/03/07 (issue #99)
+#	- 2021/03/07 (issue #99 and #100)
 
 test:
 	# These are some general tests on tags, to test if they combine correctly into a string.
@@ -11,7 +11,8 @@ test:
 	set {var2} to "HeLLO, 	MY name i\ns mwexim aND I am the creator of this test."
 	assert {var} = {var2} with "Multiple tags didn't combine correctly: {var} (%{var}%) != %{var2}%"
 
-	# Issue #99
+	# Issue #99 and #100
 	set {list::*} to "Hello", "&" and "World!"
 	set {var3} to join {list::*} with " "
 	assert "Hello & World!" = {var3} with "{list::*} joined by space should be 'Hello & World!': %{var3}%"
+	compiles "<"

--- a/src/test/resources/general/tags.txt
+++ b/src/test/resources/general/tags.txt
@@ -16,3 +16,4 @@ test:
 	set {var3} to join {list::*} with " "
 	assert "Hello & World!" = {var3} with "{list::*} joined by space should be 'Hello & World!': %{var3}%"
 	compiles "<"
+	compiles "70%% of the human body is made out of water."

--- a/src/test/resources/literals/String.txt
+++ b/src/test/resources/literals/String.txt
@@ -1,12 +1,14 @@
 # Author(s):
 # 	- Mwexim
-# Date: 2020/11/07
+# Date(s):
+#	- 2020/11/07
+#	- 2021/03/07 (R-string removal)
 
 test:
 	set {var} to "Hello World"
 	assert length of {var} = 11 with "length of {var} didn't work: %length of {var}% != 11"
 
-	set {var2} to R"something(Hello World)something" # R-literal strings will probably be removed in 0.2
-	assert {var} = {var2}
+	set {var2} to 'I can put &here <whatever> I like%!'
+	assert {var2} = "I can put \&here \<whatever> I like%%!"
 
 	assert "Hello \tWorld!" = "Hello 	World!" with "'\t'-character did not work."

--- a/src/test/resources/literals/String.txt
+++ b/src/test/resources/literals/String.txt
@@ -1,12 +1,14 @@
 # Author(s):
 # 	- Mwexim
-# Date: 2020/11/07
+# Date(s):
+#	- 2020/11/07
+#	- 2021/03/07 (R-string removal)
 
 test:
 	set {var} to "Hello World"
 	assert length of {var} = 11 with "length of {var} didn't work: %length of {var}% != 11"
 
-	set {var2} to R"something(Hello World)something" # R-literal strings will probably be removed in 0.2
-	assert {var} = {var2}
+	set {var2} to r"I can put &here <whatever> I like%!"
+	assert {var2} = "I can put \&here \<whatever> I like%%!"
 
 	assert "Hello \tWorld!" = "Hello 	World!" with "'\t'-character did not work."


### PR DESCRIPTION
Fixes #99 and #100.

- Single-character tags (using the '&'-symbol) will now be ignored if the next character is a space.
- If wide tags (as I call tags such as `<tag>`) cannot be parsed, they will now be added as a normal tag. Also applies if the closing bracket is not found or if the opening bracket is the last character of the string.
- Use double '%'-signs (like "%%") to insert a single '%'. This behaviour may be deleted later, as we already have a backslash to escape special characters.