### PR TITLE
Feature/number conversion

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/effects/EffPrint.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/effects/EffPrint.java
@@ -35,9 +35,6 @@ public class EffPrint extends Effect {
     @Override
     public void execute(TriggerContext ctx) {
         String[] strs = StringUtils.applyTags(string, ctx, "console");
-        if (strs.length == 0)
-            return;
-
         for (String str : strs) {
             System.out.println(str);
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprCompare.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprCompare.java
@@ -241,8 +241,20 @@ public class CondExprCompare extends ConditionalExpression {
         Class<?> s = third == null
                 ? second.getReturnType()
                 : ClassUtils.getCommonSuperclass(second.getReturnType(), third.getReturnType());
-        if (f == Object.class || s == Object.class)
+        if (f == Object.class || s == Object.class) {
             return true;
+        } else if (f != s) {
+            // Tries to convert the instances to each other.
+            // Basically takes expression conversions into account.
+            var converted = Expression.convertPair(first, second);
+            if (!first.equals(converted.getFirst()) || !second.equals(converted.getSecond())) {
+                first = converted.getFirst();
+                second = converted.getSecond();
+                assert Comparators.getComparator(first.getReturnType(), second.getReturnType()).isPresent();
+                comp = (Comparator<Object, Object>) Comparators.getComparator(first.getReturnType(), second.getReturnType()).get();
+                return true;
+            }
+        }
         return (comp = (Comparator<Object, Object>) Comparators.getComparator(f, s).orElse(null)) != null;
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLoopValue.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLoopValue.java
@@ -101,7 +101,7 @@ public class ExprLoopValue extends SectionValue<SecLoop, Object> {
 	@Override
 	public <R> Optional<? extends Expression<R>> convertExpression(Class<R> to) {
 		if (isVariableLoop && !isIndex) {
-			return Optional.of(new ConvertedExpression<>(this, (Class<R>) ClassUtils.getCommonSuperclass(to), o -> Converters.convert(o, to)));
+			return Optional.of(ConvertedExpression.newInstance(this, (Class<R>) ClassUtils.getCommonSuperclass(to), o -> Converters.convert(o, to)));
 		} else {
 			return super.convertExpression(to);
 		}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprNumberConvertBase.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprNumberConvertBase.java
@@ -32,10 +32,6 @@ public class ExprNumberConvertBase implements Expression<String> {
 				false,
 				"%integers% [converted] to (0:binary|1:octal|2:hex[adecimal]|3:base[ ]64|4:base %integer%)",
 				"(0:binary|1:octal|2:hex[adecimal]|3:base[ ]64) %strings% [converted] to (0:binary|8:octal|16:hex[adecimal]|24:base[ ]64|32:base %integer%|40:decimal)"
-//				"binary %strings% [converted] to (1:octal|2:hex[adecimal]|3:base[ ]64|4:base %integer%|5:decimal)",
-//				"octal %strings% [converted] to (0:binary|2:hex[adecimal]|3:base[ ]64|4:base %integer%|5:decimal)",
-//				"hex[adecimal] %strings% [converted] to (0:binary|1:octal|3:base[ ]64|4:base %integer%|5:decimal)",
-//				"base[ ]64 %strings% [converted] to (0:binary|1:octal|2:hex[adecimal]|4:base %integer%|5:decimal)"
 		);
 	}
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprNumberConvertBase.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprNumberConvertBase.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 
 /**
  * Convert a number to a different base (like binary, octal or hexadecimal) or convert a string to its decimal form.
+ * You can specify a custom base, but it can only range from 2 to 36. Values outside of this range, or invalid string
+ * representations will result in an empty list.
  * @name Number Convert Base
  * @type EXPRESSION
  * @pattern %integers% [converted] to (binary|octal|hex[adecimal]|base[ ]64|base %integer%)

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprNumberConvertBase.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprNumberConvertBase.java
@@ -1,0 +1,173 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.util.Pair;
+import org.jetbrains.annotations.Nullable;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Convert a number to a different base (like binary, octal or hexadecimal) or convert a string to its decimal form.
+ * @name Number Convert Base
+ * @type EXPRESSION
+ * @pattern %integers% converted [in]to (binary|octal|hex[adecimal]|base64|base %integer%)
+ * @pattern %strings% converted [in]to (binary|octal|hex[adecimal]|base64|base %integer%|5:decimal)
+ * @since ALPHA
+ * @author Mwexim, WeeskyBDW
+ */
+public class ExprNumberConvertBase implements Expression<String> {
+	static {
+		Parser.getMainRegistration().addExpression(
+				ExprNumberConvertBase.class,
+				String.class,
+				true,
+				"%integers% converted [in]to (0:binary|1:octal|2:hex[adecimal]|3:base[ ]64|4:base %integer%)",
+				"%strings% converted [in]to (0:binary|1:octal|2:hex[adecimal]|3:base[ ]64|4:base %integer%|5:decimal)"
+		);
+	}
+
+	private Expression<?> expression;
+	@Nullable
+	private Expression<BigInteger> base;
+	private int parseMark;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+		parseMark = parseContext.getParseMark();
+
+		expression = expressions[0];
+		if (parseMark == 4) {
+			base = (Expression<BigInteger>) expressions[1];
+		}
+		return true;
+	}
+
+	@Override
+	public String[] getValues(TriggerContext ctx) {
+		int radix = 10; // Let's default it to 10 for convenience
+		switch (parseMark) {
+			case 0:
+				radix = 2;
+				break;
+			case 1:
+				radix = 8;
+				break;
+			case 2:
+				radix = 16;
+				break;
+			case 4:
+				assert base != null;
+				radix = base.getSingle(ctx).map(BigInteger::intValue).orElse(10);
+				break;
+			case 3:
+			case 5:
+				break; // Handled separately
+			default:
+				throw new IllegalStateException();
+		}
+		if (radix < Character.MIN_RADIX || radix > Character.MAX_RADIX)
+			return new String[0];
+
+		int finalRadix = radix;
+		return Arrays.stream(expression.getValues(ctx))
+				.map(val -> {
+					if (val instanceof BigInteger) {
+						return parseMark == 3
+								? Base64.getEncoder().encodeToString(((BigInteger) val).toByteArray())
+								: ((BigInteger) val).toString(finalRadix);
+					} else {
+						assert val instanceof String;
+
+						var originalRadix = radixFromString((String) val);
+						if (originalRadix.getFirst() == -1)
+							return null;
+
+						var converted = BigInteger.valueOf(
+								parseMark == 3
+								? bytesToLong(Base64.getDecoder().decode((String) val))
+								: Long.parseLong(
+										((String) val).substring(originalRadix.getSecond() + 1),
+										originalRadix.getFirst()
+								)
+						);
+						return converted.toString(finalRadix);
+					}
+				})
+				.filter(Objects::nonNull)
+				.toArray(String[]::new);
+	}
+
+	@Override
+	public String toString(TriggerContext ctx, boolean debug) {
+		switch (parseMark) {
+			case 0:
+				return expression.toString(ctx, debug) + " converted to binary";
+			case 1:
+				return expression.toString(ctx, debug) + " converted to octal";
+			case 2:
+				return expression.toString(ctx, debug) + " converted to hexadecimal";
+			case 3:
+				return expression.toString(ctx, debug) + " converted to base 64";
+			case 4:
+				assert base != null;
+				return expression.toString(ctx, debug) + " converted to base " + base.toString(ctx, debug);
+			case 5:
+				return expression.toString(ctx, debug) + " converted to decimal";
+			default:
+				throw new IllegalStateException();
+		}
+	}
+
+	/**
+	 * Get the radix of a given string that represents a number. Prefixes are accounted for.
+	 * If no prefixes were found, base 10 (decimal) is chosen as primary base, unless this fails too.
+	 * @param str the string
+	 * @return the radix, -1 if the string does not represent a number and the last index of the string that should not be parsed
+	 */
+	private static Pair<Integer, Integer> radixFromString(String str) {
+		str = str.toLowerCase();
+
+		// First check prefixes
+		if (str.startsWith("0b") || str.startsWith("b")) {
+			return new Pair<>(2, str.indexOf('b'));
+		} else if (str.startsWith("0o") || str.startsWith("o")) {
+			return new Pair<>(8, str.indexOf('o'));
+		} else if (str.startsWith("0x") || str.startsWith("x")) {
+			return new Pair<>(16, str.indexOf('x'));
+		}
+
+		// Then check for base 10
+		try {
+			Integer.parseInt(str, 10);
+			return new Pair<>(10, -1);
+		} catch (NumberFormatException ignored) { /* Nothing */ }
+
+		// Then check radix from lowest to highest.
+		for (int i = Character.MIN_RADIX; i <= Character.MAX_RADIX; i++) {
+			if (i == 10)
+				continue;
+
+			try {
+				Integer.parseInt(str, i);
+				return new Pair<>(i, -1);
+			} catch (NumberFormatException ignored) { /* Nothing */ }
+		}
+		return new Pair<>(-1, -1);
+	}
+
+	private static long bytesToLong(byte[] bytes) {
+		long result = 0;
+		for (int i = 0; i < 8; i++) {
+			result <<= 8;
+			result |= (bytes[i] & 0xFF);
+		}
+		return result;
+	}
+}

--- a/src/test/java/io/github/syst3ms/skriptparser/parsing/SyntaxParserTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/parsing/SyntaxParserTest.java
@@ -13,13 +13,26 @@ import org.junit.runners.model.MultipleFailureException;
 
 import java.io.File;
 import java.net.URL;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class SyntaxParserTest {
     static {
         TestRegistration.register();
     }
+
+    /**
+     * Amount of milliseconds a test can take at most before failing.
+     */
+    private static final int TEST_TIMEOUT = 10_000;
 
     private static final List<Throwable> errorsFound = new ArrayList<>();
 
@@ -40,7 +53,7 @@ public class SyntaxParserTest {
                             future = executor.submit(() -> ScriptLoader.loadScript(file.toPath(), true));
                             List<LogEntry> logs;
                             try {
-                                logs = future.get(10, TimeUnit.SECONDS);
+                                logs = future.get(TEST_TIMEOUT, TimeUnit.MILLISECONDS);
                                 logs.removeIf(log -> log.getType() != LogType.ERROR);
 
                                 if (!logs.isEmpty()) {

--- a/src/test/resources/expressions/ExprNumberConvertBase.txt
+++ b/src/test/resources/expressions/ExprNumberConvertBase.txt
@@ -1,0 +1,28 @@
+# Author(s):
+# 	- Mwexim
+# Date: 2021/03/30
+
+test:
+	# All tests were made using these tools:
+	# - https://v2.cryptii.com/ (normal conversions)
+	# - https://jalu.ch/coding/base_converter.php (custom base conversions)
+
+	set {var} to 5732
+	assert {var} converted to binary = "1011001100100" with "{var} as binary should be '1011001100100': %{var} converted to binary%"
+	assert {var} to octal = "13144" with "{var} to octal should be '13144': %{var} to octal%"
+	assert {var} converted to hex = "1664" with "{var} to hex should be '1664': %{var} converted to hex%"
+	assert {var} to base64 = "FmQ=" with "{var} to base64 should be 'FmQ=': %{var} to base64%"
+	assert {var} to base 13 = "27bc" with "{var} to base 13 should be '27bc': %{var} to base 13%"
+
+	set {var} to "13144" # from decimal 5732
+	assert octal {var} converted to hex = "1664" with "octal {var} to hex should be '1664': %octal {var} converted to hex%"
+	assert octal {var} converted to base64 = "FmQ=" with "octal {var} to base64 should be 'FmQ=': %octal {var} converted to base64%"
+	assert octal {var} converted to base 19 = "fgd" with "octal {var} to hex should be 'fgd': %octal {var} converted to base 19%"
+
+	set {var} to "IKA=" # from decimal 8352
+	assert base64 {var} to decimal = "8352" with "base64 {var} to decimal should be '8352': %base64 {var} to decimal%"
+	assert base64 {var} to binary = "10000010100000" with "base64 {var} to binary should be '10000010100000': %base64 {var} to binary%"
+
+	set {var} to "101"
+	assert binary {var} converted to decimal = "5" with "binary {var} to decimal should '5': %binary {var} converted to decimal%"
+	assert binary {var} converted to decimal = 5 with "binary {var} to decimal should be 5 (integer): %binary {var} converted to decimal%"


### PR DESCRIPTION
This features number conversion.
- Any integer can be converted to binary/octal/hex/base64 or even to a custom base (max 36)
- On top of that, strings can be converted to the same instances if the user specifies which base (or radix) the string is using (so no automatic detection for that).
- If the outcome is a decimal, it is convertible to a BigInteger for easier usage.
- Supports lists

Note that this last thing only has any usage in CondExprCompare, because I specifically changed the code to support it. `Expression#convertExpression(Class<T> to)` is in no way useful as of now, because Comparators and Converters are solely Class-based. I will change this behaviour in the future to allow a more 'elegant' conversion.