### PR TITLE
Feature/regex syntax

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/Skript.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/Skript.java
@@ -11,7 +11,6 @@ import io.github.syst3ms.skriptparser.event.WhenContext;
 import io.github.syst3ms.skriptparser.lang.SkriptEvent;
 import io.github.syst3ms.skriptparser.lang.Statement;
 import io.github.syst3ms.skriptparser.lang.Trigger;
-import io.github.syst3ms.skriptparser.lang.base.ExecutableExpression;
 import io.github.syst3ms.skriptparser.registration.SkriptAddon;
 import io.github.syst3ms.skriptparser.util.ThreadUtils;
 import io.github.syst3ms.skriptparser.util.Time;
@@ -77,10 +76,5 @@ public class Skript extends SkriptAddon {
                     : Time.now().difference(time));
             ThreadUtils.runPeriodically(() -> Statement.runAll(trigger, ctx), initialDelay, Duration.ofDays(1));
         }
-    }
-
-    @Override
-    public void walkingForward() {
-        ExecutableExpression.getCachedValues().clear();
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprContains.java
@@ -15,7 +15,7 @@ import java.util.Optional;
  *
  * @name Contain
  * @type CONDITION
- * @pattern %string% [does(n't| not)] contains %string%
+ * @pattern %string% [does(n't| not)] contain[s] %string%
  * @pattern %objects% [do[es](n't| not)] contain[s] %object%
  * @since ALPHA
  * @author Mwexim

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprMatch.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprMatch.java
@@ -1,0 +1,97 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.lang.base.ConditionalExpression;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+/**
+ * Check if a given date is a certain duration before or after the current date.
+ *
+ * @name Match
+ * @type CONDITION
+ * @pattern %strings% [do[es](n't| not)] [part[ial]ly] match[es] %strings%
+ * @since ALPHA
+ * @author Mwexim
+ */
+public class CondExprMatch extends ConditionalExpression {
+    static {
+        Parser.getMainRegistration().addExpression(
+                CondExprMatch.class,
+                Boolean.class,
+                true,
+                "%strings% [1:do[es](n't| not)] [2:part[ial]ly] match[es] %strings%"
+        );
+    }
+
+    private Expression<String> matched;
+    private Expression<String> pattern;
+    private boolean partly;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+        matched = (Expression<String>) expressions[0];
+        pattern = (Expression<String>) expressions[1];
+        // 1 = negated, 2 = partially, 3 = negated and partially
+        setNegated(parseContext.getParseMark() == 1 || parseContext.getParseMark() == 3);
+        partly = parseContext.getParseMark() == 2 || parseContext.getParseMark() == 3;
+        return true;
+    }
+
+    @Override
+    public boolean check(TriggerContext ctx) {
+        String[] matchedValues = matched.getValues(ctx);
+        String[] patternValues = pattern.getValues(ctx);
+        boolean matchedAnd = matched.isAndList();
+        boolean patternAnd = pattern.isAndList();
+
+        boolean result;
+        if (matchedAnd) {
+            if (patternAnd) {
+                result = Arrays.stream(matchedValues)
+                        .allMatch(val -> Arrays.stream(patternValues)
+                                .parallel()
+                                .map(Pattern::compile)
+                                .allMatch(pattern -> matches(val, pattern, partly)));
+            } else {
+                result = Arrays.stream(matchedValues)
+                        .allMatch(val -> Arrays.stream(patternValues)
+                                .parallel()
+                                .map(Pattern::compile)
+                                .anyMatch(pattern -> matches(val, pattern, partly)));
+            }
+        } else {
+            if (patternAnd) {
+                result = Arrays.stream(matchedValues)
+                        .anyMatch(val -> Arrays.stream(patternValues)
+                                .parallel().map(Pattern::compile)
+                                .allMatch(pattern -> matches(val, pattern, partly)));
+            } else {
+                result = Arrays.stream(matchedValues)
+                        .anyMatch(val -> Arrays.stream(patternValues)
+                                .parallel()
+                                .map(Pattern::compile)
+                                .anyMatch(pattern -> matches(val, pattern, partly)));
+            }
+        }
+        return isNegated() != result;
+    }
+
+    @Override
+    public String toString(TriggerContext ctx, boolean debug) {
+        return matched.toString(ctx, debug)
+                + (isNegated() ? " does not" : "")
+                + (partly ? " partially" : "")
+                + (isNegated() ? " match " : " matches ")
+                + pattern.toString(ctx, debug);
+    }
+
+    private static boolean matches(String value, Pattern pattern, boolean partly) {
+        return partly ? pattern.matcher(value).find() : value.matches(pattern.pattern());
+    }
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprMatch.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprMatch.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.regex.Pattern;
 
 /**
- * Check if a given date is a certain duration before or after the current date.
+ * Check if the given strings match a certain regex expression.
  *
  * @name Match
  * @type CONDITION

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprMatch.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/CondExprMatch.java
@@ -48,7 +48,7 @@ public class CondExprMatch extends ConditionalExpression {
                 matched.getValues(ctx),
                 toMatch -> Expression.check(
                         pattern.getValues(ctx),
-                        val -> matches(toMatch, Pattern.compile(val), partly),
+                        pattern -> partly ? Pattern.compile(pattern).matcher(toMatch).find() : toMatch.matches(pattern),
                         false,
                         pattern.isAndList()
                 ),
@@ -64,9 +64,5 @@ public class CondExprMatch extends ConditionalExpression {
                 + (partly ? " partially" : "")
                 + (isNegated() ? " match " : " matches ")
                 + pattern.toString(ctx, debug);
-    }
-
-    private static boolean matches(String value, Pattern pattern, boolean partly) {
-        return partly ? pattern.matcher(value).find() : value.matches(pattern.pattern());
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExecExprListOperators.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExecExprListOperators.java
@@ -103,7 +103,9 @@ public class ExecExprListOperators extends ExecutableExpression<Object> {
 		var logger = parseContext.getLogger();
 		if (list.acceptsChange(ChangeMode.SET).isEmpty()) {
 			logger.error(
-					list.toString(TriggerContext.DUMMY, logger.isDebug()) + " is constant and cannot be changed",
+					"The expression '"
+							+ list.toString(TriggerContext.DUMMY, logger.isDebug())
+							+ "' cannot be changed",
 					ErrorType.SEMANTIC_ERROR
 			);
 			return false;

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExecExprListOperators.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExecExprListOperators.java
@@ -14,23 +14,24 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 /**
- * Basic list operators with the following behavior:
+ * Basic list operators that return the following elements:
  * <ul>
- *      <li>{@code pop} removes the last element and returns that removed element.</li>
- *      <li>{@code shift/poll} removes the first element and returns that removed element.</li>
- *      <li>{@code extract} removes a specific (or just the first/last element) and returns that removed element</li>
- *      <li>{@code splice} removes elements in a certain bound and returns those removed elements.</li>
+ *      <li>{@code pop}: the last element</li>
+ *      <li>{@code shift/poll}: the first element</li>
+ *      <li>{@code extract}: a specific (or just the first/last) element</li>
+ *      <li>{@code splice}: elements in a certain bound</li>
  * </ul>
- * These are all changing operators, which mean they apply the operator on the source list
- * and return other elements accordingly to the operator type. If the list is not changeable,
- * then these operators will not work.
+ * However, this syntax can also be used as an effect. If this is the case, instead of returning
+ * the elements, specified above, it will <b>remove</b> them from the list, similar to their
+ * JavaScript counter-parts.
+ * <br>
  * Note that indices in Skript start at one and that both the lower and upper bounds are inclusive.
  * The step function can be used in the {@code splice} pattern to skip over certain values. Note that
  * when a negative step function is used, the list is reversed as well as the lower and upper bounds,
  * which means the lower bound must be higher than the upper bound.
  *
  * @name List Operators
- * @type EXPRESSION
+ * @type EFFECT/EXPRESSION
  * @pattern extract [the] (last|first|%integer%(st|nd|rd|th)) element out [of] %objects%
  * @pattern pop %objects%
  * @pattern (shift|poll) %objects%
@@ -118,17 +119,19 @@ public class ExecExprListOperators extends ExecutableExpression<Object> {
 	}
 
 	@Override
-	public Object[] getAppliedValues(TriggerContext ctx) {
+	public Object[] getValues(TriggerContext ctx, boolean isEffect) {
 		var values = list.getValues(ctx);
 		if (values.length == 0)
 			return new Object[0];
 
 		switch (type) {
 			case 0:
-				list.change(ctx, Arrays.copyOfRange(values, 0, values.length - 1), ChangeMode.SET);
+				if (isEffect)
+					list.change(ctx, Arrays.copyOfRange(values, 0, values.length - 1), ChangeMode.SET);
 				return new Object[] {values[values.length - 1]};
 			case 1:
-				list.change(ctx, Arrays.copyOfRange(values, 1, values.length), ChangeMode.SET);
+				if (isEffect)
+					list.change(ctx, Arrays.copyOfRange(values, 1, values.length), ChangeMode.SET);
 				return new Object[] {values[0]};
 			case 2:
 				int ind = index.getSingle(ctx)
@@ -138,14 +141,18 @@ public class ExecExprListOperators extends ExecutableExpression<Object> {
 				if (ind == -1) {
 					return new Object[0];
 				}
-				var skipped = new Object[values.length - 1];
-				for (int i = 0, k = 0; i < values.length; i++) {
-					if (i == ind) {
-						continue;
+
+				// When used as an effect
+				if (isEffect) {
+					var skipped = new Object[values.length - 1];
+					for (int i = 0, k = 0; i < values.length; i++) {
+						if (i == ind) {
+							continue;
+						}
+						skipped[k++] = values[i];
 					}
-					skipped[k++] = values[i];
+					list.change(ctx, skipped, ChangeMode.SET);
 				}
-				list.change(ctx, skipped, ChangeMode.SET);
 				return new Object[] {values[ind]};
 			case 3:
 				var low = lower != null
@@ -166,7 +173,8 @@ public class ExecExprListOperators extends ExecutableExpression<Object> {
 					up = temp + 1;
 				}
 				if (low == -1 || up == -1 || up == 0 || st == 0 || low > up) {
-					list.change(ctx, new Object[0], ChangeMode.SET);
+					if (isEffect)
+						list.change(ctx, new Object[0], ChangeMode.SET);
 					return new Object[0];
 				} else if (low == up) {
 					// Nothing to change
@@ -183,7 +191,8 @@ public class ExecExprListOperators extends ExecutableExpression<Object> {
 					}
 				}
 
-				list.change(ctx, changed.toArray(), ChangeMode.SET);
+				if (isEffect)
+					list.change(ctx, changed.toArray(), ChangeMode.SET);
 				return spliced.toArray(new Object[0]);
 			default:
 				throw new IllegalStateException();

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExecExprReplace.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExecExprReplace.java
@@ -93,17 +93,21 @@ public class ExecExprReplace extends ExecutableExpression<String> {
 				}
 				switch (type) {
 					case 0:
+						// All occurrences
 						replaced = regex
 								? current.replaceAll(match, replacementValue)
 								: current.replace(match, replacementValue);
 						break;
 					case 1:
+						// First occurrence
 						replaced = current.replaceFirst(
 								regex ? match : Pattern.quote(match),
 								replacementValue
 						);
 						break;
 					case 2:
+						// Last occurrence
+						// This regex pattern flushes away as many characters as it can, leaving the last occurrence.
 						Matcher matcher = Pattern.compile(".*(" + match + ")").matcher(current);
 						if (regex && !matcher.matches())
 							continue;

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExecExprReplace.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExecExprReplace.java
@@ -1,0 +1,163 @@
+package io.github.syst3ms.skriptparser.expressions;
+
+import io.github.syst3ms.skriptparser.Parser;
+import io.github.syst3ms.skriptparser.lang.Expression;
+import io.github.syst3ms.skriptparser.lang.TriggerContext;
+import io.github.syst3ms.skriptparser.lang.base.ExecutableExpression;
+import io.github.syst3ms.skriptparser.log.ErrorType;
+import io.github.syst3ms.skriptparser.parsing.ParseContext;
+import io.github.syst3ms.skriptparser.types.changers.ChangeMode;
+import org.jetbrains.annotations.Nullable;
+
+import java.math.BigInteger;
+import java.util.regex.Pattern;
+
+/**
+ * Replaces certain occurrences in a string with another string and returns those applied strings.
+ * If used like an effect, instead of returning the applied strings, specified above, it will
+ * <b>replace</b> them from in the list. Note that not all expressions support this behaviour.
+ * If no valid match was found, nothing will happen.
+ * <br>
+ * Note that indices in Skript start at one.
+ *
+ * @name Replace
+ * @type EFFECT/EXPRESSION
+ * @pattern replace [(all|every|[the] first|[the] last|[the] %integer%(st|nd|rd|th))] %strings% in[side] %strings% with %string%
+ * @pattern replace [(all|every|[the] first|[the] last|[the] %integer%(st|nd|rd|th))] %strings% with %string% in[side] %strings%
+ * @since ALPHA
+ * @author Mwexim
+ * @see ExprElement
+ */
+public class ExecExprReplace extends ExecutableExpression<String> {
+	static {
+		Parser.getMainRegistration().addSelfRegisteringElement(
+				ExecExprReplace.class,
+				String.class,
+				false,
+				"replace [(0:all|0:every|1:[the] first|2:[the] last|3:[the] %integer%(st|nd|rd|th))] %strings% in[side] %strings% with %string%",
+				"replace [(0:all|0:every|1:[the] first|2:[the] last|3:[the] %integer%(st|nd|rd|th))] %strings% with %string% in[side] %strings%"
+		);
+	}
+
+	// 0 = all, 1 = first, 2 = last, 3 = indexed
+	private int type;
+	@Nullable
+	private Expression<BigInteger> index;
+	private Expression<String> toMatch;
+	private Expression<String> toReplace;
+	private Expression<String> replacement;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, ParseContext parseContext) {
+		type = parseContext.getParseMark();
+		switch (type) {
+			case 0:
+			case 1:
+			case 2:
+				toMatch = (Expression<String>) expressions[0];
+				toReplace = (Expression<String>) expressions[1 + matchedPattern];
+				replacement = (Expression<String>) expressions[2 - matchedPattern];
+				break;
+			case 3:
+				index = (Expression<BigInteger>) expressions[0];
+				toMatch = (Expression<String>) expressions[1];
+				toReplace = (Expression<String>) expressions[2 + matchedPattern];
+				replacement = (Expression<String>) expressions[3 - matchedPattern];
+				break;
+			default:
+				throw new IllegalStateException();
+		}
+		if (!toReplace.acceptsChange(ChangeMode.SET, String[].class)) {
+			var logger = parseContext.getLogger();
+			logger.error(
+					"The expression '"
+							+ toReplace.toString(TriggerContext.DUMMY, logger.isDebug())
+							+ "' cannot be changed",
+					ErrorType.SEMANTIC_ERROR
+			);
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String[] getValues(TriggerContext ctx, boolean isEffect) {
+		String[] replacedValues = toReplace.getValues(ctx);
+		String[] matchedValues = toMatch.getValues(ctx);
+		String replacementValue = replacement.getSingle(ctx).orElse(null);
+		if (replacementValue == null) {
+			return replacedValues;
+		} else if (type == 4) {
+			assert index != null;
+			if (index.getSingle(ctx).orElse(null) == null)
+				return replacedValues;
+		}
+
+		for (int i = 0; i < replacedValues.length; i++) {
+			for (String match : matchedValues) {
+				String replaced;
+				switch (type) {
+					case 0:
+						replaced = replacedValues[i].replace(match, replacementValue);
+						break;
+					case 1:
+						replaced = replacedValues[i].replaceFirst(Pattern.quote(match), replacementValue);
+						break;
+					case 2:
+						int lastIndex = replacedValues[i].lastIndexOf(match);
+						if (lastIndex < 0 || lastIndex >= replacedValues[i].length())
+							continue;
+
+						int limitIndex = lastIndex + replacedValues[i].length();
+						replaced = replacedValues[i].substring(0, lastIndex)
+								+ replacementValue
+								+ (limitIndex < replacedValues[i].length() ? replacedValues[i].substring(limitIndex) : "");
+						break;
+					case 3:
+						assert index != null;
+						int index = this.index.getSingle(ctx).map(BigInteger::intValue).orElseThrow(AssertionError::new);
+						if (index < 0 || index >= replacedValues[i].length())
+							continue;
+
+						limitIndex = index + replacedValues[i].length();
+						replaced = replacedValues[i].substring(0, index)
+								+ replacementValue
+								+ (limitIndex < replacedValues[i].length() ? replacedValues[i].substring(index + replacedValues[i].length()) : "");
+						break;
+					default:
+						throw new IllegalStateException();
+				}
+				replacedValues[i] = replaced;
+			}
+		}
+		if (isEffect)
+			toReplace.change(ctx, replacedValues, ChangeMode.SET);
+		return replacedValues;
+	}
+
+	@Override
+	public String toString(TriggerContext ctx, boolean debug) {
+		String typeString;
+		switch (type) {
+			case 0:
+				typeString = "all ";
+				break;
+			case 1:
+				typeString = "first ";
+				break;
+			case 2:
+				typeString = "last ";
+				break;
+			case 3:
+				assert index != null;
+				typeString = "occurrence number " + index.toString(ctx, debug) + " ";
+				break;
+			default:
+				throw new IllegalStateException();
+		}
+		return "replace " + typeString + toMatch.toString(ctx, debug)
+				+ " in " + toReplace.toString(ctx, debug)
+				+ " with " + replacement.toString(ctx, debug);
+	}
+}

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExecExprReplace.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExecExprReplace.java
@@ -96,34 +96,37 @@ public class ExecExprReplace extends ExecutableExpression<String> {
 
 		for (int i = 0; i < replacedValues.length; i++) {
 			for (String match : matchedValues) {
+				String current = replacedValues[i];
 				String replaced;
 				switch (type) {
 					case 0:
-						replaced = replacedValues[i].replace(match, replacementValue);
+						replaced = current.replace(match, replacementValue);
 						break;
 					case 1:
-						replaced = replacedValues[i].replaceFirst(Pattern.quote(match), replacementValue);
+						replaced = current.replaceFirst(Pattern.quote(match), replacementValue);
 						break;
 					case 2:
-						int lastIndex = replacedValues[i].lastIndexOf(match);
-						if (lastIndex < 0 || lastIndex >= replacedValues[i].length())
+						int lastIndex = current.lastIndexOf(match);
+						if (lastIndex < 0 || lastIndex >= current.length())
 							continue;
 
-						int limitIndex = lastIndex + replacedValues[i].length();
-						replaced = replacedValues[i].substring(0, lastIndex)
+						int limitIndex = lastIndex + match.length();
+						replaced = current.substring(0, lastIndex)
 								+ replacementValue
-								+ (limitIndex < replacedValues[i].length() ? replacedValues[i].substring(limitIndex) : "");
+								+ (limitIndex < current.length() ? current.substring(limitIndex) : "");
 						break;
 					case 3:
 						assert index != null;
-						int index = this.index.getSingle(ctx).map(BigInteger::intValue).orElseThrow(AssertionError::new);
-						if (index < 0 || index >= replacedValues[i].length())
+						int index = this.index.getSingle(ctx)
+								.map(val -> ordinalIndexOf(current, match, val.intValue()))
+								.orElseThrow(AssertionError::new);
+						if (index == -1)
 							continue;
 
-						limitIndex = index + replacedValues[i].length();
-						replaced = replacedValues[i].substring(0, index)
+						limitIndex = index + match.length();
+						replaced = current.substring(0, index)
 								+ replacementValue
-								+ (limitIndex < replacedValues[i].length() ? replacedValues[i].substring(index + replacedValues[i].length()) : "");
+								+ (limitIndex < current.length() ? current.substring(limitIndex) : "");
 						break;
 					default:
 						throw new IllegalStateException();
@@ -159,5 +162,13 @@ public class ExecExprReplace extends ExecutableExpression<String> {
 		return "replace " + typeString + toMatch.toString(ctx, debug)
 				+ " in " + toReplace.toString(ctx, debug)
 				+ " with " + replacement.toString(ctx, debug);
+	}
+
+	private static int ordinalIndexOf(String value, String match, int ordinal) {
+		int pos = -1;
+		do {
+			pos = value.indexOf(match, pos + 1);
+		} while (--ordinal > 0 && pos != -1);
+		return pos;
 	}
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringSplitJoin.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprStringSplitJoin.java
@@ -10,7 +10,6 @@ import org.jetbrains.annotations.Nullable;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
@@ -75,12 +74,10 @@ public class ExprStringSplitJoin implements Expression<String> {
 	public String[] getValues(TriggerContext ctx) {
 		switch (pattern) {
 			case 0:
-				return Optional.ofNullable(delimiter)
-						.flatMap(val -> val.getSingle(ctx))
-						.map(val -> (String) val)
-						.or(() -> Optional.of(""))
-						.map(val -> new String[] {String.join(val, expression.getValues(ctx))})
-						.orElse(new String[0]);
+				return new String[] {String.join(
+						delimiter != null ? delimiter.getSingle(ctx).map(val -> (String) val).orElse("") : "",
+						expression.getValues(ctx)
+				)};
 			case 1:
 				assert delimiter != null;
 				return DoubleOptional.ofOptional(expression.getSingle(ctx), delimiter.getSingle(ctx))

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Expression.java
@@ -55,6 +55,20 @@ public interface Expression<T> extends SyntaxElement {
     }
 
     /**
+     * Determines whether this expression can be changed to a specific {@link ChangeMode} and type class.
+     * @param mode the mode this Expression would be changed with
+     * @param type the type class of the instance this Expression would be changed with
+     * @return whether or not this Expression accepts this specific change
+     */
+    default boolean acceptsChange(ChangeMode mode, Class<?> type) {
+        for (var value : acceptsChange(mode).orElse(new Class[0])) {
+            if (value.isAssignableFrom(type))
+                return true;
+        }
+        return false;
+    }
+
+    /**
      * Changes this expression with the given values according to the given mode
      * @param ctx the event
      * @param changeWith the values to change this Expression with

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/Statement.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/Statement.java
@@ -1,7 +1,5 @@
 package io.github.syst3ms.skriptparser.lang;
 
-import io.github.syst3ms.skriptparser.lang.base.ExecutableExpression;
-import io.github.syst3ms.skriptparser.registration.SkriptAddon;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
@@ -67,15 +65,10 @@ public abstract class Statement implements SyntaxElement {
     /**
      * By default, runs {@link #run(TriggerContext)} ; returns {@link #getNext()} if it returns true, or {@code null} otherwise.
      * Note that if this method is overridden, then the implementation of {@linkplain #run(TriggerContext)} doesn't matter.
-     * <br>
-     * This method also calls {@link SkriptAddon#walkingForward()} for all registered addons. This
-     * implementation is not particularly required, unless you are make extensive use of {@link ExecutableExpression}
-     * and cache that needs to be cleared after each statement.
      * @param ctx the event
      * @return the next item to be ran, or {@code null} if this is the last item to be executed
      */
     public Optional<? extends Statement> walk(TriggerContext ctx) {
-        SkriptAddon.getAddons().forEach(SkriptAddon::walkingForward);
         var proceed = run(ctx);
         if (proceed) {
             return getNext();

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/base/ExecutableExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/base/ExecutableExpression.java
@@ -1,5 +1,6 @@
 package io.github.syst3ms.skriptparser.lang.base;
 
+import io.github.syst3ms.skriptparser.expressions.ExecExprListOperators;
 import io.github.syst3ms.skriptparser.lang.Effect;
 import io.github.syst3ms.skriptparser.lang.Expression;
 import io.github.syst3ms.skriptparser.lang.SelfRegistrable;
@@ -7,8 +8,6 @@ import io.github.syst3ms.skriptparser.lang.TriggerContext;
 import io.github.syst3ms.skriptparser.registration.SkriptRegistration;
 
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A base class for syntax that can be used as {@link Expression} or {@link Effect}.
@@ -19,31 +18,44 @@ import java.util.Map;
  * </ul>
  * Both syntaxes are valid and this enables productive and better coding practices.
  * <br>
- * The class automatically implements the {@link #execute(TriggerContext)} to just call
- * {@link #getValues(TriggerContext)}, ignoring the results.
- * This behavior can obviously be overridden.
+ * The behaviour is different based on how the syntax is used:
+ * <ul>
+ *     <li>If the syntax is used like an expression, the result should not change any expressions
+ *     (like variables) whatsoever.</li>
+ *     <li>Otherwise, if the syntax is used like an effect, the result should be used to perform
+ *     actions according to the syntax.</li>
+ * </ul>
+ * To look at an example, like {@link ExecExprListOperators}:
+ * <ul>
+ *     {@code set {x} to pop {y::*}} should set the variable {@code x} to the last element of the list {@code y}. <br>
+ *     {@code pop {y::*}} should remove the last element of the list {@code y}, because it is used as an effect now.
+ * </ul>
  * Finally, this implements {@link SelfRegistrable}, enabling an easy registration process.
  */
 public abstract class ExecutableExpression<T>
         extends Effect
         implements Expression<T>, SelfRegistrable {
 
-    private final static Map<ExecutableExpression<?>, Object[]> cachedValues = new HashMap<>();
-
     @Override
     protected void execute(TriggerContext ctx) {
-        getAppliedValues(ctx);
+        getValues(ctx, true);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public T[] getValues(TriggerContext ctx) {
-        if (!cachedValues.containsKey(this))
-            cachedValues.put(this, getAppliedValues(ctx));
-        return (T[]) cachedValues.get(this);
+        return getValues(ctx, false);
     }
 
-    public abstract T[] getAppliedValues(TriggerContext ctx);
+    /**
+     * Retrieves all values of this expression, if used as one.
+     * Otherwise, if used as an effect, performs side-effects with certain
+     * {@link ExecutableExpression behaviour}. Note that when this is not the case,
+     * this syntax, by convention, should not have any side-effects.
+     * @param ctx the context
+     * @param isEffect whether this syntax is used as effect or as an expression
+     * @return an array of the values
+     */
+    public abstract T[] getValues(TriggerContext ctx, boolean isEffect);
 
     @SuppressWarnings("unchecked")
     @Override
@@ -55,9 +67,5 @@ public abstract class ExecutableExpression<T>
         // The actual registration
         reg.addExpression(getClass(), type, isSingle, patterns);
         reg.addEffect(getClass(), patterns);
-    }
-
-    public static Map<ExecutableExpression<?>, Object[]> getCachedValues() {
-        return cachedValues;
     }
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/base/ExecutableExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/base/ExecutableExpression.java
@@ -36,7 +36,7 @@ public abstract class ExecutableExpression<T>
         extends Effect
         implements Expression<T>, SelfRegistrable {
 
-    @Override
+	@Override
     protected void execute(TriggerContext ctx) {
         getValues(ctx, true);
     }

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/properties/PropertyConditional.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/properties/PropertyConditional.java
@@ -87,10 +87,11 @@ public abstract class PropertyConditional<P> extends ConditionalExpression imple
             case CAN:
                 return perf.toString(ctx, debug) + (isNegated() ? " can't " : " can ") + property;
             case HAVE:
-                if (perf.isSingle())
+                if (perf.isSingle()) {
                     return perf.toString(ctx, debug) + (isNegated() ? " doesn't have " : " has ") + property;
-                else
+                } else {
                     return perf.toString(ctx, debug) + (isNegated() ? " don't have " : " have ") + property;
+                }
             default:
                 throw new AssertionError();
         }

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptAddon.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptAddon.java
@@ -37,12 +37,6 @@ public abstract class SkriptAddon {
     public void finishedLoading() {}
 
     /**
-     * Is called when moving to the next statement of the parser. Optionally overridable.
-     * Note that this is not always called, only in most occasions.
-     */
-    public void walkingForward() {}
-
-    /**
      * Checks to see whether the given event has been registered by this SkriptAddon ; a basic way to filter out
      * triggers you aren't able to deal with in {@link SkriptAddon#handleTrigger(Trigger)}.
      * A simple example of application can be found in {@link Skript#handleTrigger(Trigger)}.

--- a/src/test/resources/expressions/CondExprMatch.txt
+++ b/src/test/resources/expressions/CondExprMatch.txt
@@ -1,0 +1,24 @@
+# Author(s):
+# 	- Mwexim
+# Date: 2021/04/11
+
+test:
+	assert "hey" doesn't match "heyo" with "'Hey' matches 'heyo'"
+	assert "heyo" matches "hey." with "'Heyo' doesn't match 'hey.'"
+
+	assert "testing123." doesn't match '\w+' with "'testing123' is only made out of letters"
+	assert "testing123." partially matches '\w+' with "'testing123' doesn't contain any letters"
+
+	assert "hello" and "hey" don't match "he" with "'hello' and 'hey' match 'he'"
+	assert "hello" and "hey" partially match "he" with "'hello' and 'hey' don't partially match 'he'"
+	assert "hello" and "hey" don't partially match "he" and "hey" with "'hello' and 'hey' partially match 'he' and 'hey'"
+	assert "hello" or "hey" partially match "he" and "hey" with "'hello' or 'hey' partially match 'he'"
+
+	assert "hello" and "testing" partially match "he" or "test" with "'hello' and 'testing' don't partially match 'he' or 'test'"
+	assert "hello" or "testing" partially match "testing" or "hi" with "'hello' or 'testing' don't partially match 'testing' or 'hi'"
+
+	assert "hello" and "hey" don't match "hello" and "hey" with "'hello' and 'hey' match 'hello' and 'hey'"
+	assert "hello" or "hey" don't match "hello" and "hey" with "'hello' or 'hey' match 'hello' and 'hey'"
+
+	assert "hello" or "hey" don't match "hello test" or "hey there" with "'hello' or 'hey' match 'hello test' and 'hey there'"
+	assert "hello" or "testing" don't match "testing" and "test" with "'hello' or 'testing' match 'testing' and 'test'"

--- a/src/test/resources/expressions/ExecExprListOperators.txt
+++ b/src/test/resources/expressions/ExecExprListOperators.txt
@@ -5,17 +5,27 @@
 test:
 	set {list::*} to "a", "b", "c", "d", "e", "f" and "g"
 	set {var} to pop {list::*}
-	assert {list::*} does not contain "g" with "{list::*} should not contain 'g' anymore: %{list::*}%"
 	assert {var} is "g" with "{var} should be 'g': %{var}%"
+	assert {list::*} contains "g" with "{list::*} should contain 'g': %{list::*}%"
+	pop {list::*}
+	assert {list::*} does not contain "g" with "{list::*} should not contain 'g' anymore: %{list::*}%"
 
 	set {var} to shift {list::*}
-	assert {list::*} does not contain "a" with "{list::*} should not contain 'a' anymore: %{list::*}%"
 	assert {var} is "a" with "{var} should be 'a': %{var}%"
+	assert {list::*} contains "a" with "{list::*} should contain 'a': %{list::*}%"
+	poll {list::*}
+	assert {list::*} does not contain "a" with "{list::*} should not contain 'a' anymore: %{list::*}%"
 
 	set {var} to extract 2nd element out of {list::*}
-	assert {list::*} does not contain "c" with "{list::*} should not contain 'c' anymore: %{list::*}%"
 	assert {var} is "c" with "{var} should be 'c': %{var}%"
+	assert {list::*} contains "c" with "{list::*} should contain 'c': %{list::*}%"
+	extract 2nd element out of {list::*}
+	assert {list::*} does not contain "c" with "{list::*} should not contain 'c' anymore: %{list::*}%"
 
 	set {spliced::*} to splice {list::*} from 1 to 3
-	assert {list::*} = "f" with "{list::*} should equal 'f': %{list::*}%"
 	assert {spliced::*} = "b", "d" and "e" with "{spliced::*} should equal 'b', 'd' and 'e': %{spliced::*}%"
+	assert {list::*} = "b", "d", "e" and "f" with "{list::*} should equal 'b', 'd', 'e' and 'f': %{list::*}%"
+	splice {list::*} from 1 to 3
+	assert {list::*} = "f" with "{list::*} should equal 'f': %{list::*}%"
+
+	# Add (negative) step tests?

--- a/src/test/resources/expressions/ExecExprReplace.txt
+++ b/src/test/resources/expressions/ExecExprReplace.txt
@@ -1,0 +1,26 @@
+# Author(s):
+# 	- Mwexim
+# Date: 2021/04/17
+
+test:
+	# All
+	set {var} to "Hello world, my name is Skript."
+	assert replace "o" in {var} with "a" = "Hella warld, my name is Skript." with "single replacement didn't work"
+	assert {var} = "Hello world, my name is Skript." with "{var} should not be changed yet: %{var}%"
+	replace all "." with "!" in {var}
+	assert {var} = "Hello world, my name is Skript!" with "{var} should be 'Hello world, my name is Skript!': %{var}%"
+
+	# First
+	set {var} to "Hello, hello there!"
+	replace first "Hello" in {var} with "Goodbye"
+	assert {var} = "Goodbye, hello there!" with "{var} should be 'Goodbye, hello there!': %{var}%"
+
+	# Last and indexed
+	set {var} to "HEEEEEEELP! PLEASE!"
+	replace last "E" inside {var} with "="
+	assert {var} = "HEEEEEEELP! PLEAS=!" with "{var} should be 'HEEEEEEELP! PLEAS=!': %{var}%"
+
+	replace 3th "EE" with "/" in {var}
+	assert {var} = "HEEEE/ELP! PLEAS=!" with "{var} should be 'HEEEE/ELP! PLEAS=!': %{var}%"
+
+

--- a/src/test/resources/expressions/ExecExprReplace.txt
+++ b/src/test/resources/expressions/ExecExprReplace.txt
@@ -15,16 +15,17 @@ test:
 	replace first "Hello" in {var} with "Goodbye"
 	assert {var} = "Goodbye, hello there!" with "{var} should be 'Goodbye, hello there!': %{var}%"
 
-	# Last and indexed
-	set {var} to "HEELP HEELP REE HEELP! PLEASE!"
-	replace last "E" inside {var} with "="
-	assert {var} = "HEELP HEELP REE HEELP! PLEAS=!" with "{var} should be 'HEELP HEELP REE HEELP! PLEAS=!': %{var}%"
-
-	replace 3rd "EE" with "/" in {var}
-	assert {var} = "HEELP HEELP R/ HEELP! PLEAS=!" with "{var} should be 'HEELP HEELP R/ HEELP! PLEAS=!': %{var}%"
+	# Last
+	set {var} to "HELP, PLEASE!"
+	replace last "E" in {var} with "="
+	assert {var} = "HELP, PLEAS=!" with "{var} should be 'HELP, PLEAS=!': %{var}%"
 
 	# Multiple
 	set {list::*} to "testee", "testtee" and "testttee"
-	replace 3rd "t" and "e" in {list::*} with "u"
-	assert {list::*} = "testeu", "testueu" and "testuteu" with "Combined replacement didn't work: %{list::*}%"
+	replace last "t" and "e" in {list::*} with "u"
+	assert {list::*} = "tesueu", "testueu" and "testtueu" with "Combined replacement didn't work: %{list::*}%"
 
+	# Regex
+	set {var} to "Hello World"
+	replace last regex patterns '[A-Za-z]{2}' with "$" in {var}
+	assert {var} = "Hello Wor$" with "{var} should be 'Hello Wor$': %{var}%"

--- a/src/test/resources/expressions/ExecExprReplace.txt
+++ b/src/test/resources/expressions/ExecExprReplace.txt
@@ -5,7 +5,7 @@
 test:
 	# All
 	set {var} to "Hello world, my name is Skript."
-	assert replace "o" in {var} with "a" = "Hella warld, my name is Skript." with "single replacement didn't work"
+	assert replace "o" in {var} with "a" = "Hella warld, my name is Skript." with "Single replacement didn't work"
 	assert {var} = "Hello world, my name is Skript." with "{var} should not be changed yet: %{var}%"
 	replace all "." with "!" in {var}
 	assert {var} = "Hello world, my name is Skript!" with "{var} should be 'Hello world, my name is Skript!': %{var}%"
@@ -16,11 +16,15 @@ test:
 	assert {var} = "Goodbye, hello there!" with "{var} should be 'Goodbye, hello there!': %{var}%"
 
 	# Last and indexed
-	set {var} to "HEEEEEEELP! PLEASE!"
+	set {var} to "HEELP HEELP REE HEELP! PLEASE!"
 	replace last "E" inside {var} with "="
-	assert {var} = "HEEEEEEELP! PLEAS=!" with "{var} should be 'HEEEEEEELP! PLEAS=!': %{var}%"
+	assert {var} = "HEELP HEELP REE HEELP! PLEAS=!" with "{var} should be 'HEELP HEELP REE HEELP! PLEAS=!': %{var}%"
 
-	replace 3th "EE" with "/" in {var}
-	assert {var} = "HEEEE/ELP! PLEAS=!" with "{var} should be 'HEEEE/ELP! PLEAS=!': %{var}%"
+	replace 3rd "EE" with "/" in {var}
+	assert {var} = "HEELP HEELP R/ HEELP! PLEAS=!" with "{var} should be 'HEELP HEELP R/ HEELP! PLEAS=!': %{var}%"
 
+	# Multiple
+	set {list::*} to "testee", "testtee" and "testttee"
+	replace 3rd "t" and "e" in {list::*} with "u"
+	assert {list::*} = "testeu", "testueu" and "testuteu" with "Combined replacement didn't work: %{list::*}%"
 

--- a/src/test/resources/expressions/ExprStringSplitJoin.txt
+++ b/src/test/resources/expressions/ExprStringSplitJoin.txt
@@ -1,6 +1,8 @@
 # Author(s):
 # 	- Olyno
-# Date: 2020/12/13
+# Date:
+#	- 2020/12/13
+#	- 2021/04/18 (regex support)
 
 test:
 	set {var} to join "Hello" and "World" with " "
@@ -9,8 +11,12 @@ test:
 	set {list::*} to split "Hello World" at " "
 	assert {list::*} is "Hello" and "World" with "{list::*} should be 'Hello' and 'World': %{list::*}%"
 
-	set {list2::*} to "Hello World" split at " "
-	assert {list2::*} is "Hello" and "World" with "{list2::*} should be 'Hello' and 'World': %{list2::*}%"
+	set {list::*} to "Hello World" split at " "
+	assert {list::*} is "Hello" and "World" with "{list::*} should be 'Hello' and 'World': %{list::*}%"
 
-	set {list3::*} to "ABC" split every 1 chars
-	assert {list3::*} is "A", "B" and "C" with "{list3::*} should be 'A', 'B' and 'C': %{list3::*}%"
+	set {list::*} to "ABCDEFG" split every 2 chars
+	assert {list::*} is "AB", "CD", "EF" and "G" with "{list::*} should be 'AB', 'CD', 'EF' and 'G': %{list::*}%"
+
+	# Regex support
+	set {list::*} to split "How are  you today?" using regex pattern ' \S?'
+	assert {list::*} is "How", "re", "", "ou" and "oday?" with "{list::*} should be 'How', 're', '', 'ou' and 'oday?': %{list::*}%"

--- a/src/test/resources/expressions/ExprStringSplitJoin.txt
+++ b/src/test/resources/expressions/ExprStringSplitJoin.txt
@@ -1,5 +1,6 @@
 # Author(s):
 # 	- Olyno
+#	- Mwexim
 # Date:
 #	- 2020/12/13
 #	- 2021/04/18 (regex support)


### PR DESCRIPTION
This pull request adds the last bits of the syntax required for version 0.1 and also reworks the ExecutableExpression syntax class.
- CondExprMatch: condition to match against a regex (similar to Skript syntax with better patterns)
- ExecExprReplace: replace substrings with other strings, with regex support
- ExprStringSplitJoin: now has regex support and optimized patterns

Overhauled the general behaviour of ExecutableExpression:
- When used as an expression, the input variable should not be changed.
- When used as an effect, the input variable should be changed (as the results cannot be used anyway).
This basically means the following behaviour:
```vb
pop {list::*}
# is the same as
set {list::*} to pop {list::*}
```