### PR TITLE
Allow for a default on the isSingle

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
@@ -153,6 +153,20 @@ public class SkriptRegistration {
     }
 
     /**
+     * Registers an {@link Expression} with the isSingle set to true by default.
+     * Mainly so you can override with {@link Expression#isSingle()}
+     * 
+     * @param c the Expression's class
+     * @param returnType the Expression's return type
+     * @param patterns the Expression's patterns
+     * @param <C> the Expression
+     * @param <T> the Expression's return type
+     */
+    public <C extends Expression<T>, T> void addExpression(Class<C> c, Class<T> returnType, String... patterns) {
+        newExpression(c, returnType, true, patterns).register();
+    }
+
+    /**
      * Registers an {@link Expression}
      * @param c the Expression's class
      * @param returnType the Expression's return type


### PR DESCRIPTION
Allow for a default on the isSingle on expression registration. This is because it's confusing to register the isSingle in the method registration if the class is guaranteed to override the isSingle method. This allows for no specification to signify that the class is going to override the isSingle.