### PR TITLE
Fix null pointer exception in test class SyntaxParserTest

### DIFF
--- a/src/test/java/io/github/syst3ms/skriptparser/parsing/SyntaxParserTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/parsing/SyntaxParserTest.java
@@ -101,7 +101,9 @@ public class SyntaxParserTest {
         URL url = ClassLoader.getSystemResource(folder);
         if (url != null) {
             var path = url.getPath();
-            return new File(path).listFiles();
+            File[] files = new File(path).listFiles();
+            if (files != null)
+            	return new File[0];
         }
         return new File[0];
     }

--- a/src/test/java/io/github/syst3ms/skriptparser/parsing/SyntaxParserTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/parsing/SyntaxParserTest.java
@@ -101,7 +101,7 @@ public class SyntaxParserTest {
         URL url = ClassLoader.getSystemResource(folder);
         if (url != null) {
             var path = url.getPath();
-            File[] files = new File(path).listFiles();
+            var files = new File(path).listFiles();
             if (files != null)
             	return files;
         }

--- a/src/test/java/io/github/syst3ms/skriptparser/parsing/SyntaxParserTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/parsing/SyntaxParserTest.java
@@ -103,7 +103,7 @@ public class SyntaxParserTest {
             var path = url.getPath();
             File[] files = new File(path).listFiles();
             if (files != null)
-            	return new File[0];
+            	return files;
         }
         return new File[0];
     }


### PR DESCRIPTION
Fix null pointer exception in test class SyntaxParserTest.
```
java.lang.NullPointerException at SyntaxParserTest.java:45
```
build task fails to build because `File#listFiles()` can return null where the code at `SyntaxParserTest.java:45` thinks it's going to return an empty array.