### PR TITLE
Use Reflections library rather than Jar class scanning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,17 @@ jobs:
   building:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
+          distribution: 'microsoft'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew test
 
       - name: Upload Nightly Build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success()
         with:
           name: skript-nightly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,18 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [11, 13]
+        java-version: [11, 13, 17]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}
+          distribution: 'microsoft'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,17 +9,14 @@ on:
 jobs:
   testing:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java-version: [11, 13, 17]
     steps:
       - uses: actions/checkout@v4
       - name: validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v1
+      - name: Set up JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java-version }}
+          java-version: 17
           distribution: 'microsoft'
 
       - name: Cache Gradle packages

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 plugins {
-    id "java"
-    id "application"
+    id 'com.gradleup.shadow' version '9.0.0-beta12'
+    id 'application'
+    id 'java'
 }
 
-mainClassName = "io.github.syst3ms.skriptparser.Parser"
+compileTestJava.options.encoding = 'UTF-8'
+compileJava.options.encoding = 'UTF-8'
 
-sourceCompatibility = 1.11
+mainClassName = "io.github.syst3ms.skriptparser.Parser"
 
 repositories {
     mavenCentral()
@@ -16,12 +18,25 @@ test {
 }
 
 dependencies {
-    implementation "org.jetbrains:annotations:15.0"
-    implementation group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2"
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.4.1"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.4.1"
-    testImplementation "junit:junit:4.12"
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.4.1"
+    implementation (group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2')
+    implementation (group: 'org.jetbrains', name: 'annotations', version: '26.0.2')
+
+    shadow (group: 'org.reflections', name: 'reflections', version: '0.10.2')
+    shadow (group: 'org.javassist', name: 'javassist', version: '3.30.2-GA')
+    shadow (group: 'com.google.code.gson', name: 'gson', version: '2.13.0')
+
+    testRuntimeOnly (group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.11.4')
+    testRuntimeOnly (group: 'org.junit.jupiter', name:'junit-jupiter-engine', version: '5.11.4')
+
+    testImplementation (group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.11.4')
+    testImplementation (group: 'com.google.code.gson', name: 'gson', version: '2.13.0')
+    testImplementation (group: 'junit', name: 'junit', version: '4.13.2')
+}
+
+java {
+    withSourcesJar()
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 jar {

--- a/src/main/java/io/github/syst3ms/skriptparser/Parser.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/Parser.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.jar.JarFile;
-import java.util.stream.Stream;
 
 public class Parser {
 
@@ -90,13 +89,20 @@ public class Parser {
         registration = new SkriptRegistration(skript);
         DefaultRegistration.register();
 
-        String[] allPackages = Stream.concat(
-                Stream.of("expressions", "effects", "event", "lang", "sections", "structures", "tags")
-                        .map(subPackage -> "io.github.syst3ms.skriptparser." + subPackage),
-                Stream.of(subPackages)
-                        .flatMap(subPackage -> Stream.of(mainPackages)
-                                .map(main -> main + "." + subPackage))
-        ).toArray(String[]::new);
+        List<String> allPackages = new ArrayList<>();
+        
+        // Add default subpackages
+        List<String> defaultSubPackages = Arrays.asList("expressions", "effects", "event", "lang", "sections", "structures", "tags");
+        for (String subPackage : defaultSubPackages) {
+            allPackages.add("io.github.syst3ms.skriptparser." + subPackage);
+        }
+        
+        // Add user-defined subpackages
+        for (String mainPackage : mainPackages) {
+            for (String subPackage : subPackages) {
+                allPackages.add(mainPackage + "." + subPackage);
+            }
+        }
 
         try {
             // Load all classes in the specified packages

--- a/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
+++ b/src/main/java/io/github/syst3ms/skriptparser/util/FileUtils.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
  * Utility functions for file parsing
  */
 public class FileUtils {
+
     public static final Pattern LEADING_WHITESPACE_PATTERN = Pattern.compile("(\\s+)\\S.*");
     public static final String MULTILINE_SYNTAX_TOKEN = "\\";
     private static final String OS_SEPARATOR = FileSystems.getDefault().getSeparator();
@@ -134,7 +135,9 @@ public class FileUtils {
      * @param rootPackage a root package
      * @param subPackages a list of all subpackages of the root package, in which classes will be loaded
      * @throws IOException if an I/O error has occurred
+     * @deprecated use the Reflections library for classpath scanning and loading instead
      */
+    @Deprecated
     public static void loadClasses(File jarFile, String rootPackage, String... subPackages) throws IOException {
         if (jarFile.isDirectory())
             throw new IllegalArgumentException("The provided file is actually a directory!");
@@ -174,7 +177,9 @@ public class FileUtils {
      * @param rootPackage a root package
      * @param subPackages a list of all subpackages of the root package, in which classes will be leadied
      * @throws IOException if an I/O error has occurred
+     * @deprecated use the Reflections library for classpath scanning and loading instead
      */
+    @Deprecated
     public static void loadClasses(Path directory, String rootPackage, String... subPackages) throws IOException {
         if (!directory.toFile().isDirectory())
             throw new IllegalArgumentException("The provided file isn't a directory!");
@@ -209,8 +214,11 @@ public class FileUtils {
      *
      * @param cla the class
      * @return the JAR file containing the class
+     * @deprecated not all projects that uses skript-parser are JAR files, so this method may not work as expected
      */
+    @Deprecated
     public static File getJarFile(Class<?> cla) throws URISyntaxException {
         return new File(cla.getProtectionDomain().getCodeSource().getLocation().toURI());
     }
+
 }


### PR DESCRIPTION
Uses Reflections library rather than Jar class scanning.

Not all projects that implement the skript-parser will use Jars.
Using Reflections library also allows developers to define custom url types before skript-parser scans, such as NeoForge using Union URL Type. I need to register Union URL Type to Reflections before skript-parser.

For example Scroll https://github.com/ScrollLang on NeoForge and Fabric have development options to load the build/ classes for injection hotswapping. This allows avoiding the need to restart the Minecraft client for non new method changes.

So skript-parser will throw an exception as there is no source Jar (it's excluded as a library jar in NeoForge);
```
java.lang.IllegalArgumentException: URI scheme is not "file"
	at java.base/java.io.File.<init>(File.java:423) ~[?:?]
	at MC-BOOTSTRAP/skript.parser.alpha5/io.github.syst3ms.skriptparser.util.FileUtils.getJarFile(FileUtils.java:214) ~[skript-parser-alpha5.jar%23220!/:alpha5]
	at MC-BOOTSTRAP/skript.parser.alpha5/io.github.syst3ms.skriptparser.Parser.init(Parser.java:102) ~[skript-parser-alpha5.jar%23220!/:alpha5]
```

- Also adds the ability to define the main root folder for `/addon/` scanning in the init method.
- Needs to use gradleup's shadow plugin to shadow in Reflections library.
- Bumps Java version from 11 to 17
- Will bump the gradle version and Java to 21 in another pull request. Current gradle 8.3 can operate up to Java 20.
- Forced to update the GitHub versions (v4) for actions cache and setup-java as the current ones are removed (v2).