### PR TITLE
Improvement/number-parsing

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/DefaultRegistration.java
@@ -43,75 +43,80 @@ public class DefaultRegistration {
         );
 
         registration.newType(Number.class,"number", "number@s")
-                    .literalParser(s -> {
-                        if (s.matches(DECIMAL_PATTERN)) {
-                            return new BigDecimal(s);
-                        }
-                        // This allows formats like 1_000_000.
-                        var toMatch = s.replace("_", "");
-                        return toMatch.matches(INTEGER_PATTERN) ? new BigInteger(toMatch) : null;
-                    })
-                    .toStringFunction(o -> {
-                        if (o instanceof BigDecimal) {
-                            BigDecimal bd = (BigDecimal) o;
-                            int significantDigits = bd.scale() <= 0
-                                    ? bd.precision() + bd.stripTrailingZeros().scale()
-                                    : bd.precision();
-                            return ((BigDecimal) o).setScale(Math.min(10, significantDigits), RoundingMode.HALF_UP)
-                                                   .stripTrailingZeros()
-                                                   .toPlainString();
+                .literalParser(s -> {
+                    if (s.startsWith("_") || s.endsWith("_"))
+                        return null;
+                    s = s.replaceAll("_", "");
+                    if (s.matches(DECIMAL_PATTERN)) {
+                        return new BigDecimal(s);
+                    } else if (s.matches(INTEGER_PATTERN)) {
+                        return new BigInteger(s);
+                    } else {
+                        return null;
+                    }
+                })
+                .toStringFunction(o -> {
+                    if (o instanceof BigDecimal) {
+                        BigDecimal bd = (BigDecimal) o;
+                        int significantDigits = bd.scale() <= 0
+                                ? bd.precision() + bd.stripTrailingZeros().scale()
+                                : bd.precision();
+                        return ((BigDecimal) o).setScale(Math.min(10, significantDigits), RoundingMode.HALF_UP)
+                                .stripTrailingZeros()
+                                .toPlainString();
+                    } else {
+                        return o.toString();
+                    }
+                })
+                .arithmetic(new Arithmetic<Number, Number>() {
+                    @Override
+                    public Number difference(Number first, Number second) {
+                        if (first instanceof BigDecimal || second instanceof BigDecimal) {
+                            var f = BigDecimalMath.getBigDecimal(first);
+                            var s = BigDecimalMath.getBigDecimal(second);
+                            return f.subtract(s).abs();
                         } else {
-                            return o.toString();
+                            assert first instanceof BigInteger && second instanceof BigInteger;
+                            return ((BigInteger) first).subtract(((BigInteger) second)).abs();
                         }
-                    })
-                    .arithmetic(new Arithmetic<Number, Number>() {
-                        @Override
-                        public Number difference(Number first, Number second) {
-                            if (first instanceof BigDecimal || second instanceof BigDecimal) {
-                                var f = BigDecimalMath.getBigDecimal(first);
-                                var s = BigDecimalMath.getBigDecimal(second);
-                                return f.subtract(s).abs();
-                            } else {
-                                assert first instanceof BigInteger && second instanceof BigInteger;
-                                return ((BigInteger) first).subtract(((BigInteger) second)).abs();
-                            }
-                        }
+                    }
 
-                        @Override
-                        public Number add(Number value, Number difference) {
-                            if (value instanceof BigDecimal || difference instanceof BigDecimal) {
-                                var v = BigDecimalMath.getBigDecimal(value);
-                                var d = BigDecimalMath.getBigDecimal(difference);
-                                return v.add(d);
-                            } else {
-                                assert value instanceof BigInteger && difference instanceof BigInteger;
-                                return ((BigInteger) value).add(((BigInteger) difference));
-                            }
+                    @Override
+                    public Number add(Number value, Number difference) {
+                        if (value instanceof BigDecimal || difference instanceof BigDecimal) {
+                            var v = BigDecimalMath.getBigDecimal(value);
+                            var d = BigDecimalMath.getBigDecimal(difference);
+                            return v.add(d);
+                        } else {
+                            assert value instanceof BigInteger && difference instanceof BigInteger;
+                            return ((BigInteger) value).add(((BigInteger) difference));
                         }
+                    }
 
-                        @Override
-                        public Number subtract(Number value, Number difference) {
-                            if (value instanceof BigDecimal || difference instanceof BigDecimal) {
-                                var v = BigDecimalMath.getBigDecimal(value);
-                                var d = BigDecimalMath.getBigDecimal(difference);
-                                return v.subtract(d);
-                            } else {
-                                assert value instanceof BigInteger && difference instanceof BigInteger;
-                                return ((BigInteger) value).subtract(((BigInteger) difference));
-                            }
+                    @Override
+                    public Number subtract(Number value, Number difference) {
+                        if (value instanceof BigDecimal || difference instanceof BigDecimal) {
+                            var v = BigDecimalMath.getBigDecimal(value);
+                            var d = BigDecimalMath.getBigDecimal(difference);
+                            return v.subtract(d);
+                        } else {
+                            assert value instanceof BigInteger && difference instanceof BigInteger;
+                            return ((BigInteger) value).subtract(((BigInteger) difference));
                         }
+                    }
 
-                        @Override
-                        public Class<? extends Number> getRelativeType() {
-                            return Number.class;
-                        }
-                    }).register();
+                    @Override
+                    public Class<? extends Number> getRelativeType() {
+                        return Number.class;
+                    }
+                }).register();
 
         registration.newType(BigInteger.class, "integer", "integer@s")
                 .literalParser(s -> {
-                    // This allows formats like 1_000_000.
-                    var toMatch = s.replace("_", "");
-                    return toMatch.matches(INTEGER_PATTERN) ? new BigInteger(toMatch) : null;
+                    if (s.startsWith("_") || s.endsWith("_"))
+                        return null;
+                    s = s.replaceAll("_", "");
+                    return s.matches(INTEGER_PATTERN) ? new BigInteger(s) : null;
                 })
                 .arithmetic(new Arithmetic<BigInteger, BigInteger>() {
                     @Override
@@ -143,21 +148,20 @@ public class DefaultRegistration {
         );
 
         registration.newType(Boolean.class, "boolean", "boolean@s")
-                    .literalParser(s -> {
-                        if (s.equalsIgnoreCase("true")) {
-                            return true;
-                        } else if (s.equalsIgnoreCase("false")) {
-                            return false;
-                        } else {
-                            return null;
-                        }
-                    })
-                    .toStringFunction(String::valueOf)
-                    .register();
+                .literalParser(s -> {
+                    if (s.equalsIgnoreCase("true")) {
+                        return true;
+                    } else if (s.equalsIgnoreCase("false")) {
+                        return false;
+                    } else {
+                        return null;
+                    }
+                })
+                .toStringFunction(String::valueOf)
+                .register();
 
         registration.newType(Type.class, "type", "type@s")
-                .literalParser(s -> TypeManager.getByExactName(s.toLowerCase())
-                        .orElse(null))
+                .literalParser(s -> TypeManager.getByExactName(s.toLowerCase()).orElse(null))
                 .toStringFunction(Type::getBaseName)
                 .register();
 

--- a/src/test/resources/literals/Number.txt
+++ b/src/test/resources/literals/Number.txt
@@ -5,8 +5,6 @@
 test:
 	set {var} to 1000
 	set {var2} to 1000.0
-	set {var3} to 1000.
-	set {var4} to 1_000
+	set {var3} to 1_000
 	assert {var} = {var2} with "{var} (%{var}%) != {var2} (%{var2}%)"
 	assert {var2} = {var3} with "{var2} (%{var2}%) != {var3} (%{var3}%)"
-	assert {var3} = {var4} with "{var3} (%{var3}%) != {var4} (%{var4}%)"

--- a/src/test/resources/literals/Number.txt
+++ b/src/test/resources/literals/Number.txt
@@ -8,3 +8,8 @@ test:
 	set {var3} to 1_000
 	assert {var} = {var2} with "{var} (%{var}%) != {var2} (%{var2}%)"
 	assert {var2} = {var3} with "{var2} (%{var2}%) != {var3} (%{var3}%)"
+
+	throws _____0.1_______
+	throws _1
+	throws 1.05_
+	compiles -___5.3_0 # Yes this is possible, and we shouldn't really care how one uses this syntax sugar.


### PR DESCRIPTION
See [this pull request](https://github.com/SkriptLang/Skript/pull/4275) for background information.

I have tested this a bit and noticed that the parsing speed increase is 'hardly' noticeable and for sure less than 25% (more around 10%). I think this is due to the fact that Skript uses a lot more number types and because the test files are generally larger? Maybe skript-parser's codebase is just more optimized so that changes like this one don't affect it too much.

Either way, a simple improvement.