### PR TITLE
Fix/Pattern parser

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/StringUtils.java
@@ -212,8 +212,8 @@ public class StringUtils {
                 if (i + 1 < s.length()) {
                     sb.append(chars[++i]);
                 }
-            } else if (c == '(' || c == '[') {
-                var closing = c == '(' ? ')' : ']';
+            } else if (c == '(' || c == '[' || c == '<') {
+                var closing = c == '(' ? ')' : c == '[' ? ']' : '>';
                 var text = getEnclosedText(s, c, closing, i);
                 text.ifPresent(st -> sb.append(c).append(st).append(closing));
                 if (text.isPresent()) {

--- a/src/test/java/io/github/syst3ms/skriptparser/parsing/PatternParserTest.java
+++ b/src/test/java/io/github/syst3ms/skriptparser/parsing/PatternParserTest.java
@@ -155,6 +155,10 @@ public class PatternParserTest {
                 new RegexGroup(Pattern.compile(".+")),
                 parsePattern("<.+>", logger)
         );
+        assertEqualsOptional(
+                new RegexGroup(Pattern.compile("(\\d*1)st|(\\d*2)nd|(\\d*3)rd|(\\d*[4-90])th")),
+                parsePattern("<(\\d*1)st|(\\d*2)nd|(\\d*3)rd|(\\d*[4-90])th>", logger)
+        );
 
         // Expression elements
         assertEqualsOptional(


### PR DESCRIPTION
Fixed #152. The issue was caused because `StringUtils#splitVerticalBars` didn't take regex groups into account, and regex patterns often do contain vertical bars. Also wrote a test to (hopefully) prevent this issue from happening in the future.