### PR TITLE
Change PropertyExpression generics to match SkriptLang

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprAmount.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprAmount.java
@@ -24,13 +24,13 @@ import java.util.Map;
  * @since ALPHA
  * @author Olyno, Mwexim
  */
-public class ExprAmount extends PropertyExpression<Number, Object> {
+public class ExprAmount extends PropertyExpression<Object, Number> {
 	static {
 		Parser.getMainRegistration().addPropertyExpression(
 				ExprAmount.class,
 				Number.class,
-				"~objects",
-				"[1:recursive] (amount|number|size)"
+				"[1:recursive] (amount|number|size)",
+				"~objects"
 		);
 	}
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorValues.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprColorValues.java
@@ -19,13 +19,13 @@ import java.math.BigInteger;
  * @since ALPHA
  * @author Mwexim
  */
-public class ExprColorValues extends PropertyExpression<Object, Color> {
+public class ExprColorValues extends PropertyExpression<Color, Object> {
 	static {
 		Parser.getMainRegistration().addPropertyExpression(
 				ExprColorValues.class,
 				Object.class,
-				"colors",
-				"(0:hex[adecimal]|1:red|2:green|3:blue|4:alpha) value"
+				"(0:hex[adecimal]|1:red|2:green|3:blue|4:alpha) value",
+				"colors"
 		);
 	}
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateTimestamp.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprDateTimestamp.java
@@ -22,13 +22,13 @@ import java.math.BigInteger;
  * @since ALPHA
  * @author Mwexim
  */
-public class ExprDateTimestamp extends PropertyExpression<Number, SkriptDate> {
+public class ExprDateTimestamp extends PropertyExpression<SkriptDate, Number> {
 	static {
 		Parser.getMainRegistration().addPropertyExpression(
 				ExprDateTimestamp.class,
 				Number.class,
-				"*[date] %date%",
-				"[1:unix] timestamp"
+				"[1:unix] timestamp",
+				"*[date] %date%"
 		);
 	}
 

--- a/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/expressions/ExprLength.java
@@ -14,13 +14,13 @@ import java.math.BigInteger;
  * @since ALPHA
  * @author Romitou
  */
-public class ExprLength extends PropertyExpression<Number, String> {
+public class ExprLength extends PropertyExpression<String, Number> {
     static {
         Parser.getMainRegistration().addPropertyExpression(
                 ExprLength.class,
                 Number.class,
-				"string",
-                "length"
+                "length",
+                "string"
         );
     }
 

--- a/src/main/java/io/github/syst3ms/skriptparser/lang/properties/PropertyExpression.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/lang/properties/PropertyExpression.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  * @param <O> The type of the owner of this expression.
  * @author Mwexim
  */
-public abstract class PropertyExpression<T, O> implements Expression<T> {
+public abstract class PropertyExpression<O, T> implements Expression<T> {
     public static final String PROPERTY_IDENTIFIER = "property";
 
     private Expression<O> owner;
@@ -111,11 +111,12 @@ public abstract class PropertyExpression<T, O> implements Expression<T> {
         return genitive;
     }
 
-    public static String[] composePatterns(String owner, String property) {
+    public static String[] composePatterns(String property, String owner) {
         var ownerType = owner.startsWith("*") ? owner.substring(1) : "%" + owner + "%";
         return new String[] {
                 ownerType + "'[s] " + property,
                 "[the] " + property + " of " + ownerType
         };
     }
+
 }

--- a/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/registration/SkriptRegistration.java
@@ -189,8 +189,8 @@ public class SkriptRegistration {
      * @param <T> the Expression's return type
      * @return an {@link ExpressionRegistrar} to continue the registration process
      */
-    public <C extends PropertyExpression<T, ?>, T> ExpressionRegistrar<C, T> newPropertyExpression(Class<C> c, Class<T> returnType, String owner, String property) {
-        return (ExpressionRegistrar<C, T>) newExpression(c, returnType, false, PropertyExpression.composePatterns(owner, property))
+    public <C extends PropertyExpression<?, T>, T> ExpressionRegistrar<C, T> newPropertyExpression(Class<C> c, Class<T> returnType, String property, String owner) {
+        return (ExpressionRegistrar<C, T>) newExpression(c, returnType, false, PropertyExpression.composePatterns(property, owner))
                 .addData(PropertyExpression.PROPERTY_IDENTIFIER, property);
     }
 
@@ -203,8 +203,8 @@ public class SkriptRegistration {
      * @param <C> the Expression
      * @param <T> the Expression's return type
      */
-    public <C extends PropertyExpression<T, ?>, T> void addPropertyExpression(Class<C> c, Class<T> returnType, String owner, String property) {
-        newPropertyExpression(c, returnType, owner, property).register();
+    public <C extends PropertyExpression<?, T>, T> void addPropertyExpression(Class<C> c, Class<T> returnType, String property, String owner) {
+        newPropertyExpression(c, returnType, property, owner).register();
     }
 
     /**
@@ -217,8 +217,8 @@ public class SkriptRegistration {
      * @param <C> the Expression
      * @param <T> the Expression's return type
      */
-    public <C extends PropertyExpression<T, ?>, T> void addPropertyExpression(Class<C> c, Class<T> returnType, int priority, String owner, String property) {
-        newPropertyExpression(c, returnType, owner, property).setPriority(priority).register();
+    public <C extends PropertyExpression<?, T>, T> void addPropertyExpression(Class<C> c, Class<T> returnType, int priority, String property, String owner) {
+        newPropertyExpression(c, returnType, property, owner).setPriority(priority).register();
     }
 
     /**


### PR DESCRIPTION
Change PropertyExpression generics to match SkriptLang.
This drives me crazy when working with the skript-parser. In my opinion, it should match Skript's generic order like reading a book. Left to right. The left element gets the property return of the right element.

This is a big breaking change unfortunately.

I'll keep this updated as I will be cherry-picking this pull for my projects.