### PR TITLE
Re-add SkriptLogger#hasError method

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/log/SkriptLogger.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/log/SkriptLogger.java
@@ -292,4 +292,12 @@ public class SkriptLogger {
     public String getFileName() {
         return fileName;
     }
+
+    /**
+     * @return whether or not this Logger has an error stored
+     */
+    public boolean hasError() {
+        return hasError;
+    }
+
 }


### PR DESCRIPTION
Re-add SkriptLogger#hasError method. Other parts of skript-parser use this method.

I think this method was mistakenly removed in commit https://github.com/Mwexim/skript-parser/commit/f2f6ced5a5e8854a8d747d1a5c469038dfedebf2 as the field still exists. @Mwexim 