### PR TITLE
Fix addons not calling the initAddon

### DIFF
--- a/src/main/java/io/github/syst3ms/skriptparser/Parser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/Parser.java
@@ -108,8 +108,8 @@ public class Parser {
                                     Class<?> mainClass = Class.forName(main, true, child);
                                     try {
                                         Method init = mainClass.getDeclaredMethod("initAddon");
-                                        init.invoke(null);
-                                    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ignored) {
+                                        init.invoke(mainClass.getConstructor().newInstance());
+                                    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | IllegalArgumentException | InstantiationException | SecurityException ignored) {
                                     } finally {
                                         jar.close();
                                     }


### PR DESCRIPTION
There is an exception thrown when trying to call the initAddon method of a class, because newInstance is calling null on nothing. It must be the class itself.