### PR TITLE
Tests don't trigger on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,10 @@
 name: Build, Test & Upload
 
 on:
-  push:
-  pull_request:
-    branches-ignore:
-      - master
+    push:
+        branches:
+            - master
+    pull_request:
 
 jobs:
   building:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Build project
-        run: gradle build
+        run: gradlew build
 
       - name: Run tests
-        run: gradle test
+        run: gradlew test
 
       - name: Upload Nightly Build
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Build project
-        run: gradlew build
+        run: ./gradlew build
 
       - name: Run tests
-        run: gradlew test
+        run: ./gradlew test
 
       - name: Upload Nightly Build
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,10 @@
 name: Build, Test & Upload
 
 on:
-    push:
-        branches:
-            - master
-    pull_request:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   building:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Build skript-parser
-        run: gradlew build
+        run: ./gradlew build
 
       - name: Run tests
-        run: gradlew test
+        run: ./gradlew test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Build skript-parser
-        run: gradle build
+        run: gradlew build
 
       - name: Run tests
-        run: gradle test
+        run: gradlew test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   testing:


### PR DESCRIPTION
Tests don't trigger on pull requests.
The tests only run after merge, that's not useful. This pull request fixes that to run on pull request and merge to master.
Also switches the gradle command to be using gradlew so that everyone's test environment is done on the same gradle version.

You can see that it's working now based on the actions triggering on this pull request

**The tests are currently failing because of a NullPointerException which is fixed at https://github.com/Mwexim/skript-parser/pull/138**