### PR TITLE
SkriptLogger logs were never finalized for register method

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
@@ -543,6 +543,7 @@ public class SkriptRegistration {
         TagManager.register(this);
         Converters.registerConverters(this);
         Converters.createMissingConverters();
+        logger.finalizeLogs();
         return logger.close();
     }
 


### PR DESCRIPTION
SkriptLogger logs were never finalized for register method, so errors never get included in the SkriptLogger.