### PR TITLE
Update to Gradle 7.0.2 + file format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,12 @@ plugins {
     id 'application'
 }
 
-mainClassName = "io.github.syst3ms.skriptparser.Parser"
+mainClassName = 'io.github.syst3ms.skriptparser.Parser'
 
 sourceCompatibility = 1.11
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 test {
@@ -17,18 +16,20 @@ test {
 }
 
 dependencies {
-    compile 'org.jetbrains:annotations:15.0'
-    compile group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
-    testCompile "junit:junit:4.12"
-    testRuntime "org.junit.vintage:junit-vintage-engine:5.4.1"
-    testCompile "org.junit.jupiter:junit-jupiter-api:5.4.1"
-    testRuntime "org.junit.jupiter:junit-jupiter-engine:5.4.1"
+    implementation group: 'org.jetbrains', name: 'annotations', version: '21.0.0'
+    implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
+
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.2'
+
+    testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.7.2'
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.7.2'
 }
 
 jar {
     manifest {
-        attributes("Main-Class": mainClassName,
-                "Implementation-Title": "skript-parser",
-                "Implementation-Version": "alpha")
+        attributes('Main-Class': mainClassName,
+                'Implementation-Title': 'skript-parser',
+                'Implementation-Version': 'alpha')
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR brings Gradle up to version 7.0.2. It brings the update of some dependencies and it also fixes the consistency of the build.gradle file (use of `'` everywhere, dependency formatting...). It is also supposed to fix unsuccessful GitHub Actions builds.