### PR TITLE
Fix incorrect cast in doubleInstanceofConverter ConverterUtils

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ConverterUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/types/conversions/ConverterUtils.java
@@ -26,7 +26,8 @@ public class ConverterUtils {
     }
 
     public static <F, T> Function<?, Optional<? extends T>> createDoubleInstanceofConverter(ConverterInfo<F, ?> conv, Class<T> to) {
-        return createDoubleInstanceofConverter(conv.getFrom(), (Function<F, Optional<?>>) conv.getConverter(), to);
+        Function<? super F, ?> function = conv.getConverter();
+        return createDoubleInstanceofConverter(conv.getFrom(), (Function<F, Optional<?>>) function, to);
     }
 
     public static <F, T> Function<?, Optional<? extends T>> createDoubleInstanceofConverter(Class<F> from, Function<? super F, Optional<?>> conv, Class<T> to) {


### PR DESCRIPTION
Fix incorrect cast in createDoubleInstanceofConverter ConverterUtils.
<img width="931" alt="cast" src="https://github.com/Mwexim/skript-parser/assets/16087552/93438284-d63b-4a6c-aba5-85773ff6e5f7">

I can't build without this fix.